### PR TITLE
Exploratory: Previewing ERC-20 Token Transactions on Smart Contract Interaction

### DIFF
--- a/background/lib/uniswap.ts
+++ b/background/lib/uniswap.ts
@@ -589,7 +589,6 @@ export async function parseUniswapTx(
       return undefined
     }
   } catch (err) {
-    console.log(err)
     return undefined
   }
   return undefined

--- a/background/lib/uniswap.ts
+++ b/background/lib/uniswap.ts
@@ -1,0 +1,596 @@
+import { AlchemyProvider } from "@ethersproject/providers"
+import { BigNumber, ethers, logger } from "ethers"
+import { getNetwork } from "@ethersproject/networks"
+import { getTokenMetadata } from "./alchemy"
+import { getEthereumNetwork } from "./utils"
+import { SmartContractFungibleAsset } from "../assets"
+import { HexString } from "../types"
+
+const UNISWAP_ABI = [
+  {
+    inputs: [
+      { internalType: "address", name: "_factoryV2", type: "address" },
+      { internalType: "address", name: "factoryV3", type: "address" },
+      { internalType: "address", name: "_positionManager", type: "address" },
+      { internalType: "address", name: "_WETH9", type: "address" },
+    ],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    inputs: [],
+    name: "WETH9",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "token", type: "address" }],
+    name: "approveMax",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "token", type: "address" }],
+    name: "approveMaxMinusOne",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "token", type: "address" }],
+    name: "approveZeroThenMax",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "token", type: "address" }],
+    name: "approveZeroThenMaxMinusOne",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bytes", name: "data", type: "bytes" }],
+    name: "callPositionManager",
+    outputs: [{ internalType: "bytes", name: "result", type: "bytes" }],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "bytes[]", name: "paths", type: "bytes[]" },
+      { internalType: "uint128[]", name: "amounts", type: "uint128[]" },
+      { internalType: "uint24", name: "maximumTickDivergence", type: "uint24" },
+      { internalType: "uint32", name: "secondsAgo", type: "uint32" },
+    ],
+    name: "checkOracleSlippage",
+    outputs: [],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "bytes", name: "path", type: "bytes" },
+      { internalType: "uint24", name: "maximumTickDivergence", type: "uint24" },
+      { internalType: "uint32", name: "secondsAgo", type: "uint32" },
+    ],
+    name: "checkOracleSlippage",
+    outputs: [],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "bytes", name: "path", type: "bytes" },
+          { internalType: "address", name: "recipient", type: "address" },
+          { internalType: "uint256", name: "amountIn", type: "uint256" },
+          {
+            internalType: "uint256",
+            name: "amountOutMinimum",
+            type: "uint256",
+          },
+        ],
+        internalType: "struct IV3SwapRouter.ExactInputParams",
+        name: "params",
+        type: "tuple",
+      },
+    ],
+    name: "exactInput",
+    outputs: [{ internalType: "uint256", name: "amountOut", type: "uint256" }],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "tokenIn", type: "address" },
+          { internalType: "address", name: "tokenOut", type: "address" },
+          { internalType: "uint24", name: "fee", type: "uint24" },
+          { internalType: "address", name: "recipient", type: "address" },
+          { internalType: "uint256", name: "amountIn", type: "uint256" },
+          {
+            internalType: "uint256",
+            name: "amountOutMinimum",
+            type: "uint256",
+          },
+          {
+            internalType: "uint160",
+            name: "sqrtPriceLimitX96",
+            type: "uint160",
+          },
+        ],
+        internalType: "struct IV3SwapRouter.ExactInputSingleParams",
+        name: "params",
+        type: "tuple",
+      },
+    ],
+    name: "exactInputSingle",
+    outputs: [{ internalType: "uint256", name: "amountOut", type: "uint256" }],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "bytes", name: "path", type: "bytes" },
+          { internalType: "address", name: "recipient", type: "address" },
+          { internalType: "uint256", name: "amountOut", type: "uint256" },
+          { internalType: "uint256", name: "amountInMaximum", type: "uint256" },
+        ],
+        internalType: "struct IV3SwapRouter.ExactOutputParams",
+        name: "params",
+        type: "tuple",
+      },
+    ],
+    name: "exactOutput",
+    outputs: [{ internalType: "uint256", name: "amountIn", type: "uint256" }],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "tokenIn", type: "address" },
+          { internalType: "address", name: "tokenOut", type: "address" },
+          { internalType: "uint24", name: "fee", type: "uint24" },
+          { internalType: "address", name: "recipient", type: "address" },
+          { internalType: "uint256", name: "amountOut", type: "uint256" },
+          { internalType: "uint256", name: "amountInMaximum", type: "uint256" },
+          {
+            internalType: "uint160",
+            name: "sqrtPriceLimitX96",
+            type: "uint160",
+          },
+        ],
+        internalType: "struct IV3SwapRouter.ExactOutputSingleParams",
+        name: "params",
+        type: "tuple",
+      },
+    ],
+    name: "exactOutputSingle",
+    outputs: [{ internalType: "uint256", name: "amountIn", type: "uint256" }],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "factory",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "factoryV2",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "token", type: "address" },
+      { internalType: "uint256", name: "amount", type: "uint256" },
+    ],
+    name: "getApprovalType",
+    outputs: [
+      {
+        internalType: "enum IApproveAndCall.ApprovalType",
+        name: "",
+        type: "uint8",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "token0", type: "address" },
+          { internalType: "address", name: "token1", type: "address" },
+          { internalType: "uint256", name: "tokenId", type: "uint256" },
+          { internalType: "uint256", name: "amount0Min", type: "uint256" },
+          { internalType: "uint256", name: "amount1Min", type: "uint256" },
+        ],
+        internalType: "struct IApproveAndCall.IncreaseLiquidityParams",
+        name: "params",
+        type: "tuple",
+      },
+    ],
+    name: "increaseLiquidity",
+    outputs: [{ internalType: "bytes", name: "result", type: "bytes" }],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "token0", type: "address" },
+          { internalType: "address", name: "token1", type: "address" },
+          { internalType: "uint24", name: "fee", type: "uint24" },
+          { internalType: "int24", name: "tickLower", type: "int24" },
+          { internalType: "int24", name: "tickUpper", type: "int24" },
+          { internalType: "uint256", name: "amount0Min", type: "uint256" },
+          { internalType: "uint256", name: "amount1Min", type: "uint256" },
+          { internalType: "address", name: "recipient", type: "address" },
+        ],
+        internalType: "struct IApproveAndCall.MintParams",
+        name: "params",
+        type: "tuple",
+      },
+    ],
+    name: "mint",
+    outputs: [{ internalType: "bytes", name: "result", type: "bytes" }],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "bytes32", name: "previousBlockhash", type: "bytes32" },
+      { internalType: "bytes[]", name: "data", type: "bytes[]" },
+    ],
+    name: "multicall",
+    outputs: [{ internalType: "bytes[]", name: "", type: "bytes[]" }],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "deadline", type: "uint256" },
+      { internalType: "bytes[]", name: "data", type: "bytes[]" },
+    ],
+    name: "multicall",
+    outputs: [{ internalType: "bytes[]", name: "", type: "bytes[]" }],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bytes[]", name: "data", type: "bytes[]" }],
+    name: "multicall",
+    outputs: [{ internalType: "bytes[]", name: "results", type: "bytes[]" }],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "positionManager",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "token", type: "address" },
+      { internalType: "uint256", name: "value", type: "uint256" },
+    ],
+    name: "pull",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "refundETH",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "token", type: "address" },
+      { internalType: "uint256", name: "value", type: "uint256" },
+      { internalType: "uint256", name: "deadline", type: "uint256" },
+      { internalType: "uint8", name: "v", type: "uint8" },
+      { internalType: "bytes32", name: "r", type: "bytes32" },
+      { internalType: "bytes32", name: "s", type: "bytes32" },
+    ],
+    name: "selfPermit",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "token", type: "address" },
+      { internalType: "uint256", name: "nonce", type: "uint256" },
+      { internalType: "uint256", name: "expiry", type: "uint256" },
+      { internalType: "uint8", name: "v", type: "uint8" },
+      { internalType: "bytes32", name: "r", type: "bytes32" },
+      { internalType: "bytes32", name: "s", type: "bytes32" },
+    ],
+    name: "selfPermitAllowed",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "token", type: "address" },
+      { internalType: "uint256", name: "nonce", type: "uint256" },
+      { internalType: "uint256", name: "expiry", type: "uint256" },
+      { internalType: "uint8", name: "v", type: "uint8" },
+      { internalType: "bytes32", name: "r", type: "bytes32" },
+      { internalType: "bytes32", name: "s", type: "bytes32" },
+    ],
+    name: "selfPermitAllowedIfNecessary",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "token", type: "address" },
+      { internalType: "uint256", name: "value", type: "uint256" },
+      { internalType: "uint256", name: "deadline", type: "uint256" },
+      { internalType: "uint8", name: "v", type: "uint8" },
+      { internalType: "bytes32", name: "r", type: "bytes32" },
+      { internalType: "bytes32", name: "s", type: "bytes32" },
+    ],
+    name: "selfPermitIfNecessary",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "amountIn", type: "uint256" },
+      { internalType: "uint256", name: "amountOutMin", type: "uint256" },
+      { internalType: "address[]", name: "path", type: "address[]" },
+      { internalType: "address", name: "to", type: "address" },
+    ],
+    name: "swapExactTokensForTokens",
+    outputs: [{ internalType: "uint256", name: "amountOut", type: "uint256" }],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "amountOut", type: "uint256" },
+      { internalType: "uint256", name: "amountInMax", type: "uint256" },
+      { internalType: "address[]", name: "path", type: "address[]" },
+      { internalType: "address", name: "to", type: "address" },
+    ],
+    name: "swapTokensForExactTokens",
+    outputs: [{ internalType: "uint256", name: "amountIn", type: "uint256" }],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "token", type: "address" },
+      { internalType: "uint256", name: "amountMinimum", type: "uint256" },
+      { internalType: "address", name: "recipient", type: "address" },
+    ],
+    name: "sweepToken",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "token", type: "address" },
+      { internalType: "uint256", name: "amountMinimum", type: "uint256" },
+    ],
+    name: "sweepToken",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "token", type: "address" },
+      { internalType: "uint256", name: "amountMinimum", type: "uint256" },
+      { internalType: "uint256", name: "feeBips", type: "uint256" },
+      { internalType: "address", name: "feeRecipient", type: "address" },
+    ],
+    name: "sweepTokenWithFee",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "token", type: "address" },
+      { internalType: "uint256", name: "amountMinimum", type: "uint256" },
+      { internalType: "address", name: "recipient", type: "address" },
+      { internalType: "uint256", name: "feeBips", type: "uint256" },
+      { internalType: "address", name: "feeRecipient", type: "address" },
+    ],
+    name: "sweepTokenWithFee",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "int256", name: "amount0Delta", type: "int256" },
+      { internalType: "int256", name: "amount1Delta", type: "int256" },
+      { internalType: "bytes", name: "_data", type: "bytes" },
+    ],
+    name: "uniswapV3SwapCallback",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "amountMinimum", type: "uint256" },
+      { internalType: "address", name: "recipient", type: "address" },
+    ],
+    name: "unwrapWETH9",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "amountMinimum", type: "uint256" },
+    ],
+    name: "unwrapWETH9",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "amountMinimum", type: "uint256" },
+      { internalType: "address", name: "recipient", type: "address" },
+      { internalType: "uint256", name: "feeBips", type: "uint256" },
+      { internalType: "address", name: "feeRecipient", type: "address" },
+    ],
+    name: "unwrapWETH9WithFee",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "amountMinimum", type: "uint256" },
+      { internalType: "uint256", name: "feeBips", type: "uint256" },
+      { internalType: "address", name: "feeRecipient", type: "address" },
+    ],
+    name: "unwrapWETH9WithFee",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "value", type: "uint256" }],
+    name: "wrapETH",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  { stateMutability: "payable", type: "receive" },
+]
+
+const UNISWAP_INTERFACE = new ethers.utils.Interface(UNISWAP_ABI)
+
+const ALCHEMY_KEY = process.env.ALCHEMY_KEY // eslint-disable-line prefer-destructuring
+
+const alchemyProvider = new AlchemyProvider(
+  getNetwork(Number(getEthereumNetwork().chainID)),
+  ALCHEMY_KEY
+)
+
+interface UniswapV3ExactInputSingle {
+  amountIn: BigNumber
+  amountOutMinimum: BigNumber
+  fee: 100
+  recipient: HexString
+  sqrtPriceLimitX96: BigNumber
+  tokenIn: HexString
+  tokenOut: HexString
+}
+
+interface UniswapV3ExactOutputSingle {
+  amountOut: BigNumber
+  amountInMinimum: BigNumber
+  fee: 100
+  recipient: HexString
+  sqrtPriceLimitX96: BigNumber
+  tokenIn: HexString
+  tokenOut: HexString
+}
+
+interface EnrichedUniswapTransactionInformation {
+  amount: string
+}
+
+export const getTokenMetaData = async (
+  address: string
+): Promise<SmartContractFungibleAsset | null> => {
+  try {
+    const tokenMetadata = await getTokenMetadata(alchemyProvider, address)
+    return tokenMetadata
+  } catch (err) {
+    logger.warn("Couldn't find token with specified address", address)
+  }
+  return null
+}
+
+export async function parseUniswapTx(
+  input: string
+): Promise<EnrichedUniswapTransactionInformation | undefined> {
+  try {
+    const transaction = UNISWAP_INTERFACE.parseTransaction({
+      data: input,
+    })
+    if (transaction.name === "multicall") {
+      const [deadline, transactionInputs] = transaction.args as [
+        BigNumber,
+        string[]
+      ]
+      // eslint-disable-next-line no-restricted-syntax
+      for (const transactionInput of transactionInputs) {
+        const detailedUniswapTransaction = UNISWAP_INTERFACE.parseTransaction({
+          data: transactionInput,
+        })
+        if (detailedUniswapTransaction.name === "exactInputSingle") {
+          const params = detailedUniswapTransaction
+            .args[0] as UniswapV3ExactInputSingle
+
+          // eslint-disable-next-line no-await-in-loop
+          const tokenInfo = await getTokenMetaData(params.tokenIn)
+          if (tokenInfo) {
+            return {
+              amount: params.amountIn.div(10 ** tokenInfo.decimals).toString(), // @TODO Decimals
+            }
+          }
+          return {
+            amount: params.amountIn.toString(),
+          }
+        }
+        if (detailedUniswapTransaction.name === "exactOutputSingle") {
+          const params = detailedUniswapTransaction
+            .args[0] as UniswapV3ExactOutputSingle
+
+          // eslint-disable-next-line no-await-in-loop
+          const tokenInfo = await getTokenMetaData(params.tokenOut)
+          if (tokenInfo) {
+            return {
+              amount: params.amountOut.div(tokenInfo?.decimals).toString(),
+            }
+          }
+          return {
+            amount: params.amountOut.toString(),
+          }
+        }
+      }
+      return undefined
+    }
+  } catch (err) {
+    console.log(err)
+    return undefined
+  }
+  return undefined
+}

--- a/background/services/enrichment/index.ts
+++ b/background/services/enrichment/index.ts
@@ -243,24 +243,28 @@ export default class EnrichmentService extends BaseService<Events> {
         }
       } else {
         // Fall back on a standard contract interaction.
-        const uniswapTx = await parseUniswapTx(transaction.input)
 
-        if (uniswapTx) {
-          txAnnotation = {
-            type: "contract-interaction",
-            timestamp: Date.now(),
-            transactionLogoURL,
-            assetAmount: uniswapTx.amount,
+        // If we are interacting with Uniswap
+        if (transaction.to === "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45") {
+          const uniswapTx = await parseUniswapTx(transaction.input)
+
+          if (uniswapTx) {
+            txAnnotation = {
+              type: "contract-interaction",
+              timestamp: Date.now(),
+              transactionLogoURL,
+              assetAmount: uniswapTx.amount,
+            }
+            return txAnnotation
           }
-        } else {
-          txAnnotation = {
-            timestamp: Date.now(),
-            type: "contract-interaction",
-            // Include the logo URL if we resolve it even if the interaction is
-            // non-specific; the UI can choose to use it or not, but if we know the
-            // address has an associated logo it's worth passing on.
-            transactionLogoURL,
-          }
+        }
+        txAnnotation = {
+          timestamp: Date.now(),
+          type: "contract-interaction",
+          // Include the logo URL if we resolve it even if the interaction is
+          // non-specific; the UI can choose to use it or not, but if we know the
+          // address has an associated logo it's worth passing on.
+          transactionLogoURL,
         }
       }
     }

--- a/ui/components/SignTransaction/SignTransactionInfoBaseProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionInfoBaseProvider.tsx
@@ -1,4 +1,5 @@
 import { EIP1559TransactionRequest } from "@tallyho/tally-background/networks"
+import { EnrichedEIP1559TransactionRequest } from "@tallyho/tally-background/services/enrichment"
 import { TransactionDescription } from "ethers/lib/utils"
 import { ReactElement, ReactNode } from "react"
 
@@ -10,7 +11,9 @@ export interface SignTransactionInfo {
 }
 
 export interface SignTransactionInfoProviderProps {
-  transactionDetails: EIP1559TransactionRequest
+  transactionDetails:
+    | EIP1559TransactionRequest
+    | EnrichedEIP1559TransactionRequest
   parsedTx: TransactionDescription | undefined
   inner: (info: SignTransactionInfo) => ReactElement
 }

--- a/ui/components/SignTransaction/SignTransactionSignInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSignInfoProvider.tsx
@@ -39,11 +39,6 @@ export default function SignTransactionSignInfoProvider({
     annotation = transactionDetails.annotation
   }
 
-  console.log({
-    annotation,
-    transactionDetails,
-  })
-
   const completeTransactionAssetAmount:
     | (AnyAssetAmount & AssetDecimalAmount)
     | CompleteAssetAmount =

--- a/ui/components/SignTransaction/SignTransactionSignInfoProvider.tsx
+++ b/ui/components/SignTransaction/SignTransactionSignInfoProvider.tsx
@@ -8,6 +8,7 @@ import {
   enrichAssetAmountWithDecimalValues,
   enrichAssetAmountWithMainCurrencyValues,
 } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
+import { TransactionAnnotation } from "@tallyho/tally-background/services/enrichment"
 import React, { ReactElement } from "react"
 import { useBackgroundSelector } from "../../hooks"
 import TransactionDetailAddressValue from "../TransactionDetail/TransactionDetailAddressValue"
@@ -32,6 +33,16 @@ export default function SignTransactionSignInfoProvider({
     },
     4
   )
+
+  let annotation: TransactionAnnotation | undefined
+  if ("annotation" in transactionDetails) {
+    annotation = transactionDetails.annotation
+  }
+
+  console.log({
+    annotation,
+    transactionDetails,
+  })
 
   const completeTransactionAssetAmount:
     | (AnyAssetAmount & AssetDecimalAmount)
@@ -70,7 +81,8 @@ export default function SignTransactionSignInfoProvider({
             <div className="spend_amount_label">Spend Amount</div>
             <div className="spend_amount">
               <div className="eth_value">
-                {completeTransactionAssetAmount.localizedDecimalAmount}
+                {(annotation && (annotation as any).assetAmount) ??
+                  completeTransactionAssetAmount.localizedDecimalAmount}
               </div>
               <div className="main_currency_value">
                 {"localizedMainCurrencyAmount" in


### PR DESCRIPTION
This is a very naive implementation of how we can preview ERC-20 tokens  to be sent when interacting with Uniswap per suggestion from @wojciech-turek.

Currently when we interact with uniswap (and probably any dex) the "Spend Amount" shown on our Sign Transaction page is `0` for any asset except ETH.  For Uniswap specifically - this happens because the swap is a `contract-interaction` whose inputs we do not know how to parse.

### At a high level - what is going on is

1. Transaction Signature Request comes in.
2. We attempt to parse the input data using the uniswap v3 abi to see if it is a uniswap v3 contract function
3. If it is - we assume that is a call to `multicall` - and attempt to parse the arguments to `multicall`.
4. If one of the functions called by `multicall` is `exactInputSingle` or `exactOutputSingle` - assume the interaction is a swap - and enrich enrich transaction annotation with amount being swapped.

The implementation as-is has a number of limitations.
• It only works with assets that actually have a pool - swaps that require multiple-hops will not be parsed correctly.
• It is tightly coupled to uniswap (by virtue of relying on the uniswap abi) - I'm not sure if there is a more general solution possible but I imagine the input is un-parseable without relying on the abi.
• It assumes that the inital transaction is always a `multicall` transaction - this may be because I am testing on a wallet that has no assets approved on uniswap.
• This pattern of parsing contract-interaction amounts likely relies on an integration-per-dapp - this is not ideal.
• Many shortcuts were taken with typing / linter rules


![image](https://user-images.githubusercontent.com/94649004/152656453-717c0ed8-db41-4c24-b5cf-bfed9dd6e2f2.png)


If this is the direction we want to head in - I am happy to push forward and take this PR into a mergeable state.  

This PR is brought to you by virtue of accidentally drinking 4 shots of espresso assumed to be one cup of coffee ☕ ☕ 
