### PR TITLE
WIP UI: Normalize HexString Values

### DIFF
--- a/background/lib/utils/index.ts
+++ b/background/lib/utils/index.ts
@@ -112,7 +112,8 @@ export function getEthereumNetwork(): EVMNetwork {
 }
 
 export function truncateAddress(address: string): string {
-  return `${address.slice(0, 6)}...${address.slice(-5)}`
+  const normalizedAddress = normalizeEVMAddress(address)
+  return `${normalizedAddress.slice(0, 6)}...${normalizedAddress.slice(-5)}`
 }
 
 export const getNumericStringValueFromBigNumber = (

--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -133,7 +133,9 @@ function SelectAssetMenuContent<T extends AnyAsset>(
               key={
                 asset.metadata?.coinGeckoID ??
                 asset.symbol +
-                  ("contractAddress" in asset ? asset.contractAddress : "")
+                  ("contractAddress" in asset
+                    ? normalizeEVMAddress(asset.contractAddress)
+                    : "")
               }
               assetAndAmount={assetWithOptionalAmount}
               onClick={() => setSelectedAssetAndClose(assetWithOptionalAmount)}

--- a/ui/components/SignTransaction/SignTransactionWrongLedgerConnected.tsx
+++ b/ui/components/SignTransaction/SignTransactionWrongLedgerConnected.tsx
@@ -1,3 +1,4 @@
+import { truncateAddress } from "@tallyho/tally-background/lib/utils"
 import { AccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
 import React, { ReactElement } from "react"
 import SharedButton from "../Shared/SharedButton"
@@ -31,10 +32,7 @@ export default function SignTransactionWrongLedgerConnected({
                     ?.focus()
                 }}
               >
-                {`${signerAccountTotal.address.slice(
-                  0,
-                  7
-                )}...${signerAccountTotal.address.slice(-6)}`}
+                {`${truncateAddress(signerAccountTotal.address)}`}
               </SharedButton>
             </div>
           </div>

--- a/ui/components/Wallet/WalletActivityList.tsx
+++ b/ui/components/Wallet/WalletActivityList.tsx
@@ -7,7 +7,6 @@ import {
 import { ActivityItem } from "@tallyho/tally-background/redux-slices/activities"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import SharedSlideUpMenu from "../Shared/SharedSlideUpMenu"
-import SharedLoadingSpinner from "../Shared/SharedLoadingSpinner"
 import WalletActivityDetails from "./WalletActivityDetails"
 import WalletActivityListItem from "./WalletActivityListItem"
 

--- a/ui/components/Wallet/WalletAssetListItem.tsx
+++ b/ui/components/Wallet/WalletAssetListItem.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from "react"
 import { Link } from "react-router-dom"
 import { CompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
 
+import { normalizeEVMAddress } from "@tallyho/tally-background/lib/utils"
 import SharedLoadingSpinner from "../Shared/SharedLoadingSpinner"
 import SharedAssetIcon from "../Shared/SharedAssetIcon"
 
@@ -25,7 +26,7 @@ export default function WalletAssetListItem(props: Props): ReactElement {
             symbol: assetAmount.asset.symbol,
             contractAddress:
               "contractAddress" in assetAmount.asset
-                ? assetAmount.asset.contractAddress
+                ? normalizeEVMAddress(assetAmount.asset.contractAddress)
                 : undefined,
           },
         }}

--- a/ui/pages/EarnDeposit.tsx
+++ b/ui/pages/EarnDeposit.tsx
@@ -9,6 +9,10 @@ import {
 
 import { AnyAsset } from "@tallyho/tally-background/assets"
 import { HexString } from "@tallyho/tally-background/types"
+import {
+  sameEVMAddress,
+  normalizeEVMAddress,
+} from "@tallyho/tally-background/lib/utils"
 import { useLocation } from "react-router-dom"
 import BackButton from "../components/Shared/SharedBackButton"
 import SharedAssetIcon from "../components/Shared/SharedAssetIcon"
@@ -47,8 +51,8 @@ export default function EarnDeposit(): ReactElement {
 
   const isTokenApproved = () => {
     if (!isApproved) {
-      const allowanceIndex = approvals?.findIndex(
-        (approval) => approval.contractAddress === asset.contractAddress
+      const allowanceIndex = approvals?.findIndex((approval) =>
+        sameEVMAddress(approval.contractAddress, asset.contractAddress)
       )
       if (allowanceIndex !== -1) {
         setIsApproved(true)
@@ -59,13 +63,13 @@ export default function EarnDeposit(): ReactElement {
   isTokenApproved()
 
   const approve = () => {
-    dispatch(approveApprovalTarget(asset.contractAddress))
+    dispatch(approveApprovalTarget(normalizeEVMAddress(asset.contractAddress)))
   }
 
   const enable = () => {
     dispatch(
       permitVaultDeposit({
-        vaultContractAddress: asset.contractAddress,
+        vaultContractAddress: normalizeEVMAddress(asset.contractAddress),
         amount: 2000n,
       })
     )
@@ -85,7 +89,9 @@ export default function EarnDeposit(): ReactElement {
   }
 
   useEffect(() => {
-    dispatch(checkApprovalTargetApproval(asset.contractAddress))
+    dispatch(
+      checkApprovalTargetApproval(normalizeEVMAddress(asset.contractAddress))
+    )
   }, [dispatch, asset.contractAddress])
 
   return (

--- a/ui/pages/SignTransaction.tsx
+++ b/ui/pages/SignTransaction.tsx
@@ -10,6 +10,7 @@ import {
   TransactionConstructionStatus,
 } from "@tallyho/tally-background/redux-slices/transaction-construction"
 import { getAccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
+import { normalizeEVMAddress } from "@tallyho/tally-background/lib/utils"
 import {
   useBackgroundDispatch,
   useBackgroundSelector,
@@ -53,7 +54,10 @@ export default function SignTransaction({
 
   const signerAccountTotal = useBackgroundSelector((state) => {
     if (typeof transactionDetails !== "undefined") {
-      return getAccountTotal(state, transactionDetails.from)
+      return getAccountTotal(
+        state,
+        normalizeEVMAddress(transactionDetails.from)
+      )
     }
     return undefined
   })

--- a/ui/pages/SingleAsset.tsx
+++ b/ui/pages/SingleAsset.tsx
@@ -9,7 +9,10 @@ import {
   HIDE_SEND_BUTTON,
   HIDE_SWAP,
 } from "@tallyho/tally-background/features/features"
-import { normalizeEVMAddress } from "@tallyho/tally-background/lib/utils"
+import {
+  normalizeEVMAddress,
+  sameEVMAddress,
+} from "@tallyho/tally-background/lib/utils"
 import { isSmartContractFungibleAsset } from "@tallyho/tally-background/assets"
 import { useBackgroundSelector } from "../hooks"
 import SharedAssetIcon from "../components/Shared/SharedAssetIcon"
@@ -30,7 +33,7 @@ export default function SingleAsset(): ReactElement {
       (activity) => {
         if (
           typeof contractAddress !== "undefined" &&
-          contractAddress === activity.to
+          sameEVMAddress(contractAddress, activity.to)
         ) {
           return true
         }
@@ -64,8 +67,7 @@ export default function SingleAsset(): ReactElement {
         if (typeof contractAddress !== "undefined") {
           return (
             isSmartContractFungibleAsset(candidateAsset) &&
-            normalizeEVMAddress(candidateAsset.contractAddress) ===
-              normalizeEVMAddress(contractAddress)
+            sameEVMAddress(candidateAsset.contractAddress, contractAddress)
           )
         }
         return candidateAsset.symbol === symbol
@@ -114,7 +116,7 @@ export default function SingleAsset(): ReactElement {
                         symbol,
                         contractAddress:
                           "contractAddress" in asset
-                            ? asset.contractAddress
+                            ? normalizeEVMAddress(asset.contractAddress)
                             : undefined,
                       },
                     }}
@@ -133,7 +135,7 @@ export default function SingleAsset(): ReactElement {
                         symbol,
                         contractAddress:
                           "contractAddress" in asset
-                            ? asset.contractAddress
+                            ? normalizeEVMAddress(asset.contractAddress)
                             : undefined,
                       },
                     }}

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -24,7 +24,10 @@ import { fixedPointNumberToString } from "@tallyho/tally-background/lib/fixed-po
 import { AsyncThunkFulfillmentType } from "@tallyho/tally-background/redux-slices/utils"
 import logger from "@tallyho/tally-background/lib/logger"
 import { useHistory, useLocation } from "react-router-dom"
-import { normalizeEVMAddress } from "@tallyho/tally-background/lib/utils"
+import {
+  normalizeEVMAddress,
+  sameEVMAddress,
+} from "@tallyho/tally-background/lib/utils"
 import { CompleteSmartContractFungibleAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
 import {
   clearTransactionState,
@@ -50,10 +53,7 @@ function isSameAsset(asset1: AnyAsset, asset2: AnyAsset) {
     isSmartContractFungibleAsset(asset1) &&
     isSmartContractFungibleAsset(asset2)
   ) {
-    return (
-      normalizeEVMAddress(asset1.contractAddress) ===
-      normalizeEVMAddress(asset2.contractAddress)
-    )
+    return sameEVMAddress(asset1.contractAddress, asset2.contractAddress)
   }
 
   if (
@@ -100,8 +100,10 @@ export default function Swap(): ReactElement {
       if (typeof locationAssetContractAddress !== "undefined") {
         return (
           isSmartContractFungibleAsset(candidateAsset) &&
-          normalizeEVMAddress(candidateAsset.contractAddress) ===
-            normalizeEVMAddress(locationAssetContractAddress)
+          sameEVMAddress(
+            candidateAsset.contractAddress,
+            locationAssetContractAddress
+          )
         )
       }
       return candidateAsset.symbol === locationAssetSymbol
@@ -173,9 +175,10 @@ export default function Swap(): ReactElement {
   const inProgressApprovalContract = useBackgroundSelector(
     selectInProgressApprovalContract
   )
-  const isApprovalInProgress =
-    normalizeEVMAddress(inProgressApprovalContract || "0x") ===
-    normalizeEVMAddress(sellAsset?.contractAddress || "0x")
+  const isApprovalInProgress = sameEVMAddress(
+    inProgressApprovalContract || "0x",
+    sellAsset?.contractAddress || "0x"
+  )
 
   const [sellAmountLoading, setSellAmountLoading] = useState(false)
   const [buyAmountLoading, setBuyAmountLoading] = useState(false)
@@ -234,7 +237,7 @@ export default function Swap(): ReactElement {
 
     dispatch(
       approveTransfer({
-        assetContractAddress: sellAsset.contractAddress,
+        assetContractAddress: normalizeEVMAddress(sellAsset.contractAddress),
         approvalTarget,
       })
     )


### PR DESCRIPTION
# Issue
Not all hex strings were being normalized.

# Solution
Leverage the existing functionality from `@tallyho/hd-keyring` and `background/lib/utils/index.ts` to normalize hex strings including block hashes, account strings, and transaction hashes.