### PR TITLE
Fidget Spinners: Simplify DOM and eliminate strange render loops in Popup

### DIFF
--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -18,6 +18,12 @@ const defaultSettings = {
   hideBanners: false,
 }
 
+export interface Location {
+  pathname: string
+  key?: string
+  hash: string
+}
+
 export type UIState = {
   selectedAccount: AddressOnNetwork
   showingActivityDetailID: string | null

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -30,9 +30,7 @@ setTimeout(() => {
     reloadCount = 0
     window.history.replaceState(state, "", document.URL)
   } else {
-    const isAppRendered = !!document.getElementsByClassName(
-      "top_menu_wrap_decoy"
-    ).length
+    const isAppRendered = document.getElementsByTagName("main").length > 0
     if (!isAppRendered) {
       window.location.reload()
     }

--- a/ui/components/AccountItem/AccountItemActionHeader.tsx
+++ b/ui/components/AccountItem/AccountItemActionHeader.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement } from "react"
 interface AccountItemActionHeaderProps {
   label: string
   icon: string
-  color?: string
+  color: string
 }
 
 export default function AccountItemActionHeader({
@@ -19,14 +19,14 @@ export default function AccountItemActionHeader({
           .icon {
             mask-image: url("./images/${icon}");
             mask-size: cover;
-            background-color: ${color || "#fff"};
+            background-color: ${color};
             width: 16px;
             margin-right: 5px;
             height: 16px;
           }
           .action_header {
             display: flex;
-            color: ${color || "#fff"};
+            color: ${color};
             flexDirection: row;
             align-items: center;
             font-size: 18px;
@@ -38,4 +38,8 @@ export default function AccountItemActionHeader({
         `}</style>
     </div>
   )
+}
+
+AccountItemActionHeader.defaultProps = {
+  color: "var(--white)",
 }

--- a/ui/components/AccountItem/AccountItemEditName.tsx
+++ b/ui/components/AccountItem/AccountItemEditName.tsx
@@ -68,7 +68,6 @@ export default function AccountItemEditName({
         <AccountItemActionHeader
           label={t("editName")}
           icon="icons/s/edit.svg"
-          color="#fff"
         />
       </div>
       <div className="account_container standard_width">

--- a/ui/components/AccountsNotificationPanel/EditSectionForm.tsx
+++ b/ui/components/AccountsNotificationPanel/EditSectionForm.tsx
@@ -61,7 +61,6 @@ function EditSectionForm({
         <AccountItemActionHeader
           label={t("editName")}
           icon="icons/s/edit.svg"
-          color="#fff"
         />
       </div>
       <div className="wallet_title">

--- a/ui/components/Core/CorePage.tsx
+++ b/ui/components/Core/CorePage.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames"
 import React, { ReactElement } from "react"
 import Snackbar from "../Snackbar/Snackbar"
 import TabBar from "../TabBar/TabBar"
@@ -12,23 +13,52 @@ interface Props {
    * children will handle it instead.
    */
   handleScrolling: boolean
+  /**
+   * Indicates how direct children of the page should be aligned. Defaults to
+   * center. Start is roughly equivalent to left (but respects right-to-left
+   * language ordering), and end is equivalent to right.
+   */
+  contentAlign: "center" | "start" | "end"
+  /**
+   * When specified, the page is set to have the standard popup width. If set
+   * to `padded`, standard padding is applied.
+   */
+  standardWidth?: true | "padded"
 }
 
 export default function CorePage(props: Props): ReactElement {
-  const { children, hasTopBar, hasTabBar, handleScrolling } = props
+  const {
+    children,
+    hasTopBar,
+    hasTabBar,
+    handleScrolling,
+    contentAlign,
+    standardWidth,
+  } = props
 
   return (
-    <>
+    <section>
       {hasTopBar ? <TopMenu /> : <></>}
-      <main>
+      <main
+        className={classNames({
+          standard_width: standardWidth === true,
+          standard_width_padded: standardWidth === "padded",
+        })}
+      >
         {children}
         <Snackbar />
       </main>
       {hasTabBar ? <TabBar /> : <></>}
       <style jsx>
         {`
+          section {
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+          }
           main {
-            width: 100%;
+            ${standardWidth === undefined ? "width: 100%;" : ""}
+
             ${handleScrolling
               ? "overflow-y: auto"
               : "height: 100%; overflow: hidden;"};
@@ -36,12 +66,12 @@ export default function CorePage(props: Props): ReactElement {
             flex-direction: column;
             flex-grow: 1;
             margin: 0 auto;
-            align-items: center;
+            align-items: ${contentAlign};
             background-color: var(--hunter-green);
           }
         `}
       </style>
-    </>
+    </section>
   )
 }
 
@@ -49,4 +79,5 @@ CorePage.defaultProps = {
   hasTopBar: false,
   hasTabBar: false,
   handleScrolling: true,
+  contentAlign: "center",
 }

--- a/ui/components/Core/CorePage.tsx
+++ b/ui/components/Core/CorePage.tsx
@@ -1,54 +1,52 @@
 import React, { ReactElement } from "react"
 import Snackbar from "../Snackbar/Snackbar"
+import TabBar from "../TabBar/TabBar"
+import TopMenu from "../TopMenu/TopMenu"
 
 interface Props {
   children: React.ReactNode
-  hasTopBar?: boolean
-  hasTabBar?: boolean
+  hasTopBar: boolean
+  hasTabBar: boolean
+  /**
+   * Indicates whether the page component should handle scrolling, or whether
+   * children will handle it instead.
+   */
+  handleScrolling: boolean
 }
 
 export default function CorePage(props: Props): ReactElement {
-  const { children, hasTopBar, hasTabBar } = props
-
-  let barSpace = 0
-  if (hasTabBar) {
-    // Tab bar is given 56px of height
-    barSpace += 56
-  }
-  if (hasTopBar) {
-    // Top bar is given 64px of height
-    barSpace += 64
-  }
+  const { children, hasTopBar, hasTabBar, handleScrolling } = props
 
   return (
-    <main>
-      {children}
-      <Snackbar />
+    <>
+      {hasTopBar ? <TopMenu /> : <></>}
+      <main>
+        {children}
+        <Snackbar />
+      </main>
+      {hasTabBar ? <TabBar /> : <></>}
       <style jsx>
         {`
           main {
             width: 100%;
-            overflow-y: auto;
+            ${handleScrolling
+              ? "overflow-y: auto"
+              : "height: 100%; overflow: hidden;"};
             display: flex;
             flex-direction: column;
             flex-grow: 1;
             margin: 0 auto;
             align-items: center;
             background-color: var(--hunter-green);
-            z-index: 10;
-            height: calc(100vh - ${barSpace}px);
-            margin-top: ${hasTopBar ? "0px" : "-64px"};
-          }
-          .top_menu_wrap {
-            z-index: 10;
-            cursor: default;
           }
         `}
       </style>
-    </main>
+    </>
   )
 }
 
 CorePage.defaultProps = {
-  hasTopBar: true,
+  hasTopBar: false,
+  hasTabBar: false,
+  handleScrolling: true,
 }

--- a/ui/components/HiddenDevPanel/HiddenDevPanel.tsx
+++ b/ui/components/HiddenDevPanel/HiddenDevPanel.tsx
@@ -1,18 +1,15 @@
 import React, { ReactElement } from "react"
 import { useTranslation } from "react-i18next"
 import { useHistory } from "react-router-dom"
+import SettingsPage from "../../pages/Settings/SettingsPage"
 import SharedButton from "../Shared/SharedButton"
-import SharedPageHeader from "../Shared/SharedPageHeader"
 
 export default function HiddenDevPanel(): ReactElement {
   const { t } = useTranslation("translation", { keyPrefix: "devPanel" })
   const history = useHistory()
 
   return (
-    <section className="standard_width_padded">
-      <SharedPageHeader backPath="/settings" withoutBackText>
-        {t("title")}
-      </SharedPageHeader>
+    <SettingsPage title={t("title")}>
       <div className="buttons_wrap">
         <SharedButton
           type="secondary"
@@ -42,6 +39,6 @@ export default function HiddenDevPanel(): ReactElement {
           margin-top: 16px;
         }
       `}</style>
-    </section>
+    </SettingsPage>
   )
 }

--- a/ui/components/NFTs/NFTsWallet.tsx
+++ b/ui/components/NFTs/NFTsWallet.tsx
@@ -6,11 +6,15 @@ import {
 } from "@tallyho/tally-background/redux-slices/selectors"
 import { selectNFTs } from "@tallyho/tally-background/redux-slices/selectors/nftsSelectors"
 import { normalizeEVMAddress } from "@tallyho/tally-background/lib/utils"
+import { useTranslation } from "react-i18next"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import NFTsList from "./NFTsList"
 import NFTsEmpty from "./NFTsEmpty"
+import SharedBanner from "../Shared/SharedBanner"
 
 export default function NFTsWallet(): ReactElement {
+  const { t } = useTranslation("translation", { keyPrefix: "wallet" })
+
   const NFTs = useBackgroundSelector(selectNFTs)
   const { address } = useBackgroundSelector(selectCurrentAccount) ?? {}
   const currentNetwork = useBackgroundSelector(selectCurrentNetwork)
@@ -34,12 +38,21 @@ export default function NFTsWallet(): ReactElement {
   }, [NFTs, currentNetwork.chainID, address])
 
   return (
-    <>
+    <section>
+      <SharedBanner
+        icon="notif-announcement"
+        iconColor="var(--link)"
+        canBeClosed
+        id="nft_soon"
+        customStyles="margin: 8px 0;"
+      >
+        {t("NFTPricingComingSoon")}
+      </SharedBanner>
       {currentOwnedNFTsList?.length ? (
         <NFTsList nfts={currentOwnedNFTsList} />
       ) : (
         <NFTsEmpty />
       )}
-    </>
+    </section>
   )
 }

--- a/ui/components/Shared/SharedButton.tsx
+++ b/ui/components/Shared/SharedButton.tsx
@@ -166,6 +166,7 @@ export default function SharedButton(
             background-color: var(--hunter-green);
             display: inline-block;
             margin-top: -1px;
+            transition: background-color 0.2s;
           }
           .large {
             height: 48px;

--- a/ui/components/TopMenu/TopMenu.tsx
+++ b/ui/components/TopMenu/TopMenu.tsx
@@ -124,7 +124,7 @@ export default function TopMenu(): ReactElement {
         />
       </SharedSlideUpMenu>
       <div className="nav_wrap">
-        <nav className="standard_width_padded">
+        <nav id="top_menu" className="standard_width_padded">
           <TopMenuProtocolSwitcher
             onClick={() => setIsProtocolListOpen(true)}
           />

--- a/ui/components/Wallet/AssetListItem/CommonAssetListItem.tsx
+++ b/ui/components/Wallet/AssetListItem/CommonAssetListItem.tsx
@@ -23,13 +23,13 @@ export default function CommonAssetListItem({
       : undefined
 
   return (
-    <Link
-      to={{
-        pathname: "/singleAsset",
-        state: assetAmount.asset,
-      }}
-    >
-      <div className="asset_list_item">
+    <>
+      <Link
+        to={{
+          pathname: "/singleAsset",
+          state: assetAmount.asset,
+        }}
+      >
         <div className="asset_left">
           <SharedAssetIcon
             logoURL={assetAmount?.asset?.metadata?.logoURL}
@@ -55,24 +55,26 @@ export default function CommonAssetListItem({
             )}
           </div>
         </div>
-        <div className="asset_right">
-          <>
-            <SharedIconRouterLink
-              path="/send"
-              state={assetAmount.asset}
-              iconClass="asset_icon_send"
-            />
-            <SharedIconRouterLink
-              path="/swap"
-              state={{
-                symbol: assetAmount.asset.symbol,
-                contractAddress,
-              }}
-              iconClass="asset_icon_swap"
-            />
-          </>
-        </div>
-      </div>
+      </Link>
+      <ul className="asset_right quick_links">
+        <li>
+          <SharedIconRouterLink
+            path="/send"
+            state={assetAmount.asset}
+            iconClass="asset_icon_send"
+          />
+        </li>
+        <li>
+          <SharedIconRouterLink
+            path="/swap"
+            state={{
+              symbol: assetAmount.asset.symbol,
+              contractAddress,
+            }}
+            iconClass="asset_icon_swap"
+          />
+        </li>
+      </ul>
       <style jsx>{`
         ${styles}
         .price {
@@ -85,6 +87,6 @@ export default function CommonAssetListItem({
           line-height: 16px;
         }
       `}</style>
-    </Link>
+    </>
   )
 }

--- a/ui/components/Wallet/AssetListItem/styles.ts
+++ b/ui/components/Wallet/AssetListItem/styles.ts
@@ -1,5 +1,6 @@
 export default `
-  .asset_list_item {
+  .asset_list_item > a {
+    display: block;
     height: 72px;
     width: 100%;
     border-radius: 16px;
@@ -11,7 +12,10 @@ export default `
     justify-content: space-between;
     align-items: center;
   }
-  .asset_list_item:hover {
+  .asset_list_item:last-of-type > a {
+    margin-bottom: 0;
+  }
+  .asset_list_item:hover > a {
     background-color: var(--green-80);
   }
   .asset_left {
@@ -23,10 +27,20 @@ export default `
     justify-content: center;
     margin-left: 16px;
   }
-  .asset_right {
+
+  .asset_list_item {
+     position: relative; /* for positioning quick_links */
+  }
+  .quick_links {
+    position: absolute;
+    top: calc(50% - 14px /* 1/2 of icon height */);
+    right: 4px;
     display: flex;
     justify-content: flex-end;
     margin-right: 16px;
+  }
+  .quick_links a {
+    display: block;
   }
   .asset_amount {
     height: 17px;

--- a/ui/components/Wallet/WalletActivityList.tsx
+++ b/ui/components/Wallet/WalletActivityList.tsx
@@ -86,7 +86,7 @@ export default function WalletActivityList({
     )
 
   return (
-    <>
+    <section>
       {!instantlyHideActivityDetails && (
         <SharedSlideUpMenu isOpen={!!showingActivityDetail} close={handleClose}>
           {showingActivityDetail ? (
@@ -97,7 +97,7 @@ export default function WalletActivityList({
         </SharedSlideUpMenu>
       )}
 
-      <ul>
+      <ul className="activites">
         {activities.map((activityItem) => {
           if (activityItem) {
             return (
@@ -129,33 +129,38 @@ export default function WalletActivityList({
             {scanWebsite[network.chainID].title}
           </SharedButton>
         </div>
-        <style jsx>{`
-          span {
-            width: 100%;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            color: var(--green-20);
-            font-size: 16px;
-            font-weight: 400;
-            line-height: 24px;
-            text-align: center;
-          }
-          .row {
-            display: flex;
-            flex-direction: row;
-            align-items: center;
-            gap: 8px;
-          }
-          .hand {
-            margin: 10px 0px;
-            font-size: 22px;
-          }
-          div:last-child {
-            margin-bottom: 40px;
-          }
-        `}</style>
       </span>
-    </>
+      <style jsx>{`
+        section {
+          box-sizing: border-box;
+          width: 100%;
+          padding: 15px;
+        }
+        span {
+          width: 100%;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          color: var(--green-20);
+          font-size: 16px;
+          font-weight: 400;
+          line-height: 24px;
+          text-align: center;
+        }
+        .row {
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+          gap: 8px;
+        }
+        .hand {
+          margin: 10px 0px;
+          font-size: 22px;
+        }
+        div:last-child {
+          margin-bottom: 40px;
+        }
+      `}</style>
+    </section>
   )
 }

--- a/ui/components/Wallet/WalletAssetList.tsx
+++ b/ui/components/Wallet/WalletAssetList.tsx
@@ -29,6 +29,12 @@ export default function WalletAssetList(props: Props): ReactElement {
         <li className="loading">{t("loadingActivities")}</li>
       )}
       <style jsx>{`
+        ul {
+          box-sizing: border-box;
+
+          width: 100%;
+          padding: 15px;
+        }
         .loading {
           display: flex;
           justify-content: center;

--- a/ui/components/Wallet/WalletAssetListItem.tsx
+++ b/ui/components/Wallet/WalletAssetListItem.tsx
@@ -15,7 +15,7 @@ export default function WalletAssetListItem(props: Props): ReactElement {
   const isDoggoAsset = assetAmount.asset.symbol === "DOGGO"
 
   return (
-    <li>
+    <li className="asset_list_item">
       {isDoggoAsset ? (
         <DoggoAssetListItem assetAmount={assetAmount} />
       ) : (
@@ -27,28 +27,28 @@ export default function WalletAssetListItem(props: Props): ReactElement {
       <style jsx global>
         {`
           .asset_icon {
-          mask-size: cover;
-          background-color: var(--green-60);
-          width: 12px;
-          height: 12px;
+            mask-size: cover;
+            background-color: var(--green-60);
+            width: 12px;
+            height: 12px;
           }
           .asset_icon_earn {
-          width: 22px;
-          height: 22px;
-          mask-image: url("./images/earn_tab@2x.png");
-          margin-left: 10px;
-          margin-right: -5px;
+            width: 22px;
+            height: 22px;
+            mask-image: url("./images/earn_tab@2x.png");
+            margin-left: 10px;
+            margin-right: -5px;
           }
           .asset_icon_gift {
-          width: 22px;
-          height: 22px;
-          mask-image: url("./images/gift@2x.png");
+            width: 22px;
+            height: 22px;
+            mask-image: url("./images/gift@2x.png");
           }
           .asset_icon_send {
-          mask-image: url("./images/send_asset.svg");
+            mask-image: url("./images/send_asset.svg");
           }
           .asset_icon_swap {
-          mask-image: url("./images/swap_asset.svg");
+            mask-image: url("./images/swap_asset.svg");
         `}
       </style>
     </li>

--- a/ui/hooks/index.ts
+++ b/ui/hooks/index.ts
@@ -88,8 +88,11 @@ type PanelDescriptor = {
  * return <>{switchablePanels}</>
  * ```
  */
-export function useSwitchablePanels(panels: PanelDescriptor[]): ReactNode {
-  const [panelNumber, setPanelNumber] = useState(0)
+export function useSwitchablePanels(
+  panels: PanelDescriptor[],
+  selectedPanel = 0
+): ReactNode {
+  const [panelNumber, setPanelNumber] = useState(selectedPanel)
 
   return [
     SharedPanelSwitcher({

--- a/ui/pages/Overview.tsx
+++ b/ui/pages/Overview.tsx
@@ -17,6 +17,7 @@ import BalanceHeader from "../components/Overview/BalanceHeader"
 import NetworksChart from "../components/Overview/NetworksChart"
 import AccountList from "../components/Overview/AccountList"
 import AchievementsOverview from "../components/NFTs/AchievementsOverview"
+import CorePage from "../components/Core/CorePage"
 
 const panelNames = ["Assets", "NFTs"]
 
@@ -39,7 +40,7 @@ export default function Overview(): ReactElement {
   )
 
   return (
-    <>
+    <CorePage hasTabBar>
       <section className="stats">
         <BalanceHeader
           balance={balance}
@@ -93,6 +94,6 @@ export default function Overview(): ReactElement {
           }
         `}
       </style>
-    </>
+    </CorePage>
   )
 }

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -43,6 +43,7 @@ import {
 import SharedLoadingSpinner from "../components/Shared/SharedLoadingSpinner"
 import ReadOnlyNotice from "../components/Shared/ReadOnlyNotice"
 import SharedIcon from "../components/Shared/SharedIcon"
+import CorePage from "../components/Core/CorePage"
 
 export default function Send(): ReactElement {
   const { t } = useTranslation()
@@ -171,7 +172,7 @@ export default function Send(): ReactElement {
     !sameEVMAddress(destinationAddress, userAddressValue)
 
   return (
-    <>
+    <CorePage hasTopBar>
       <div className="standard_width">
         <div className="back_button_wrap">
           <SharedBackButton path="/" />
@@ -404,6 +405,6 @@ export default function Send(): ReactElement {
           }
         `}
       </style>
-    </>
+    </CorePage>
   )
 }

--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -21,6 +21,7 @@ import { getLanguageIndex, getAvalableLanguages } from "../_locales"
 import { getLanguage, setLanguage } from "../_locales/i18n"
 import SettingButton from "./Settings/SettingButton"
 import { useBackgroundSelector } from "../hooks"
+import CorePage from "../components/Core/CorePage"
 
 const NUMBER_OF_CLICKS_FOR_DEV_PANEL = 15
 
@@ -234,7 +235,7 @@ export default function Settings(): ReactElement {
   }
 
   return (
-    <>
+    <CorePage hasTabBar>
       <section className="standard_width_padded">
         <h1>{t("settings.mainMenu")}</h1>
         <ul>
@@ -321,6 +322,6 @@ export default function Settings(): ReactElement {
           }
         `}
       </style>
-    </>
+    </CorePage>
   )
 }

--- a/ui/pages/Settings/SettingsAnalytics.tsx
+++ b/ui/pages/Settings/SettingsAnalytics.tsx
@@ -9,8 +9,8 @@ import { useTranslation } from "react-i18next"
 import { useDispatch, useSelector } from "react-redux"
 import AnalyticsSlideUpMenu from "../../components/Analytics/AnalyticsSlideUpMenu"
 import SharedButton from "../../components/Shared/SharedButton"
-import SharedPageHeader from "../../components/Shared/SharedPageHeader"
 import SharedToggleButton from "../../components/Shared/SharedToggleButton"
+import SettingsPage from "./SettingsPage"
 
 /* List items */
 
@@ -45,10 +45,7 @@ export default function SettingsAnalytics(): ReactElement {
   }
 
   return (
-    <div className="standard_width_padded analytics_wrapper">
-      <SharedPageHeader withoutBackText backPath="/settings">
-        {t("title")}
-      </SharedPageHeader>
+    <SettingsPage title={t("title")}>
       <section className="toggle_container">
         <div className="header_container">
           <div className="title_container">
@@ -182,6 +179,6 @@ export default function SettingsAnalytics(): ReactElement {
           justify-content: space-between;
         }
       `}</style>
-    </div>
+    </SettingsPage>
   )
 }

--- a/ui/pages/Settings/SettingsConnectedWebsites.tsx
+++ b/ui/pages/Settings/SettingsConnectedWebsites.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { selectAllowedPages } from "@tallyho/tally-background/redux-slices/selectors"
-import SharedPageHeader from "../../components/Shared/SharedPageHeader"
 import ConnectedWebsitesListItem from "./ConnectedWebsitesListItem"
 import { useBackgroundSelector } from "../../hooks"
 import ConnectedWebsitesListEmpty from "./ConnectedWebsitesListEmpty"
+import SettingsPage from "./SettingsPage"
 
 export default function SettingsConnectedWebsites(): ReactElement {
   const { t } = useTranslation("translation", { keyPrefix: "settings" })
@@ -22,10 +22,7 @@ export default function SettingsConnectedWebsites(): ReactElement {
   }, [allowedPages])
 
   return (
-    <div className="standard_width_padded wrapper">
-      <SharedPageHeader withoutBackText backPath="/settings">
-        {t(`connectedWebsitesSettings.title`)}
-      </SharedPageHeader>
+    <SettingsPage title={t(`connectedWebsitesSettings.title`)}>
       <section>
         {dappsByOrigin.length === 0 ? (
           <ConnectedWebsitesListEmpty />
@@ -40,12 +37,10 @@ export default function SettingsConnectedWebsites(): ReactElement {
         )}
       </section>
       <style jsx>{`
-        .wrapper {
-          display: flex;
-          flex-direction: column;
-          gap: 20px;
+        section {
+          align-self: center;
         }
       `}</style>
-    </div>
+    </SettingsPage>
   )
 }

--- a/ui/pages/Settings/SettingsExportLogs.tsx
+++ b/ui/pages/Settings/SettingsExportLogs.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import dayjs from "dayjs"
 import { serializeLogs } from "@tallyho/tally-background/lib/logger"
 import SharedButton from "../../components/Shared/SharedButton"
-import SharedPageHeader from "../../components/Shared/SharedPageHeader"
+import SettingsPage from "./SettingsPage"
 
 export default function SettingsExportLogs(): ReactElement {
   const { t } = useTranslation()
@@ -19,10 +19,7 @@ export default function SettingsExportLogs(): ReactElement {
   )}__${dayjs().format()}.txt`
 
   return (
-    <div className="standard_width_padded">
-      <SharedPageHeader withoutBackText backPath="/settings">
-        {t("settings.exportLogs.title")}
-      </SharedPageHeader>
+    <SettingsPage title={t("settings.exportLogs.title")}>
       <section>
         <h2>{t("settings.exportLogs.discordTitle")}</h2>
         <p className="simple_text">{t("settings.exportLogs.discordDesc")}</p>
@@ -68,6 +65,6 @@ export default function SettingsExportLogs(): ReactElement {
           margin-bottom: 35px;
         }
       `}</style>
-    </div>
+    </SettingsPage>
   )
 }

--- a/ui/pages/Settings/SettingsPage.tsx
+++ b/ui/pages/Settings/SettingsPage.tsx
@@ -1,0 +1,35 @@
+import React, { ReactElement, ReactNode } from "react"
+import CorePage from "../../components/Core/CorePage"
+import SharedBackButton from "../../components/Shared/SharedBackButton"
+
+type Props = {
+  title: string
+  children: ReactNode
+}
+
+export default function SettingsPage({ title, children }: Props): ReactElement {
+  return (
+    <CorePage hasTabBar standardWidth="padded" contentAlign="start">
+      <header>
+        <SharedBackButton withoutBackText path="/settings" />
+        <h1>{title}</h1>
+        <style jsx>{`
+          h1 {
+            font-size: 22px;
+            font-weight: 500;
+            line-height: 32px;
+            padding: 0px;
+            margin: -5px 0px 0px 0px;
+          }
+          header {
+            display: flex;
+            flex-direction: row;
+            gap: 8px;
+            margin: 25px 0 15px;
+          }
+        `}</style>
+      </header>
+      {children}
+    </CorePage>
+  )
+}

--- a/ui/pages/SingleAsset.tsx
+++ b/ui/pages/SingleAsset.tsx
@@ -20,6 +20,7 @@ import WalletActivityList from "../components/Wallet/WalletActivityList"
 import SharedBackButton from "../components/Shared/SharedBackButton"
 import SharedTooltip from "../components/Shared/SharedTooltip"
 import { scanWebsite } from "../utils/constants"
+import CorePage from "../components/Core/CorePage"
 
 export default function SingleAsset(): ReactElement {
   const { t } = useTranslation()
@@ -85,7 +86,7 @@ export default function SingleAsset(): ReactElement {
     }
 
   return (
-    <>
+    <CorePage hasTopBar hasTabBar>
       <div className="back_button_wrap standard_width_padded">
         <SharedBackButton path="/" />
       </div>
@@ -227,6 +228,6 @@ export default function SingleAsset(): ReactElement {
           }
         `}
       </style>
-    </>
+    </CorePage>
   )
 }

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -392,6 +392,7 @@ export default function Swap(): ReactElement {
       }
 
       latestQuoteRequest.current = quoteRequest
+
       const {
         quote,
         needsApproval: quoteNeedsApproval,
@@ -529,143 +530,126 @@ export default function Swap(): ReactElement {
   }
 
   return (
-    <>
-      <CorePage>
-        <SharedSlideUpMenu
-          isOpen={typeof finalQuote !== "undefined"}
-          close={() => {
-            dispatch(clearSwapQuote())
-          }}
-          size="large"
-        >
-          {typeof sellAsset !== "undefined" &&
-          typeof buyAsset !== "undefined" &&
-          typeof finalQuote !== "undefined" ? (
-            <SwapQuote
-              sellAsset={sellAsset}
-              buyAsset={buyAsset}
-              finalQuote={finalQuote}
-              swapTransactionSettings={swapTransactionSettings}
-            />
-          ) : (
-            <></>
-          )}
-        </SharedSlideUpMenu>
-        <div className="standard_width swap_wrap">
-          <div className="header">
-            <SharedActivityHeader label={t("swap.title")} activity="swap" />
-            <ReadOnlyNotice isLite />
-            {isEnabled(FeatureFlags.HIDE_TOKEN_FEATURES) ? (
-              <></>
-            ) : (
-              !isEnabled(FeatureFlags.HIDE_SWAP_REWARDS) && (
-                // TODO: Add onClick function after design is ready
-                <SharedIcon
-                  icon="cog@2x.png"
-                  width={20}
-                  color="var(--green-60)"
-                  hoverColor="#fff"
-                  customStyles="margin: 17px 0 25px;"
-                />
-              )
-            )}
-          </div>
+    <CorePage hasTabBar hasTopBar>
+      <SharedSlideUpMenu
+        isOpen={typeof finalQuote !== "undefined"}
+        close={() => {
+          dispatch(clearSwapQuote())
+        }}
+        size="large"
+      >
+        {typeof sellAsset !== "undefined" &&
+        typeof buyAsset !== "undefined" &&
+        typeof finalQuote !== "undefined" ? (
+          <SwapQuote
+            sellAsset={sellAsset}
+            buyAsset={buyAsset}
+            finalQuote={finalQuote}
+            swapTransactionSettings={swapTransactionSettings}
+          />
+        ) : (
+          <></>
+        )}
+      </SharedSlideUpMenu>
+      <div className="standard_width swap_wrap">
+        <div className="header">
+          <SharedActivityHeader label={t("swap.title")} activity="swap" />
+          <ReadOnlyNotice isLite />
           {isEnabled(FeatureFlags.HIDE_TOKEN_FEATURES) ? (
             <></>
           ) : (
-            isEnabled(FeatureFlags.HIDE_SWAP_REWARDS) && (
-              <SharedBanner
-                id="swap_rewards"
-                canBeClosed
-                icon="notif-announcement"
-                iconColor="var(--link)"
-                customStyles="margin-bottom: 16px"
-              >
-                {t("swap.swapRewardsTeaser")}
-              </SharedBanner>
+            !isEnabled(FeatureFlags.HIDE_SWAP_REWARDS) && (
+              // TODO: Add onClick function after design is ready
+              <SharedIcon
+                icon="cog@2x.png"
+                width={20}
+                color="var(--green-60)"
+                hoverColor="#fff"
+                customStyles="margin: 17px 0 25px;"
+              />
             )
           )}
-          <div className="form">
-            <div className="form_input">
-              <SharedAssetInput<SmartContractFungibleAsset | FungibleAsset>
-                currentNetwork={currentNetwork}
-                amount={sellAmount}
-                amountMainCurrency={priceDetails?.sellCurrencyAmount}
-                showPriceDetails
-                isPriceDetailsLoading={!priceDetails}
-                assetsAndAmounts={sellAssetAmounts}
-                selectedAsset={sellAsset}
-                isDisabled={sellAmountLoading}
-                mainCurrencySign={mainCurrencySign}
-                onAssetSelect={updateSellAsset}
-                onAmountChange={(newAmount, error) => {
-                  setPriceDetails(undefined)
-                  setSellAmount(newAmount)
-                  if (typeof error === "undefined") {
-                    updateSwapData("sell", newAmount)
-                  }
-                }}
-                label={t("swap.from")}
-              />
-            </div>
-            <button className="icon_change" type="button" onClick={flipSwap}>
-              {t("swap.switchAssets")}
-            </button>
-            <div className="form_input">
-              <SharedAssetInput<SmartContractFungibleAsset | FungibleAsset>
-                currentNetwork={currentNetwork}
-                amount={buyAmount}
-                amountMainCurrency={priceDetails?.buyCurrencyAmount}
-                priceImpact={priceDetails?.priceImpact}
-                isPriceDetailsLoading={!priceDetails}
-                showPriceDetails
-                // FIXME Merge master asset list with account balances.
-                assetsAndAmounts={buyAssets.map((asset) => ({ asset }))}
-                selectedAsset={buyAsset}
-                isDisabled={buyAmountLoading}
-                showMaxButton={false}
-                mainCurrencySign={mainCurrencySign}
-                onAssetSelect={updateBuyAsset}
-                onAmountChange={(newAmount, error) => {
-                  setPriceDetails(undefined)
-                  setBuyAmount(newAmount)
-                  if (typeof error === "undefined") {
-                    updateSwapData("buy", newAmount)
-                  }
-                }}
-                label={t("swap.to")}
-              />
-            </div>
-            <div className="settings_wrap">
-              {!isEnabled(FeatureFlags.HIDE_SWAP_REWARDS) ? (
-                <SwapRewardsCard />
-              ) : null}
-            </div>
-            <div className="footer standard_width_padded">
-              {
-                // Would welcome an alternative here---this is pretty gnarly.
-                // eslint-disable-next-line no-nested-ternary
-                needsApproval ? (
-                  isApprovalInProgress ? (
-                    <SharedButton type="primary" size="large" isDisabled>
-                      {t("swap.waitingForApproval")}
-                    </SharedButton>
-                  ) : (
-                    <SharedButton
-                      type="primary"
-                      size="large"
-                      isDisabled={
-                        isReadOnlyAccount ||
-                        typeof latestQuoteRequest.current === "undefined" ||
-                        sellAmountLoading ||
-                        buyAmountLoading
-                      }
-                      onClick={approveAsset}
-                      showLoadingOnClick={!confirmationMenu}
-                    >
-                      {t("swap.approveAsset")}
-                    </SharedButton>
-                  )
+        </div>
+        {isEnabled(FeatureFlags.HIDE_TOKEN_FEATURES) ? (
+          <></>
+        ) : (
+          isEnabled(FeatureFlags.HIDE_SWAP_REWARDS) && (
+            <SharedBanner
+              id="swap_rewards"
+              canBeClosed
+              icon="notif-announcement"
+              iconColor="var(--link)"
+              customStyles="margin-bottom: 16px"
+            >
+              {t("swap.swapRewardsTeaser")}
+            </SharedBanner>
+          )
+        )}
+        <div className="form">
+          <div className="form_input">
+            <SharedAssetInput<SmartContractFungibleAsset | FungibleAsset>
+              currentNetwork={currentNetwork}
+              amount={sellAmount}
+              amountMainCurrency={priceDetails?.sellCurrencyAmount}
+              showPriceDetails
+              isPriceDetailsLoading={!priceDetails}
+              assetsAndAmounts={sellAssetAmounts}
+              selectedAsset={sellAsset}
+              isDisabled={sellAmountLoading}
+              mainCurrencySign={mainCurrencySign}
+              onAssetSelect={updateSellAsset}
+              onAmountChange={(newAmount, error) => {
+                setPriceDetails(undefined)
+                setSellAmount(newAmount)
+                if (typeof error === "undefined") {
+                  updateSwapData("sell", newAmount)
+                }
+              }}
+              label={t("swap.from")}
+            />
+          </div>
+          <button className="icon_change" type="button" onClick={flipSwap}>
+            {t("swap.switchAssets")}
+          </button>
+          <div className="form_input">
+            <SharedAssetInput<SmartContractFungibleAsset | FungibleAsset>
+              currentNetwork={currentNetwork}
+              amount={buyAmount}
+              amountMainCurrency={priceDetails?.buyCurrencyAmount}
+              priceImpact={priceDetails?.priceImpact}
+              isPriceDetailsLoading={!priceDetails}
+              showPriceDetails
+              // FIXME Merge master asset list with account balances.
+              assetsAndAmounts={buyAssets.map((asset) => ({ asset }))}
+              selectedAsset={buyAsset}
+              isDisabled={buyAmountLoading}
+              showMaxButton={false}
+              mainCurrencySign={mainCurrencySign}
+              onAssetSelect={updateBuyAsset}
+              onAmountChange={(newAmount, error) => {
+                setPriceDetails(undefined)
+                setBuyAmount(newAmount)
+                if (typeof error === "undefined") {
+                  updateSwapData("buy", newAmount)
+                }
+              }}
+              label={t("swap.to")}
+            />
+          </div>
+          <div className="settings_wrap">
+            {!isEnabled(FeatureFlags.HIDE_SWAP_REWARDS) ? (
+              <SwapRewardsCard />
+            ) : null}
+          </div>
+          <div className="footer standard_width_padded">
+            {
+              // Would welcome an alternative here---this is pretty gnarly.
+              // eslint-disable-next-line no-nested-ternary
+              needsApproval ? (
+                isApprovalInProgress ? (
+                  <SharedButton type="primary" size="large" isDisabled>
+                    {t("swap.waitingForApproval")}
+                  </SharedButton>
                 ) : (
                   <SharedButton
                     type="primary"
@@ -674,23 +658,38 @@ export default function Swap(): ReactElement {
                       isReadOnlyAccount ||
                       typeof latestQuoteRequest.current === "undefined" ||
                       sellAmountLoading ||
-                      buyAmountLoading ||
-                      !sellAsset ||
-                      !sellAmount ||
-                      !buyAsset ||
-                      !buyAmount
+                      buyAmountLoading
                     }
-                    onClick={getFinalQuote}
+                    onClick={approveAsset}
                     showLoadingOnClick={!confirmationMenu}
                   >
-                    {t("swap.getFinalQuote")}
+                    {t("swap.approveAsset")}
                   </SharedButton>
                 )
-              }
-            </div>
+              ) : (
+                <SharedButton
+                  type="primary"
+                  size="large"
+                  isDisabled={
+                    isReadOnlyAccount ||
+                    typeof latestQuoteRequest.current === "undefined" ||
+                    sellAmountLoading ||
+                    buyAmountLoading ||
+                    !sellAsset ||
+                    !sellAmount ||
+                    !buyAsset ||
+                    !buyAmount
+                  }
+                  onClick={getFinalQuote}
+                  showLoadingOnClick={!confirmationMenu}
+                >
+                  {t("swap.getFinalQuote")}
+                </SharedButton>
+              )
+            }
           </div>
         </div>
-      </CorePage>
+      </div>
       <style jsx>
         {`
           .swap_wrap {
@@ -757,6 +756,6 @@ export default function Swap(): ReactElement {
           }
         `}
       </style>
-    </>
+    </CorePage>
   )
 }

--- a/ui/utils/pageTransition.ts
+++ b/ui/utils/pageTransition.ts
@@ -1,7 +1,7 @@
 import { RouteComponentProps } from "react-router-dom"
 import tabs from "./tabs"
 
-export default function setAnimationConditions(
+export default function getAnimationDirection(
   routeProps: RouteComponentProps & {
     history?: {
       entries?: {
@@ -14,9 +14,8 @@ export default function setAnimationConditions(
     location?: {
       pathname: string
     }
-  },
-  setIsDirectionRight: (choice: boolean) => void
-): void {
+  }
+): "right" | "left" | "none" {
   const { entries } = routeProps.history
   const locationName = routeProps.location.pathname.split("/")[1]
   const prevLocationName =
@@ -37,45 +36,19 @@ export default function setAnimationConditions(
     entries[entries.length - 1] &&
     entries[entries.length - 1]?.state?.isBack === true
 
-  if (isGoingBack) {
-    setIsDirectionRight(true)
-  } else if (isGoingBetweenTabs) {
-    if (isGoingToATabLeftOfTab) {
-      setIsDirectionRight(true)
-    } else if (!isGoingToATabLeftOfTab) {
-      setIsDirectionRight(false)
-    }
-  } else {
-    setIsDirectionRight(false)
+  // Note that these directions are the *animation* directions, which are
+  // opposite of the spatial direction that the content is moving.
+  if (isGoingBack || (isGoingBetweenTabs && isGoingToATabLeftOfTab)) {
+    return "right"
   }
+  return "left"
 }
 
-export function animationStyles(isDirectionRight: boolean): string {
+export function animationStyles(): string {
   return `
-      .page-transition-enter {
-        opacity: 0.3;
-        transform: ${isDirectionRight ? `translateX(-7px)` : `translateX(7px)`};
-      }
-      .page-transition-enter-active {
-        opacity: 1;
-        transform: translateX(0px);
-        transition: transform cubic-bezier(0.25, 0.4, 0.55, 1.4) 250ms,
-          opacity 250ms;
-      }
-      .page-transition-exit {
-        opacity: 1;
-        transform: translateX(0px);
-      }
-      .page-transition-exit-active {
-        opacity: 0;
-        transform: ${isDirectionRight ? `translateX(-7px)` : `translateX(7px)`};
-        transition: transform cubic-bezier(0.25, 0.4, 0.55, 1.4) 250ms,
-          opacity 250ms;
-      }
-
       .page-transition-enter .anti_animation {
         transform: ${
-          !isDirectionRight ? `translateX(-7px)` : `translateX(7px)`
+          /*! isDirectionRight */ false ? `translateX(-7px)` : `translateX(7px)`
         };
       }
       .page-transition-enter-active .anti_animation {
@@ -88,7 +61,7 @@ export function animationStyles(isDirectionRight: boolean): string {
       .page-transition-exit-active .anti_animation {
         opacity: 1;
         transform: ${
-          !isDirectionRight ? `translateX(-7px)` : `translateX(7px)`
+          /*! isDirectionRight */ false ? `translateX(-7px)` : `translateX(7px)`
         };
         transition: transform cubic-bezier(0.25, 0.4, 0.55, 1.4) 250ms;
       }

--- a/ui/utils/pageTransition.ts
+++ b/ui/utils/pageTransition.ts
@@ -15,13 +15,6 @@ export default function setAnimationConditions(
       pathname: string
     }
   },
-  pagePreferences: {
-    [path: string]: {
-      hasTabBar: boolean
-      hasTopBar: boolean
-    }
-  },
-  setShouldDisplayDecoy: (choice: boolean) => void,
   setIsDirectionRight: (choice: boolean) => void
 ): void {
   const { entries } = routeProps.history
@@ -31,13 +24,6 @@ export default function setAnimationConditions(
       entries[entries.length - 2] &&
       entries[entries.length - 2].pathname.split("/")[1]) ||
     ""
-
-  const isDecoyNeeded =
-    pagePreferences[`/${prevLocationName === "wallet" ? "" : prevLocationName}`]
-      ?.hasTopBar &&
-    pagePreferences[`/${locationName === "wallet" ? "" : locationName}`]
-      ?.hasTopBar
-  setShouldDisplayDecoy(isDecoyNeeded)
 
   const isGoingBetweenTabs =
     tabs.includes(locationName) && tabs.includes(prevLocationName)
@@ -64,22 +50,8 @@ export default function setAnimationConditions(
   }
 }
 
-export function animationStyles(
-  shouldDisplayDecoy: boolean,
-  isDirectionRight: boolean
-): string {
+export function animationStyles(isDirectionRight: boolean): string {
   return `
-      .top_menu_wrap_decoy {
-        position: absolute;
-        top: -6px;
-        left: 0px;
-        right: 0px;
-        margin: 0 auto;
-        width: max-content;
-        z-index: -1;
-        opacity: ${!shouldDisplayDecoy ? "0" : "1"};
-      }
-
       .page-transition-enter {
         opacity: 0.3;
         transform: ${isDirectionRight ? `translateX(-7px)` : `translateX(7px)`};


### PR DESCRIPTION
The goal here is to simplify scroll handling, clarify ownership of styles,
remove render warnings and glitches, and fix types in `Popup`.

- `CorePage` is now used by page components, not forcibly wrapped in the
  router.
- `CorePage` owns, through props, rendering or not rendering the top and
  tab bars.
- Transition handling is drastically simplified, involving no `useState`
  and simply relying on CSS classes to determine transition direction.
- Proper typing is used in `Popup.tsx`; `ts-expect-error` usage is gone.
- Fixed positioning is largely removed for anything other than popovers
  and slideovers.
- Less z-indexing.
- Wallet asset list element structure more clearly reflects the quick
  links to swap and send as distinct, non-hierarchically-descendant of
  the asset item link.

Still need to check the onboarding flow; also the functionality that resets the tab selection in wallet activity
when the NFT availability changes is currently not working, but no such
networks exist by default. Some more work to be done there.

Latest build: [extension-builds-2663](https://github.com/tallycash/extension/suites/9455038633/artifacts/447435047) (as of Tue, 22 Nov 2022 22:06:13 GMT).