### PR TITLE
[Proposal]: Refactor CI build flows into smaller chunks by function

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,9 @@
-name: Build
+name: Main flow
 
 on:
-  pull_request: {}
   push:
     branches:
       - main
-    tags:
-      - v*
 
 jobs:
   build:
@@ -24,28 +21,9 @@ jobs:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
           cache: "yarn"
       - run: yarn install --frozen-lockfile
-      - name: Detect env block
-        id: env-block
-        if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const detectEnvBlock = require("./.github/workflows/builds/detect-env-block.js")
-            return await detectEnvBlock({ github, context })
-      - name: Dev build
-        if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
+      - name: Beta build
         run: |
-          echo ${{ steps.env-block.outputs.result }} > .env
           echo 'USE_ANALYTICS_SOURCE="BETA"' >> .env
-          yarn build
-        env:
-          ALCHEMY_KEY: ${{ secrets.DEV_ALCHEMY_API_KEY || 'oV1Rtjh61hGa97X2MTqMY9kEUcpxP-6K' }}
-          BLOCKNATIVE_API_KEY: ${{ secrets.DEV_BLOCKNATIVE_API_KEY || 'f60816ff-da02-463f-87a6-67a09c6d53fa' }}
-          COMMIT_SHA: ${{ github.sha }}
-      - name: Production build
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
-        run: |
-          echo 'USE_ANALYTICS_SOURCE="PROD"' >> .env
           yarn build
         env:
           ALCHEMY_KEY: ${{ secrets.ALCHEMY_API_KEY }}
@@ -56,19 +34,10 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           POAP_API_KEY: ${{ secrets.POAP_API_KEY }}
       - name: Upload build asset
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/upload-artifact@v3
         with:
-          name: extension-builds-${{ github.event.number || github.event.head_commit.id }}
+          name: extension-builds-${{ github.event.head_commit.id }}
           path: dist/*.zip
-      - name: Create Release and Upload Artifacts
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: dist/*.zip
-          draft: true
-          generate_release_notes: true
-          prerelease: ${{ contains(github.ref, '-pre') || contains(github.ref, 'v0.') }}
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,70 @@
+name: PR flow
+
+on:
+  pull_request: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Read .nvmrc
+        run: echo "::set-output name=NVMRC::$(cat ./.nvmrc)"
+        id: nvm
+      - name: Use Node + Yarn
+        uses: actions/setup-node@v3
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile
+      - name: Detect env block
+        id: env-block
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const detectEnvBlock = require("./.github/workflows/builds/detect-env-block.js")
+            return await detectEnvBlock({ github, context })
+      - name: Dev build
+        run: |
+          echo ${{ steps.env-block.outputs.result }} > .env
+          echo 'USE_ANALYTICS_SOURCE="BETA"' >> .env
+          yarn build
+        env:
+          ALCHEMY_KEY: ${{ secrets.DEV_ALCHEMY_API_KEY || 'oV1Rtjh61hGa97X2MTqMY9kEUcpxP-6K' }}
+          BLOCKNATIVE_API_KEY: ${{ secrets.DEV_BLOCKNATIVE_API_KEY || 'f60816ff-da02-463f-87a6-67a09c6d53fa' }}
+          COMMIT_SHA: ${{ github.sha }}
+      - name: Upload build asset
+        uses: actions/upload-artifact@v3
+        with:
+          name: extension-builds-${{ github.event.number }}
+          path: dist/*.zip
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Read .nvmrc
+        run: echo "::set-output name=NVMRC::$(cat ./.nvmrc)"
+        id: nvm
+      - name: Use Node + Yarn
+        uses: actions/setup-node@v3
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile
+      - run: yarn test
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Read .nvmrc
+        run: echo "::set-output name=NVMRC::$(cat ./.nvmrc)"
+        id: nvm
+      - name: Use Node + Yarn
+        uses: actions/setup-node@v3
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release flow
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Read .nvmrc
+        run: echo "::set-output name=NVMRC::$(cat ./.nvmrc)"
+        id: nvm
+      - name: Use Node + Yarn
+        uses: actions/setup-node@v3
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile
+      - name: Release build
+        run: |
+          echo 'USE_ANALYTICS_SOURCE="PROD"' >> .env
+          yarn build
+        env:
+          ALCHEMY_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+          BLOCKNATIVE_API_KEY: ${{ secrets.BLOCKNATIVE_API_KEY }}
+          UNS_API_KEY: ${{ secrets.UNS_API_KEY }}
+          SIMPLE_HASH_API_KEY: ${{ secrets.SIMPLE_HASH_API_KEY }}
+          ZEROX_API_KEY: ${{ secrets.ZEROX_API_KEY }}
+          COMMIT_SHA: ${{ github.sha }}
+          POAP_API_KEY: ${{ secrets.POAP_API_KEY }}
+      - name: Create Release and Upload Artifacts
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # v1
+        with:
+          files: dist/*.zip
+          draft: true
+          generate_release_notes: true


### PR DESCRIPTION
⚠️ This is not mergeable! This code wasn't tested at all and can break many things. ⚠️
At this point, this is an illustration of the concept.

If this idea interferes with the new CI design we can close this PR without any further ado.

## Why

It has started to become increasingly difficult to reason about what is happening exactly in which workflow. 

## What 

PRs, main and release workflows have different triggers and different steps. Instead of unifying all the triggers and then separating steps conditionally, let's create a separate workflow for every context.

PRs should build, upload asset, detect env blocks, test and lint Main should build, upload asset, test, lint, run e2e tests Release should build, and create release

test and build is redundant between PR and main. This is intentional. In theory we never push directly to main but if we do — which we shouldn't — let's make sure lint and tests are passing.

Release is not running tests and lint. This might not be the best idea but seems reasonable enough for now.

## Future work

lint and test steps should be refactored and reused throughout the workflows