### PR TITLE
Merge intersection observer hooks into one

### DIFF
--- a/ui/components/NFTS_update/NFTCollection.tsx
+++ b/ui/components/NFTS_update/NFTCollection.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, useCallback, useEffect, useState } from "react"
+import React, {
+  ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import { NFT } from "@tallyho/tally-background/nfts"
 import {
   fetchMoreNFTsFromCollection,
@@ -46,6 +52,7 @@ export default function NFTCollection(props: {
     [id, owner, network, dispatch]
   )
 
+  const collectionRef = useRef<HTMLLIElement>(null)
   const intersectionCallback = useCallback(
     ([element]) => {
       if (element.isIntersecting && !wasUpdated) {
@@ -71,11 +78,11 @@ export default function NFTCollection(props: {
     [fetchCollection, isLoading, isUpdating, wasUpdated, nfts.length]
   )
 
-  const collectionRef = useIntersectionObserver<HTMLLIElement>(
-    intersectionCallback,
-    { threshold: 0.1 }
-  )
+  useIntersectionObserver<HTMLLIElement>(collectionRef, intersectionCallback, {
+    threshold: 0.1,
+  })
 
+  const loadMoreRef = useRef<HTMLDivElement>(null)
   const loadMoreCallback = useCallback(
     ([element]) => {
       if (element.isIntersecting && !isUpdating) {
@@ -88,10 +95,9 @@ export default function NFTCollection(props: {
     [fetchMore, hasNextPage, isUpdating]
   )
 
-  const loadMoreRef = useIntersectionObserver<HTMLDivElement>(
-    loadMoreCallback,
-    { threshold: 0.1 }
-  )
+  useIntersectionObserver<HTMLDivElement>(loadMoreRef, loadMoreCallback, {
+    threshold: 0.1,
+  })
 
   useEffect(() => {
     // update collection on expand if needed

--- a/ui/components/NFTS_update/NFTPreview.tsx
+++ b/ui/components/NFTS_update/NFTPreview.tsx
@@ -1,7 +1,7 @@
 import { FeatureFlags, isEnabled } from "@tallyho/tally-background/features"
 import { truncateAddress } from "@tallyho/tally-background/lib/utils"
 import { NFTWithCollection } from "@tallyho/tally-background/redux-slices/nfts_update"
-import React, { ReactElement, useMemo } from "react"
+import React, { ReactElement, useCallback, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { useIntersectionObserver } from "../../hooks"
 import SharedButton from "../Shared/SharedButton"
@@ -47,13 +47,14 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
   // out of the viewport - browser is not rendering them at all. This is a workaround
   // to force them to rerender.
   // TODO: scrolling in and out of the view is still breaking it, needs more work
+  const backdropCallback = useCallback(([div]) => {
+    if (div.isIntersecting) {
+      div.target.classList.remove("preview_backdrop")
+      div.target.classList.add("preview_backdrop")
+    }
+  }, [])
   const backdropRef = useIntersectionObserver<HTMLDivElement>(
-    ([div]) => {
-      if (div.isIntersecting) {
-        div.target.classList.remove("preview_backdrop")
-        div.target.classList.add("preview_backdrop")
-      }
-    },
+    backdropCallback,
     { threshold: 0.8 }
   )
 

--- a/ui/components/NFTS_update/NFTPreview.tsx
+++ b/ui/components/NFTS_update/NFTPreview.tsx
@@ -1,7 +1,7 @@
 import { FeatureFlags, isEnabled } from "@tallyho/tally-background/features"
 import { truncateAddress } from "@tallyho/tally-background/lib/utils"
 import { NFTWithCollection } from "@tallyho/tally-background/redux-slices/nfts_update"
-import React, { ReactElement, useCallback, useMemo } from "react"
+import React, { ReactElement, useCallback, useMemo, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { useIntersectionObserver } from "../../hooks"
 import SharedButton from "../Shared/SharedButton"
@@ -47,16 +47,17 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
   // out of the viewport - browser is not rendering them at all. This is a workaround
   // to force them to rerender.
   // TODO: scrolling in and out of the view is still breaking it, needs more work
+  const backdropRef = useRef<HTMLDivElement>(null)
   const backdropCallback = useCallback(([div]) => {
     if (div.isIntersecting) {
       div.target.classList.remove("preview_backdrop")
       div.target.classList.add("preview_backdrop")
     }
   }, [])
-  const backdropRef = useIntersectionObserver<HTMLDivElement>(
-    backdropCallback,
-    { threshold: 0.8 }
-  )
+
+  useIntersectionObserver<HTMLDivElement>(backdropRef, backdropCallback, {
+    threshold: 0.8,
+  })
 
   const marketsList = useMemo(() => getRelevantMarketsList(nft), [nft])
   const { t } = useTranslation("translation", {

--- a/ui/components/Shared/SharedAssetIcon.tsx
+++ b/ui/components/Shared/SharedAssetIcon.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, useCallback, useEffect, useState } from "react"
+import React, {
+  ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import { storageGatewayURL } from "@tallyho/tally-background/lib/storage-gateway"
 import classNames from "classnames"
 import { useIntersectionObserver } from "../../hooks"
@@ -34,12 +40,15 @@ export default function SharedAssetIcon(props: Props): ReactElement {
 
   const sizeClass = typeof size === "string" ? size : "custom_size"
 
+  const containerRef = useRef<HTMLDivElement>(null)
   const containerObserverCallback = useCallback(([entry]) => {
     if (entry.isIntersecting) {
       setIsVisible(true)
     }
   }, [])
-  const containerRef = useIntersectionObserver<HTMLDivElement>(
+
+  useIntersectionObserver<HTMLDivElement>(
+    containerRef,
     containerObserverCallback,
     { threshold: 0.01, root: null, rootMargin: "50px 0px 50px 0px" }
   )

--- a/ui/hooks/dom-hooks.ts
+++ b/ui/hooks/dom-hooks.ts
@@ -5,6 +5,7 @@ import {
   useState,
   useCallback,
   useMemo,
+  useLayoutEffect,
 } from "react"
 
 export const useOnClickOutside = <T extends HTMLElement = HTMLElement>(
@@ -139,24 +140,27 @@ export function useLocalStorage(
 }
 
 export function useIntersectionObserver<T extends HTMLElement>(
-  callback: IntersectionObserverCallback,
-  options?: { threshold: number }
+  callback: IntersectionObserverCallback, // should be created with useCallback
+  initialOptions?: IntersectionObserverInit
 ): RefObject<T> {
-  const ref = useRef<T>(null)
-  const observer = useMemo(
-    () => new IntersectionObserver(callback, options),
-    [callback, options]
-  )
+  const optionsRef = useRef(initialOptions)
+  const elementRef = useRef<T>(null)
 
-  useEffect(() => {
-    const element = ref.current
+  const observer = useMemo(() => {
+    return new IntersectionObserver(callback, optionsRef.current)
+  }, [callback, optionsRef])
+
+  useLayoutEffect(() => {
+    const element = elementRef.current
+
     if (element) {
-      observer.observe(ref.current)
+      observer.observe(elementRef.current)
     }
+
     return () => {
       if (element) observer.unobserve(element)
     }
-  }, [observer])
+  }, [elementRef, observer])
 
-  return ref
+  return elementRef
 }

--- a/ui/hooks/dom-hooks.ts
+++ b/ui/hooks/dom-hooks.ts
@@ -140,11 +140,11 @@ export function useLocalStorage(
 }
 
 export function useIntersectionObserver<T extends HTMLElement>(
+  elementRef: RefObject<T>,
   callback: IntersectionObserverCallback, // should be created with useCallback
   initialOptions?: IntersectionObserverInit
 ): RefObject<T> {
   const optionsRef = useRef(initialOptions)
-  const elementRef = useRef<T>(null)
 
   const observer = useMemo(() => {
     return new IntersectionObserver(callback, optionsRef.current)


### PR DESCRIPTION
Resolves https://github.com/tallyhowallet/extension/issues/2766

### What 
As we have multiple places using the intersection observer hook let's merge them into one hook.

- I had to make some compromises as the [NFTs Collection component](https://github.com/tallyhowallet/extension/blob/unite-intersection-observers/ui/components/NFTS_update/NFTCollection.tsx#L49-L94) is passing to the intersection observer callbacks with some dependencies - so we have to allow callback to change over time. 
- I think creating element ref in the hook and returning it is a nice thing to have so we don't have to create element ref outside of the hook

Latest build: [extension-builds-2797](https://github.com/tallyhowallet/extension/suites/9992690730/artifacts/484975261) (as of Wed, 21 Dec 2022 14:39:59 GMT).