### PR TITLE
Prepare logger to work with Manifest v3

### DIFF
--- a/background/lib/logger.ts
+++ b/background/lib/logger.ts
@@ -225,11 +225,13 @@ const logger = () => {
   }
 
   async function clearStorage() {
-    localStorage.removeItem(groupKey(LogLevel.debug))
-    localStorage.removeItem(groupKey(LogLevel.log))
-    localStorage.removeItem(groupKey(LogLevel.info))
-    localStorage.removeItem(groupKey(LogLevel.warn))
-    localStorage.removeItem(groupKey(LogLevel.error))
+    await browser.storage.local.remove([
+      groupKey(LogLevel.debug),
+      groupKey(LogLevel.log),
+      groupKey(LogLevel.info),
+      groupKey(LogLevel.warn),
+      groupKey(LogLevel.error),
+    ])
   }
 
   async function init(env: LoggerEnvironment) {
@@ -239,7 +241,7 @@ const logger = () => {
 
     // Clear all locally stored logs on load, which were used in older versions
     // of the extension.
-    clearStorage()
+    await clearStorage()
   }
 
   return {

--- a/background/lib/logger.ts
+++ b/background/lib/logger.ts
@@ -2,12 +2,6 @@
 // the console.
 /* eslint-disable no-console */
 
-import browser from "webextension-polyfill"
-
-// Clear all localStorage logs on load, which were used in older versions of
-// the extension.
-localStorage.removeItem("logs")
-
 enum LogLevel {
   debug = "debug",
   log = "log",
@@ -28,6 +22,11 @@ interface LogStyles {
   info: LogStyle
   warn: LogStyle
   error: LogStyle
+}
+
+export enum LoggerEnvironment {
+  bg = "bg",
+  popup = "popup",
 }
 
 const styles: LogStyles = {
@@ -64,182 +63,201 @@ const styles: LogStyles = {
   },
 }
 
-function purgeSensitiveFailSafe(log: string): string {
-  // 1. Hexadecimal segments
-  // 2. Private key length segments
-  // 3. Lowercase groups of 12 words, which therefore covers 24
-
-  return log.replaceAll(
-    /0x[0-9a-fA-F]+|(\b[a-zA-Z0-9]{64}\b)|(?:[a-z]+(?:\s|$)){12}/g,
-    "[REDACTED]"
-  )
+function getEnvGroupKey(
+  environment: LoggerEnvironment | "unknown",
+  level: LogLevel
+) {
+  return `logs-${level}-${environment}`
 }
 
-const isBackgroundLogger = browser.extension.getBackgroundPage() === window
-// isPopupLogger will briefly be true even if we're in a tab, but should
-// quickly resolve to false.
-//
-// Note that as of this comment's writing the content scripts do not use the
-// logger, so defaulting to true should generally always produce the correct
-// result even if the following check never completes.
-let isPopupLogger = !isBackgroundLogger
-browser.tabs.getCurrent().then((value) => {
-  isPopupLogger = !isBackgroundLogger && value === undefined
-})
+const logger = () => {
+  let environment: LoggerEnvironment | "unknown" = "unknown"
+  let isBackgroundLogger = false
+  let isPopupLogger = false
 
-async function saveLog(
-  level: LogLevel,
-  isoDateString: string,
-  logLabel: string,
-  input: unknown[],
-  stackTrace: string[] | undefined
-) {
-  const formattedInput = input
-    .map((loggedValue) => {
-      if (typeof loggedValue === "object") {
-        try {
-          return JSON.stringify(loggedValue)
-        } catch (_) {
-          // If we can't stringify thats OK, we'll still see [object Object] or
-          // null in the logs.
+  function groupKey(level: LogLevel) {
+    return getEnvGroupKey(environment, level)
+  }
+
+  function purgeSensitiveFailSafe(log: string): string {
+    // 1. Hexadecimal segments
+    // 2. Private key length segments
+    // 3. Lowercase groups of 12 words, which therefore covers 24
+
+    return log.replaceAll(
+      /0x[0-9a-fA-F]+|(\b[a-zA-Z0-9]{64}\b)|(?:[a-z]+(?:\s|$)){12}/g,
+      "[REDACTED]"
+    )
+  }
+
+  async function saveLog(
+    level: LogLevel,
+    isoDateString: string,
+    logLabel: string,
+    input: unknown[],
+    stackTrace: string[] | undefined
+  ) {
+    const formattedInput = input
+      .map((loggedValue) => {
+        if (typeof loggedValue === "object") {
+          try {
+            return JSON.stringify(loggedValue)
+          } catch (_) {
+            // If we can't stringify thats OK, we'll still see [object Object] or
+            // null in the logs.
+            return String(loggedValue)
+          }
+        } else {
           return String(loggedValue)
         }
-      } else {
-        return String(loggedValue)
-      }
-    })
-    .join(" ")
+      })
+      .join(" ")
 
-  const formattedStackTrace =
-    stackTrace === undefined ? "" : `\n${stackTrace.join("\n")}`
+    const formattedStackTrace =
+      stackTrace === undefined ? "" : `\n${stackTrace.join("\n")}`
 
-  // Indent formatted input under the parent.
-  const logData = `    ${formattedInput}${formattedStackTrace}`
-    .split("\n")
-    .join("\n    ")
+    // Indent formatted input under the parent.
+    const logData = `    ${formattedInput}${formattedStackTrace}`
+      .split("\n")
+      .join("\n    ")
 
-  const logKey = `logs-${level}`
-  const existingLogs = localStorage.getItem(logKey) ?? ""
+    const existingLogs = localStorage.getItem(groupKey(level)) ?? ""
 
-  const backgroundPrefix = isBackgroundLogger ? "BG" : ""
-  const popupPrefix = isPopupLogger ? "POPUP" : ""
-  const tabPrefix = isBackgroundLogger || isPopupLogger ? "" : "TAB"
+    const backgroundPrefix = isBackgroundLogger ? "BG" : ""
+    const popupPrefix = isPopupLogger ? "POPUP" : ""
+    const tabPrefix = isBackgroundLogger || isPopupLogger ? "" : "TAB"
 
-  const fullPrefix = `[${isoDateString}] [${level.toUpperCase()}:${backgroundPrefix}${popupPrefix}${tabPrefix}]`
+    const fullPrefix = `[${isoDateString}] [${level.toUpperCase()}:${backgroundPrefix}${popupPrefix}${tabPrefix}]`
 
-  // Note: we have to do everything from here to `storage.local.set`
-  // synchronously, i.e. no promises, otherwise we risk losing logs between
-  // background and content/UI scripts.
-  const purgedData = purgeSensitiveFailSafe(logData)
-  const updatedLogs =
-    `${existingLogs}${fullPrefix} ${logLabel}\n${purgedData}\n\n`
-      // Restrict each log level to hold 50k characters to avoid excess resource
-      // usage.
-      .substring(0, 50000)
+    // Note: we have to do everything from here to `storage.local.set`
+    // synchronously, i.e. no promises, otherwise we risk losing logs between
+    // background and content/UI scripts.
+    const purgedData = purgeSensitiveFailSafe(logData)
+    const updatedLogs =
+      `${existingLogs}${fullPrefix} ${logLabel}\n${purgedData}\n\n`
+        // Restrict each log level to hold 50k characters to avoid excess resource
+        // usage.
+        .substring(0, 50000)
 
-  localStorage.setItem(logKey, updatedLogs)
-}
-
-const BLINK_PREFIX = "    at "
-const WEBKIT_GECKO_DELIMITER = "@"
-const WEBKIT_MARKER = "@"
-const GECKO_MARKER = "/"
-
-function logLabelFromStackEntry(
-  stackEntry: string | undefined
-): string | undefined {
-  // Blink-ish.
-  if (stackEntry?.startsWith(BLINK_PREFIX)) {
-    // "    at [Class.][function] (... source file ...)
-    return stackEntry.substring(BLINK_PREFIX.length).split(" ")[0]
+    localStorage.setItem(groupKey(level), updatedLogs)
   }
 
-  // Fall back to Gecko-ish.
-  if (
-    stackEntry?.includes(GECKO_MARKER) &&
-    stackEntry.includes(WEBKIT_GECKO_DELIMITER)
-  ) {
-    // "[path/to/Class/]method<?[/internal<?]@(... source file ...)"
-    return stackEntry
-      .split(WEBKIT_GECKO_DELIMITER)[0]
-      .split(GECKO_MARKER)
-      .filter((item) => item.replace(/(?:promise)?</, "").trim() !== "")
-      .slice(-2)
-      .join(".")
+  const BLINK_PREFIX = "    at "
+  const WEBKIT_GECKO_DELIMITER = "@"
+  const WEBKIT_MARKER = "@"
+  const GECKO_MARKER = "/"
+
+  function logLabelFromStackEntry(
+    stackEntry: string | undefined
+  ): string | undefined {
+    // Blink-ish.
+    if (stackEntry?.startsWith(BLINK_PREFIX)) {
+      // "    at [Class.][function] (... source file ...)
+      return stackEntry.substring(BLINK_PREFIX.length).split(" ")[0]
+    }
+
+    // Fall back to Gecko-ish.
+    if (
+      stackEntry?.includes(GECKO_MARKER) &&
+      stackEntry.includes(WEBKIT_GECKO_DELIMITER)
+    ) {
+      // "[path/to/Class/]method<?[/internal<?]@(... source file ...)"
+      return stackEntry
+        .split(WEBKIT_GECKO_DELIMITER)[0]
+        .split(GECKO_MARKER)
+        .filter((item) => item.replace(/(?:promise)?</, "").trim() !== "")
+        .slice(-2)
+        .join(".")
+    }
+
+    // WebKit-ish.
+    if (stackEntry?.includes(WEBKIT_MARKER)) {
+      // "[function]@(... source ...)
+      return stackEntry.split(WEBKIT_MARKER)[0]
+    }
+
+    return undefined
   }
 
-  // WebKit-ish.
-  if (stackEntry?.includes(WEBKIT_MARKER)) {
-    // "[function]@(... source ...)
-    return stackEntry.split(WEBKIT_MARKER)[0]
+  function genericLogger(level: LogLevel, input: unknown[]) {
+    const stackTrace = new Error().stack
+      ?.split("\n")
+      ?.filter((line) => {
+        // Remove empty lines from the output
+        // Chrome prepends the word "Error" to the first line of the trace, but Firefox doesn't
+        // Let's ignore that for consistency between browsers!
+        if (line.trim() === "" || line.trim() === "Error") {
+          return false
+        }
+
+        return true
+      })
+      // The first two lines of the stack trace will always be generated by this
+      // file, so let's ignore them.
+      ?.slice(2)
+
+    const logLabel =
+      logLabelFromStackEntry(stackTrace?.[0]) ?? "(unknown function)"
+    const isoDateString = new Date().toISOString()
+    const [logDate, logTime] = isoDateString.split(/T/)
+
+    console.group(
+      `%c ${styles[level].icon} [${logTime.replace(
+        /Z$/,
+        ""
+      )}] ${logLabel} %c [${logDate}]`,
+      styles[level].css.join(";"),
+      styles[level].dateCss ?? styles.debug.dateCss.join(";")
+    )
+
+    console[level](...input)
+
+    // Suppress displaying stack traces when we use console.error(), since the browser already does that
+    if (typeof stackTrace !== "undefined" && level !== "error") {
+      console[level](stackTrace.join("\n"))
+    }
+
+    console.groupEnd()
+
+    saveLog(level, isoDateString, logLabel, input, stackTrace)
   }
 
-  return undefined
-}
-
-function genericLogger(level: LogLevel, input: unknown[]) {
-  const stackTrace = new Error().stack
-    ?.split("\n")
-    ?.filter((line) => {
-      // Remove empty lines from the output
-      // Chrome prepends the word "Error" to the first line of the trace, but Firefox doesn't
-      // Let's ignore that for consistency between browsers!
-      if (line.trim() === "" || line.trim() === "Error") {
-        return false
-      }
-
-      return true
-    })
-    // The first two lines of the stack trace will always be generated by this
-    // file, so let's ignore them.
-    ?.slice(2)
-
-  const logLabel =
-    logLabelFromStackEntry(stackTrace?.[0]) ?? "(unknown function)"
-  const isoDateString = new Date().toISOString()
-  const [logDate, logTime] = isoDateString.split(/T/)
-
-  console.group(
-    `%c ${styles[level].icon} [${logTime.replace(
-      /Z$/,
-      ""
-    )}] ${logLabel} %c [${logDate}]`,
-    styles[level].css.join(";"),
-    styles[level].dateCss ?? styles.debug.dateCss.join(";")
-  )
-
-  console[level](...input)
-
-  // Suppress displaying stack traces when we use console.error(), since the browser already does that
-  if (typeof stackTrace !== "undefined" && level !== "error") {
-    console[level](stackTrace.join("\n"))
+  async function clearStorage() {
+    localStorage.removeItem(groupKey(LogLevel.debug))
+    localStorage.removeItem(groupKey(LogLevel.log))
+    localStorage.removeItem(groupKey(LogLevel.info))
+    localStorage.removeItem(groupKey(LogLevel.warn))
+    localStorage.removeItem(groupKey(LogLevel.error))
   }
 
-  console.groupEnd()
+  async function init(env: LoggerEnvironment) {
+    environment = env
+    isBackgroundLogger = environment === LoggerEnvironment.bg
+    isPopupLogger = environment === LoggerEnvironment.popup
 
-  saveLog(level, isoDateString, logLabel, input, stackTrace)
-}
+    // Clear all locally stored logs on load, which were used in older versions
+    // of the extension.
+    clearStorage()
+  }
 
-const logger = {
-  debug(...input: unknown[]): void {
-    genericLogger(LogLevel.debug, input)
-  },
-
-  log(...input: unknown[]): void {
-    genericLogger(LogLevel.log, input)
-  },
-
-  info(...input: unknown[]): void {
-    genericLogger(LogLevel.info, input)
-  },
-
-  warn(...input: unknown[]): void {
-    genericLogger(LogLevel.warn, input)
-  },
-
-  error(...input: unknown[]): void {
-    genericLogger(LogLevel.error, input)
-  },
+  return {
+    init,
+    debug(...input: unknown[]): void {
+      genericLogger(LogLevel.debug, input)
+    },
+    log(...input: unknown[]): void {
+      genericLogger(LogLevel.log, input)
+    },
+    info(...input: unknown[]): void {
+      genericLogger(LogLevel.info, input)
+    },
+    warn(...input: unknown[]): void {
+      genericLogger(LogLevel.warn, input)
+    },
+    error(...input: unknown[]): void {
+      genericLogger(LogLevel.error, input)
+    },
+  }
 }
 
 // The length of an ISO8601 date string.
@@ -261,15 +279,22 @@ type StoredLogData = {
   -readonly [level in keyof typeof LogLevel]: string
 }
 
+function concatLogGroups(level: LogLevel) {
+  return `${
+    localStorage.getItem(getEnvGroupKey(LoggerEnvironment.popup, level)) ?? ""
+  }${localStorage.getItem(getEnvGroupKey(LoggerEnvironment.bg, level)) ?? ""}`
+}
+
 export function serializeLogs(): string {
   const logs: StoredLogData = {
-    debug: localStorage.getItem("logs-debug") ?? "",
-    log: localStorage.getItem("logs-log") ?? "",
-    info: localStorage.getItem("logs-info") ?? "",
-    warn: localStorage.getItem("logs-warn") ?? "",
-    error: localStorage.getItem("logs-error") ?? "",
+    debug: concatLogGroups(LogLevel.debug),
+    log: concatLogGroups(LogLevel.log),
+    info: concatLogGroups(LogLevel.info),
+    warn: concatLogGroups(LogLevel.warn),
+    error: concatLogGroups(LogLevel.error),
   }
 
+  // FIXME this check is broken, will be fixed in the next commit
   if (Object.values(logs).every((entry) => entry === "")) {
     return "[NO LOGS FOUND]"
   }
@@ -300,4 +325,4 @@ export function serializeLogs(): string {
   )
 }
 
-export default logger
+export default logger()

--- a/src/background.ts
+++ b/src/background.ts
@@ -4,6 +4,9 @@ import {
   isEnabled,
   RuntimeFlag,
 } from "@tallyho/tally-background/features"
+import logger, { LoggerEnvironment } from "@tallyho/tally-background/lib/logger"
+
+logger.init(LoggerEnvironment.bg)
 
 browser.runtime.onInstalled.addListener((obj) => {
   if (

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,8 +1,11 @@
+import logger, { LoggerEnvironment } from "@tallyho/tally-background/lib/logger"
 import {
   attachPopupUIToRootElement,
   attachUIToRootElement,
 } from "@tallyho/tally-ui"
 import GlobalError from "@tallyho/tally-ui/components/GlobalError/GlobalError"
+
+logger.init(LoggerEnvironment.popup)
 
 // Prevents from the green screen. The solution checks if the first top-level element is rendered.
 // If this does not happen then reload the UI thread.  To prevent an infinity loop

--- a/ui/pages/Settings/SettingsExportLogs.tsx
+++ b/ui/pages/Settings/SettingsExportLogs.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react"
+import React, { ReactElement, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import dayjs from "dayjs"
 import { serializeLogs } from "@tallyho/tally-background/lib/logger"
@@ -7,11 +7,20 @@ import SharedPageHeader from "../../components/Shared/SharedPageHeader"
 
 export default function SettingsExportLogs(): ReactElement {
   const { t } = useTranslation()
+  const [base64LogData, setBase64LogData] = useState<string | undefined>()
 
-  const serializedLogs = serializeLogs()
-  const base64LogData = Buffer.from(
-    `${window.navigator.userAgent}\n\n\n${serializedLogs}` || ""
-  ).toString("base64")
+  async function generateLogData() {
+    const serializedLogs = await serializeLogs()
+    setBase64LogData(
+      Buffer.from(
+        `${window.navigator.userAgent}\n\n\n${serializedLogs}` || ""
+      ).toString("base64")
+    )
+  }
+
+  useEffect(() => {
+    generateLogData()
+  }, [])
 
   const logFileName = `logs_v${(process.env.VERSION || "").replace(
     /\./g,


### PR DESCRIPTION
Closes #2828 

It now uses the `browser.storage.local` api, while the api of the logger kept sync.

It handles multiple logger instances, so no any log can overwrite an another one.

A suggestion: the entries of the export result are grouped by kind (debug, warn, etc.), and are ordered by time only inside these groups. It can't be read all the logs from the beginning to the end linearly by time. 
It would be nice to have all the log entries ordered regardless its kind, or source.
To achieve this, we should store every single log entries in serialized arrays, instead of storing all of it in finalized, formatted, joined strings. So ordering, and joining could happen at export time. And also regex splitting at `logger.ts@366` could be omitted, so the code would be simpler, and more elegant.

Latest build: [extension-builds-2841](https://github.com/tallyhowallet/extension/suites/10174954713/artifacts/500956359) (as of Fri, 06 Jan 2023 15:03:24 GMT).