### PR TITLE
Replace window global to self in service worker environment

### DIFF
--- a/background/redux-slices/utils/contract-utils.ts
+++ b/background/redux-slices/utils/contract-utils.ts
@@ -21,7 +21,10 @@ export const internalProviderPort = {
   removeEventListener(toRemove: (message: any) => unknown): void {
     this.listeners = this.listeners.filter((listener) => listener !== toRemove)
   },
-  origin: window.location.origin,
+
+  // Service workers don't have access to DOM elements like window, so need to use self or globalThis
+  // eslint-disable-next-line no-restricted-globals
+  origin: self.location.origin,
   postMessage(message: any): void {
     this.emitter.emit("message", message)
   },

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -369,7 +369,9 @@ export default class IndexingService extends BaseService<Events> {
           )
 
           this.acceleratedTokenRefresh.assetLookups.push(...assetLookups)
-          this.acceleratedTokenRefresh.timeout ??= window.setTimeout(
+          // Service workers don't have access to DOM elements like window, so need to use self or globalThis
+          // eslint-disable-next-line no-restricted-globals
+          this.acceleratedTokenRefresh.timeout ??= self.setTimeout(
             this.handleAcceleratedTokenRefresh.bind(this),
             ACCELERATED_TOKEN_REFRESH_TIMEOUT
           )

--- a/window-provider/wallet-connection-handlers.ts
+++ b/window-provider/wallet-connection-handlers.ts
@@ -465,7 +465,9 @@ export default function monitorForWalletConnectionPrompts(): void {
   ;(
     Object.keys(hostnameToHandler) as Array<keyof typeof hostnameToHandler>
   ).forEach((hostname) => {
-    if (window.location.hostname.includes(hostname)) {
+    // Service workers don't have access to DOM elements like window, so need to use self or globalThis
+    // eslint-disable-next-line no-restricted-globals
+    if (self.location.hostname.includes(hostname)) {
       observeMutations(hostnameToHandler[hostname])
     }
   })


### PR DESCRIPTION
Closes #2832 

Service workers don't have access to DOM elements like window, so need to use self or globalThis.

I tried to define custom rule in eslintrc, but I didn't find a nice way to exclude one item from the default blacklist. Plus we should allow self only in the SW environment, not in the whole project. This why I decided to turn warnings off locally for the affected lines.

Latest build: [extension-builds-2845](https://github.com/tallyhowallet/extension/suites/10193417355/artifacts/506854480) (as of Wed, 11 Jan 2023 12:26:03 GMT).