### PR TITLE
🛟 Safety measure for the transaction nonce

### DIFF
--- a/background/services/chain/tests/index.integration.test.ts
+++ b/background/services/chain/tests/index.integration.test.ts
@@ -52,6 +52,7 @@ describe("ChainService", () => {
     const chainServiceExternalized =
       chainService as unknown as ChainServiceExternalized
     const CHAIN_NONCE = 100
+    const PENDING_CHAIN_NONCE = CHAIN_NONCE + 1
     // Return a fake provider
     const onceSpy = sandbox.spy()
     const providerForNetworkOrThrow = sandbox
@@ -59,7 +60,8 @@ describe("ChainService", () => {
       .callsFake(
         () =>
           ({
-            getTransactionCount: async () => CHAIN_NONCE,
+            getTransactionCount: async (_: string, blockTag: string) =>
+              blockTag === "latest" ? CHAIN_NONCE : PENDING_CHAIN_NONCE,
             once: onceSpy,
           } as unknown as SerialFallbackProvider)
       )
@@ -96,6 +98,7 @@ describe("ChainService", () => {
     const chainServiceExternalized =
       chainService as unknown as ChainServiceExternalized
     const CHAIN_NONCE = 100
+    const PENDING_CHAIN_NONCE = CHAIN_NONCE + 1
     // Return a fake provider
     const onceSpy = sandbox.spy()
     const providerForNetworkOrThrow = sandbox
@@ -103,7 +106,8 @@ describe("ChainService", () => {
       .callsFake(
         () =>
           ({
-            getTransactionCount: async () => CHAIN_NONCE,
+            getTransactionCount: async (_: string, blockTag: string) =>
+              blockTag === "latest" ? CHAIN_NONCE : PENDING_CHAIN_NONCE,
             once: onceSpy,
           } as unknown as SerialFallbackProvider)
       )


### PR DESCRIPTION
**WIP**

Closes #2404 

This PR adds further security measure for setting the correct nonce transaction value. The change involves referring to the actual state of the nonce chain and resetting the last seen nonce if needed.

See https://github.com/tallyhowallet/extension/pull/2516#discussion_r1008970149 for background

## TBD
Where should we apply security measures?
Should the safety measure also be called for the `releaseEVMTransactionNonce` method?

Latest build: [extension-builds-2860](https://github.com/tallyhowallet/extension/suites/10351382289/artifacts/510070011) (as of Fri, 13 Jan 2023 09:58:45 GMT).