### PR TITLE
[Custom RPCs] Allow displaying and removing custom networks

### DIFF
--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -103,6 +103,10 @@ export function isBuiltInNetwork(network: EVMNetwork): boolean {
   )
 }
 
+export const DEFAULT_NETWORKS_BY_CHAIN_ID = new Set(
+  DEFAULT_NETWORKS.map((network) => network.chainID)
+)
+
 export const FORK: EVMNetwork = {
   name: "Ethereum",
   baseAsset: ETH,

--- a/background/main.ts
+++ b/background/main.ts
@@ -1677,6 +1677,10 @@ export default class Main extends BaseService<never> {
     )
   }
 
+  async removeEVMNetwork(chainID: string): Promise<void> {
+    return this.chainService.removeCustomChain(chainID)
+  }
+
   private connectPopupMonitor() {
     runtime.onConnect.addListener((port) => {
       if (port.name !== popupMonitorPortName) return

--- a/background/redux-slices/networks.ts
+++ b/background/redux-slices/networks.ts
@@ -1,5 +1,10 @@
 import { createSlice } from "@reduxjs/toolkit"
+import type { RootState } from "."
+import { ETHEREUM } from "../constants"
 import { EIP1559Block, AnyEVMBlock, EVMNetwork } from "../networks"
+import { selectCurrentNetwork } from "./selectors/uiSelectors"
+import { setSelectedNetwork } from "./ui"
+import { createBackgroundAsyncThunk } from "./utils"
 
 type NetworkState = {
   blockHeight: number | null
@@ -50,9 +55,22 @@ const networksSlice = createSlice({
           block?.baseFeePerGas ?? null
       }
     },
+    /**
+     * Receives all supported networks as the payload
+     */
     setEVMNetworks: (immerState, { payload }: { payload: EVMNetwork[] }) => {
+      const chainIds = payload.map((network) => network.chainID)
+
       payload.forEach((network) => {
         immerState.evmNetworks[network.chainID] = network
+      })
+
+      // Remove payload missing networks from state
+      Object.keys(immerState.evmNetworks).forEach((chainID) => {
+        if (!chainIds.includes(chainID)) {
+          delete immerState.evmNetworks[chainID]
+          delete immerState.blockInfo[chainID]
+        }
       })
     },
   },
@@ -61,3 +79,17 @@ const networksSlice = createSlice({
 export const { blockSeen, setEVMNetworks } = networksSlice.actions
 
 export default networksSlice.reducer
+
+export const removeCustomChain = createBackgroundAsyncThunk(
+  "networks/removeCustomChain",
+  async (chainID: string, { getState, dispatch, extra: { main } }) => {
+    const store = getState() as RootState
+    const currentNetwork = selectCurrentNetwork(store)
+
+    if (currentNetwork.chainID === chainID) {
+      await dispatch(setSelectedNetwork(ETHEREUM))
+    }
+
+    return main.removeEVMNetwork(chainID)
+  }
+)

--- a/background/redux-slices/selectors/networks.ts
+++ b/background/redux-slices/selectors/networks.ts
@@ -1,6 +1,9 @@
 import { createSelector } from "@reduxjs/toolkit"
 import { RootState } from ".."
-import { TEST_NETWORK_BY_CHAIN_ID } from "../../constants"
+import {
+  DEFAULT_NETWORKS_BY_CHAIN_ID,
+  TEST_NETWORK_BY_CHAIN_ID,
+} from "../../constants"
 import { EVMNetwork } from "../../networks"
 
 // Adds chainID to each NFT for convenience in frontend
@@ -17,5 +20,13 @@ export const selectProductionEVMNetworks = createSelector(
   (evmNetworks) =>
     evmNetworks.filter(
       (network) => !TEST_NETWORK_BY_CHAIN_ID.has(network.chainID)
+    )
+)
+
+export const selectCustomNetworks = createSelector(
+  selectEVMNetworks,
+  (evmNetworks) =>
+    evmNetworks.filter(
+      (network) => !DEFAULT_NETWORKS_BY_CHAIN_ID.has(network.chainID)
     )
 )

--- a/background/redux-slices/selectors/uiSelectors.ts
+++ b/background/redux-slices/selectors/uiSelectors.ts
@@ -1,5 +1,5 @@
 import { createSelector } from "@reduxjs/toolkit"
-import { RootState } from ".."
+import type { RootState } from ".."
 import {
   hardcodedMainCurrencySign,
   hardcodedMainCurrencySymbol,

--- a/background/services/chain/db.ts
+++ b/background/services/chain/db.ts
@@ -250,6 +250,21 @@ export class ChainDatabase extends Dexie {
     await this.addRpcUrls(chainID, rpcUrls)
   }
 
+  async removeEVMNetwork(chainID: string): Promise<void> {
+    await this.transaction(
+      "rw",
+      this.networks,
+      this.baseAssets,
+      this.rpcUrls,
+      () =>
+        Promise.all([
+          this.networks.where({ chainID }).delete(),
+          this.baseAssets.where({ chainID }).delete(),
+          this.rpcUrls.where({ chainID }).delete(),
+        ])
+    )
+  }
+
   async getAllEVMNetworks(): Promise<EVMNetwork[]> {
     return this.networks.where("family").equals("EVM").toArray()
   }

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -1900,6 +1900,11 @@ export default class ChainService extends BaseService<Events> {
     await this.startTrackingNetworkOrThrow(chainInfo.chainId)
   }
 
+  async removeCustomChain(chainID: string): Promise<void> {
+    await this.db.removeEVMNetwork(chainID)
+    await this.updateSupportedNetworks()
+  }
+
   async updateSupportedNetworks(): Promise<void> {
     const supportedNetworks = await this.db.getAllEVMNetworks()
 

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -538,6 +538,11 @@
     "customNetworksSettings": {
       "title": "Custom networks",
       "ariaLabel": "Open custom networks page",
+      "subtitleAdded": "Added chains",
+      "subtitleAddMore": "Add more chains",
+      "networksList": {
+        "typeCustom": "Custom network"
+      },
       "chainList": {
         "description": "Fastest and safest way of adding a custom network is by visiting <url></url>, connecting your wallet and adding the chains you wish to see.",
         "addBtn": "Add chains with Chainlist"
@@ -775,7 +780,7 @@
     },
     "analyticsNotification": {
       "title": "Analytics are enabled",
-      "description": "They help us improve the wallet.  You can disable anytime", 
+      "description": "They help us improve the wallet.  You can disable anytime",
       "settingsLink": "Change settings"
     }
   },

--- a/ui/pages/Settings/SettingsCustomNetworks.tsx
+++ b/ui/pages/Settings/SettingsCustomNetworks.tsx
@@ -53,7 +53,9 @@ export default function SettingsCustomNetworks(): ReactElement {
                 <li className="custom_network_item" key={item.chainID}>
                   <SharedNetworkIcon size={42} network={item} />
                   <div className="network_label">
-                    <span className="network_name">{item.name}</span>
+                    <span className="network_name" title={item.name}>
+                      {item.name}
+                    </span>
                     <span className="network_type">
                       {t("networksList.typeCustom")}
                     </span>
@@ -159,6 +161,10 @@ export default function SettingsCustomNetworks(): ReactElement {
           letter-spacing: 0em;
           text-align: center;
           color: var(--white);
+          overflow-x: hidden;
+          text-overflow: ellipsis;
+          white-space: pre;
+          max-width: 200px;
         }
         .network_type {
           font-family: Segment;

--- a/ui/pages/Settings/SettingsCustomNetworks.tsx
+++ b/ui/pages/Settings/SettingsCustomNetworks.tsx
@@ -1,9 +1,15 @@
 import { FeatureFlags, isEnabled } from "@tallyho/tally-background/features"
+import { removeCustomChain } from "@tallyho/tally-background/redux-slices/networks"
+import { selectCustomNetworks } from "@tallyho/tally-background/redux-slices/selectors/networks"
 import React, { ReactElement } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import SharedButton from "../../components/Shared/SharedButton"
+import SharedIcon from "../../components/Shared/SharedIcon"
 import SharedLink from "../../components/Shared/SharedLink"
+import SharedNetworkIcon from "../../components/Shared/SharedNetworkIcon"
 import SharedPageHeader from "../../components/Shared/SharedPageHeader"
+import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
+import { intersperseWith } from "../../utils/lists"
 
 const CHAIN_LIST = {
   name: "ChainList",
@@ -14,71 +20,186 @@ export default function SettingsCustomNetworks(): ReactElement {
   const { t } = useTranslation("translation", {
     keyPrefix: "settings.customNetworksSettings",
   })
+  const dispatch = useBackgroundDispatch()
+
+  const allCustomNetworks = useBackgroundSelector(selectCustomNetworks)
+
+  const customNetworksListItems = intersperseWith(
+    allCustomNetworks,
+    () => "spacer" as const
+  )
 
   return (
     <div className="standard_width_padded wrapper">
       <SharedPageHeader withoutBackText backPath="/settings">
         {t(`title`)}
       </SharedPageHeader>
+      {customNetworksListItems.length > 0 && (
+        <section className="content">
+          <h2 className="subheader">{t("subtitleAdded")}</h2>
+          <ul className="custom_networks_list">
+            {customNetworksListItems.map((item, index) => {
+              if (item === "spacer") {
+                return (
+                  <li
+                    role="presentation"
+                    key={`spacer-${index.toString()}`}
+                    className="spacer"
+                  />
+                )
+              }
+
+              return (
+                <li className="custom_network_item" key={item.chainID}>
+                  <SharedNetworkIcon size={42} network={item} />
+                  <div className="network_label">
+                    <span className="network_name">{item.name}</span>
+                    <span className="network_type">
+                      {t("networksList.typeCustom")}
+                    </span>
+                  </div>
+                  <div className="actions">
+                    <SharedIcon
+                      width={16}
+                      onClick={() => dispatch(removeCustomChain(item.chainID))}
+                      icon="icons/s/garbage.svg"
+                      color="var(--green-40)"
+                    />
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        </section>
+      )}
       <section className="content">
-        <div className="chain_list_wrap">
-          <div className="icon" />
-          <span className="simple_text">
-            <Trans
-              t={t}
-              i18nKey="chainList.description"
-              components={{
-                url: <SharedLink text={CHAIN_LIST.name} url={CHAIN_LIST.url} />,
-              }}
-            />
-          </span>
-          <div>
-            <SharedButton
-              type="primary"
-              size="medium"
-              iconSmall="new-tab"
-              style={{ marginTop: "24px" }}
-              onClick={() => window.open(CHAIN_LIST.url, "_blank")?.focus()}
-            >
-              {t(`chainList.addBtn`)}
-            </SharedButton>
+        <h2 className="subheader">{t("subtitleAddMore")}</h2>
+        <div className="chain_add_options">
+          <div className="chain_list_wrap">
+            <div className="icon" />
+            <span className="simple_text">
+              <Trans
+                t={t}
+                i18nKey="chainList.description"
+                components={{
+                  url: (
+                    <SharedLink text={CHAIN_LIST.name} url={CHAIN_LIST.url} />
+                  ),
+                }}
+              />
+            </span>
+            <div>
+              <SharedButton
+                type="primary"
+                size="medium"
+                iconSmall="new-tab"
+                style={{ marginTop: "24px" }}
+                onClick={() => window.open(CHAIN_LIST.url, "_blank")?.focus()}
+              >
+                {t(`chainList.addBtn`)}
+              </SharedButton>
+            </div>
           </div>
+          <hr className="separator" />
+          {isEnabled(FeatureFlags.SUPPORT_CUSTOM_RPCS) && (
+            <div className="custom_rpc_wrap">
+              <span className="simple_text">{t(`customRPC.description`)}</span>
+              <SharedButton type="tertiary" size="medium" iconSmall="new-tab">
+                {t(`customRPC.addBtn`)}
+              </SharedButton>
+            </div>
+          )}
         </div>
-        {isEnabled(FeatureFlags.SUPPORT_CUSTOM_RPCS) && (
-          <div className="custom_rpc_wrap">
-            <span className="simple_text">{t(`customRPC.description`)}</span>
-            <SharedButton type="tertiary" size="medium" iconSmall="new-tab">
-              {t(`customRPC.addBtn`)}
-            </SharedButton>
-          </div>
-        )}
       </section>
       <style jsx>{`
         .wrapper {
           display: flex;
           flex-direction: column;
-          gap: 50px;
+          gap: 32px;
         }
+        .spacer {
+          width: 100%;
+          border: 0.5px solid var(--green-120);
+        }
+        .subheader {
+          font-family: Segment;
+          font-size: 18px;
+          font-weight: 600;
+          line-height: 24px;
+          letter-spacing: 0em;
+          text-align: left;
+          color: var(--green-20);
+          margin: 0;
+        }
+
+        .custom_networks_list {
+          display: flex;
+          flex-direction: column;
+          gap: 16px;
+        }
+        .custom_network_item .actions {
+          margin-left: auto;
+        }
+        .custom_network_item {
+          display: flex;
+          gap: 12px;
+          align-items: center;
+        }
+
+        .network_label {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
+        }
+        .network_name {
+          font-family: Segment;
+          font-size: 18px;
+          font-weight: 600;
+          line-height: 24px;
+          letter-spacing: 0em;
+          text-align: center;
+          color: var(--white);
+        }
+        .network_type {
+          font-family: Segment;
+          font-size: 16px;
+          font-weight: 400;
+          line-height: 24px;
+          letter-spacing: 0em;
+          text-align: center;
+          color: var(--green-40);
+        }
+
         .content {
           padding: 0 24px;
           display: flex;
           flex-direction: column;
-          gap: 50px;
+          gap: 16px;
         }
+
         .chain_list_wrap {
           display: flex;
           flex-direction: column;
           gap: 8px;
         }
+
+        .chain_add_options {
+          gap: 32px;
+        }
+
+        .separator {
+          border: none;
+          border-top: 1px solid var(--green-95);
+          margin: 32px 0;
+        }
+
         .icon {
           background: url("./images/chain_list.svg") center no-repeat;
           width: 132px;
           height: 32px;
         }
         .custom_rpc_wrap {
-          padding-top: 28px;
-          border-top: 1px solid var(--green-95);
-          width: 100%;
+          padding-bottom: 32px;
         }
       `}</style>
     </div>


### PR DESCRIPTION
Closes #2758

Allows managing custom networks from within the settings page

![thismightjustbethenextbigthing](https://user-images.githubusercontent.com/28708889/218964952-737b1aae-ca5d-496b-ba77-970fdd5cd483.png)


## Testing Env

```
SUPPORT_CUSTOM_NETWORKS=true
SUPPORT_CUSTOM_RPCS=true
```

## To Test
- [ ] Add a few custom networks
- [ ] Head to settings, try removing some of the networks just added

Latest build: [extension-builds-3032](https://github.com/tahowallet/extension/suites/11529113568/artifacts/596372116) (as of Mon, 13 Mar 2023 16:40:02 GMT).