### PR TITLE
Fix migration for users without abilities slice

### DIFF
--- a/background/redux-slices/migrations/to-26.ts
+++ b/background/redux-slices/migrations/to-26.ts
@@ -16,6 +16,11 @@ export default (
   const typedPrevState = prevState as State
 
   const { abilities } = typedPrevState
+
+  if (!abilities) {
+    return prevState
+  }
+
   const { filter } = abilities
 
   const types = filter.types.includes("claim")


### PR DESCRIPTION
### What
Fix failing migration for users that don't have abilities slice yet (they are updating from earlier versions)

### Testing
 
- checkout tag with version for example v0.18.6
- install extension
- checkout main and hit 'reload' - extension should have green screen and error in the background
- checkout this branch and hit reload - extension should be back 

Latest build: [extension-builds-3074](https://github.com/tahowallet/extension/suites/11164255473/artifacts/570011862) (as of Thu, 23 Feb 2023 16:36:37 GMT).