### PR TITLE
Update the existing ability

### DIFF
--- a/background/redux-slices/abilities.ts
+++ b/background/redux-slices/abilities.ts
@@ -59,7 +59,17 @@ const abilitiesSlice = createSlice({
         if (!immerState.abilities[address]) {
           immerState.abilities[address] = {}
         }
-        immerState.abilities[address][ability.abilityId] = ability
+        if (immerState.abilities[address][ability.abilityId]) {
+          const existingAbility =
+            immerState.abilities[address][ability.abilityId]
+          immerState.abilities[address][ability.abilityId] = {
+            ...ability,
+            completed: existingAbility.completed,
+            removedFromUi: existingAbility.removedFromUi,
+          }
+        } else {
+          immerState.abilities[address][ability.abilityId] = ability
+        }
       })
     },
     updateAbility: (immerState, { payload }: { payload: Ability }) => {

--- a/background/services/abilities/db.ts
+++ b/background/services/abilities/db.ts
@@ -27,6 +27,17 @@ export class AbilitiesDatabase extends Dexie {
       await this.abilities.add(ability)
       return true
     }
+    const { id, ...correctAbility } = existingAbility as Ability & {
+      id: number
+    }
+    if (JSON.stringify(correctAbility) !== JSON.stringify(ability)) {
+      await this.abilities.update(existingAbility, {
+        ...ability,
+        completed: existingAbility.completed,
+        removedFromUi: existingAbility.removedFromUi,
+      })
+      return true
+    }
     return false
   }
 


### PR DESCRIPTION
This PR gives the opportunity to update existing abilities. Property such as `completed` and `removedFromUi`  should not be updated.

Latest build: [extension-builds-3075](https://github.com/tahowallet/extension/suites/11165565147/artifacts/570107603) (as of Thu, 23 Feb 2023 17:31:53 GMT).