### PR TITLE
Analytics - Remove background start event

### DIFF
--- a/background/lib/posthog.ts
+++ b/background/lib/posthog.ts
@@ -3,6 +3,12 @@ import { v4 as uuidv4 } from "uuid"
 import { FeatureFlags, isEnabled } from "../features"
 import logger from "./logger"
 
+export enum AnalyticsEvent {
+  NEW_INSTALL = "New install",
+  UI_SHOWN = "UI shown",
+  NEW_ACCOUNT_TO_TRACK = "Address added to tracking on network",
+}
+
 const POSTHOG_PROJECT_ID = "11112"
 
 const PERSON_ENDPOINT = `https://app.posthog.com/api/projects/${POSTHOG_PROJECT_ID}/persons`

--- a/background/main.ts
+++ b/background/main.ts
@@ -167,6 +167,7 @@ import {
   initAbilities,
 } from "./redux-slices/abilities"
 import { AddChainRequestData } from "./services/provider-bridge"
+import { AnalyticsEvent } from "./lib/posthog"
 
 // This sanitizer runs on store and action data before serializing for remote
 // redux devtools. The goal is to end up with an object that is directly
@@ -1683,7 +1684,7 @@ export default class Main extends BaseService<never> {
       const openTime = Date.now()
 
       port.onDisconnect.addListener(() => {
-        this.analyticsService.sendAnalyticsEvent("UI shown", {
+        this.analyticsService.sendAnalyticsEvent(AnalyticsEvent.UI_SHOWN, {
           openTime: new Date(openTime).toISOString(),
           closeTime: new Date().toISOString(),
           openLength: (Date.now() - openTime) / 1e3,

--- a/background/services/analytics/index.ts
+++ b/background/services/analytics/index.ts
@@ -79,8 +79,6 @@ export default class AnalyticsService extends BaseService<Events> {
       if (isNew) {
         await this.sendAnalyticsEvent("New install")
       }
-
-      await this.sendAnalyticsEvent("Background start")
     }
   }
 

--- a/background/services/analytics/index.ts
+++ b/background/services/analytics/index.ts
@@ -5,7 +5,12 @@ import { ServiceCreatorFunction, ServiceLifecycleEvents } from "../types"
 
 import BaseService from "../base"
 import { AnalyticsDatabase, getOrCreateDB } from "./db"
-import { deletePerson, getPersonId, sendPosthogEvent } from "../../lib/posthog"
+import {
+  AnalyticsEvent,
+  deletePerson,
+  getPersonId,
+  sendPosthogEvent,
+} from "../../lib/posthog"
 import ChainService from "../chain"
 import PreferenceService from "../preferences"
 import { FeatureFlags, isEnabled as isFeatureFlagEnabled } from "../../features"
@@ -77,7 +82,7 @@ export default class AnalyticsService extends BaseService<Events> {
       )
 
       if (isNew) {
-        await this.sendAnalyticsEvent("New install")
+        await this.sendAnalyticsEvent(AnalyticsEvent.NEW_INSTALL)
       }
     }
   }
@@ -89,7 +94,7 @@ export default class AnalyticsService extends BaseService<Events> {
   }
 
   async sendAnalyticsEvent(
-    eventName: string,
+    eventName: AnalyticsEvent,
     payload?: Record<string, unknown>
   ): Promise<void> {
     // @TODO: implement event batching
@@ -115,7 +120,7 @@ export default class AnalyticsService extends BaseService<Events> {
   private initializeListeners() {
     // ⚠️ Note: We NEVER send addresses to analytics!
     this.chainService.emitter.on("newAccountToTrack", () => {
-      this.sendAnalyticsEvent("Address added to tracking on network", {
+      this.sendAnalyticsEvent(AnalyticsEvent.NEW_ACCOUNT_TO_TRACK, {
         description: `
             This event is fired when any address on a network is added to the tracked list. 
             

--- a/background/services/analytics/tests/index.integration.test.ts
+++ b/background/services/analytics/tests/index.integration.test.ts
@@ -14,6 +14,8 @@ import { Writeable } from "../../../types"
 import PreferenceService from "../../preferences"
 import * as posthog from "../../../lib/posthog"
 
+const { AnalyticsEvent } = posthog
+
 describe("AnalyticsService", () => {
   let analyticsService: AnalyticsService
   let preferenceService: PreferenceService
@@ -75,7 +77,7 @@ describe("AnalyticsService", () => {
     })
 
     it("should not send any analytics events when both of the feature flags are off", async () => {
-      await analyticsService.sendAnalyticsEvent("Some event")
+      await analyticsService.sendAnalyticsEvent(AnalyticsEvent.UI_SHOWN)
 
       expect(fetch).not.toBeCalled()
     })
@@ -173,7 +175,7 @@ describe("AnalyticsService", () => {
 
       expect(analyticsService.sendAnalyticsEvent).not.toHaveBeenCalledWith(
         expect.anything(),
-        "New install",
+        AnalyticsEvent.NEW_INSTALL,
         undefined
       )
 
@@ -214,7 +216,7 @@ describe("AnalyticsService", () => {
       expect(fetch).not.toBeCalled()
     })
     it("should not send any event when the 'sendAnalyticsEvent()' method is called", async () => {
-      await analyticsService.sendAnalyticsEvent("Some event")
+      await analyticsService.sendAnalyticsEvent(AnalyticsEvent.UI_SHOWN)
       expect(analyticsService.sendAnalyticsEvent).toBeCalledTimes(1)
 
       expect(posthog.sendPosthogEvent).not.toBeCalled()

--- a/background/services/analytics/tests/index.integration.test.ts
+++ b/background/services/analytics/tests/index.integration.test.ts
@@ -73,13 +73,9 @@ describe("AnalyticsService", () => {
 
       await analyticsService.startService()
     })
-    it("should not send any analytics events when both of the feature flags are off", async () => {
-      await analyticsService.sendAnalyticsEvent("Background start")
 
-      expect(fetch).not.toBeCalled()
-    })
-    it("should not send any analytics events when only the support feature flag is on but the default on is not", async () => {
-      await analyticsService.sendAnalyticsEvent("Background start")
+    it("should not send any analytics events when both of the feature flags are off", async () => {
+      await analyticsService.sendAnalyticsEvent("Some event")
 
       expect(fetch).not.toBeCalled()
     })
@@ -130,25 +126,20 @@ describe("AnalyticsService", () => {
 
     it("should generate a new uuid and save it to database", async () => {
       // Called once for generating the new user uuid
-      // and once for the 'Background start' and once for the `New install' event
-      expect(uuid.v4).toBeCalledTimes(3)
+      // and once for the `New install' event
+      expect(uuid.v4).toBeCalledTimes(2)
 
       expect(analyticsService["db"].setAnalyticsUUID).toBeCalledTimes(1)
     })
 
-    it("should send 'New Install' and 'Background start' events", () => {
+    it("should send 'New Install' event", () => {
       // Posthog events are sent through global.fetch method
       // During initialization we send 2 events
-      expect(fetch).toBeCalledTimes(2)
+      expect(fetch).toBeCalledTimes(1)
 
       expect(posthog.sendPosthogEvent).toHaveBeenCalledWith(
         expect.anything(),
         "New install",
-        undefined
-      )
-      expect(posthog.sendPosthogEvent).toHaveBeenCalledWith(
-        expect.anything(),
-        "Background start",
         undefined
       )
     })
@@ -190,12 +181,7 @@ describe("AnalyticsService", () => {
         preferenceService.updateAnalyticsPreferences
       ).not.toHaveBeenCalled()
     })
-    it("should send 'Background start' event when the service starts", async () => {
-      expect(analyticsService.sendAnalyticsEvent).toBeCalledTimes(1)
-      expect(analyticsService.sendAnalyticsEvent).toBeCalledWith(
-        "Background start"
-      )
-    })
+
     it("should set the uninstall url when the service starts", async () => {
       expect(browser.runtime.setUninstallURL).toBeCalledTimes(1)
     })
@@ -228,7 +214,7 @@ describe("AnalyticsService", () => {
       expect(fetch).not.toBeCalled()
     })
     it("should not send any event when the 'sendAnalyticsEvent()' method is called", async () => {
-      await analyticsService.sendAnalyticsEvent("Background start")
+      await analyticsService.sendAnalyticsEvent("Some event")
       expect(analyticsService.sendAnalyticsEvent).toBeCalledTimes(1)
 
       expect(posthog.sendPosthogEvent).not.toBeCalled()


### PR DESCRIPTION
Closes #3078

Removes extension load time event as we can get this data from the chrome store. Additionally, moved all events to a string enum so we get some protection against sending inconsistent events and also code-wise they're easier to track.

## To Test
- [ ] Inspect background page and do a reload
- [ ] You should not see any Posthog `Background start` events sent

Latest build: [extension-builds-3079](https://github.com/tahowallet/extension/suites/11172086788/artifacts/570582817) (as of Thu, 23 Feb 2023 23:17:52 GMT).