### PR TITLE
Token Discovery - Update networks stored in chain & preferences db

### DIFF
--- a/background/services/chain/db.ts
+++ b/background/services/chain/db.ts
@@ -16,6 +16,8 @@ import {
   CHAIN_ID_TO_RPC_URLS,
   DEFAULT_NETWORKS,
   GOERLI,
+  isBuiltInNetwork,
+  NETWORK_BY_CHAIN_ID,
   POLYGON,
 } from "../../constants"
 
@@ -165,6 +167,19 @@ export class ChainDatabase extends Dexie {
 
     this.version(7).stores({
       rpcUrls: "&chainID, rpcUrls",
+    })
+
+    // Updates saved accounts stored networks for old installs
+    this.version(8).upgrade((tx) => {
+      tx.table("accountsToTrack")
+        .toCollection()
+        .modify((account: AddressOnNetwork) => {
+          if (isBuiltInNetwork(account.network)) {
+            Object.assign(account, {
+              network: NETWORK_BY_CHAIN_ID[account.network.chainID],
+            })
+          }
+        })
     })
   }
 

--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -7,6 +7,7 @@ import DEFAULT_PREFERENCES from "./defaults"
 import { AccountSignerSettings } from "../../ui"
 import { AccountSignerWithId } from "../../signing"
 import { AnalyticsPreferences } from "./types"
+import { NETWORK_BY_CHAIN_ID } from "../../constants"
 
 type SignerRecordId = `${AccountSignerWithId["type"]}/${string}`
 
@@ -303,6 +304,18 @@ export class PreferenceDatabase extends Dexie {
           )
 
           Object.assign(storedPreferences.tokenLists, { urls })
+        })
+    })
+
+    // Updates saved accounts stored networks for old installs
+    this.version(16).upgrade((tx) => {
+      return tx
+        .table("preferences")
+        .toCollection()
+        .modify((storedPreferences: Preferences) => {
+          const { selectedAccount } = storedPreferences
+          selectedAccount.network =
+            NETWORK_BY_CHAIN_ID[selectedAccount.network.chainID]
         })
     })
 


### PR DESCRIPTION
Closes #3076

Updates networks stored in both chain and preferences db in order to prevent the wallet from treating these stored network assets as untrusted.

## To Test 

- [ ] Checkout v0.18.6, onboard an account then switch to main branch, base network assets should show up as untrusted since they are missing a chainID
- [ ] Switch to this branch and reload the extension, base assets should no longer display a warning sign

Latest build: [extension-builds-3082](https://github.com/tahowallet/extension/suites/11177745994/artifacts/571046923) (as of Fri, 24 Feb 2023 07:33:23 GMT).