### PR TITLE
Don't show add network popup if SUPPORT_CUSTOM_NETWORKS is not enabled

### DIFF
--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -36,6 +36,7 @@ import {
 } from "./utils"
 import { toHexChainID } from "../../networks"
 import { TALLY_INTERNAL_ORIGIN } from "../internal-ethereum-provider/constants"
+import { FeatureFlags, isEnabled } from "../../features"
 
 type Events = ServiceLifecycleEvents & {
   requestPermission: PermissionRequest
@@ -515,6 +516,15 @@ export default class ProviderBridgeService extends BaseService<Events> {
           )
 
         case "wallet_addEthereumChain": {
+          if (!isEnabled(FeatureFlags.SUPPORT_CUSTOM_NETWORKS)) {
+            // Attempt to switch to a chain if its one of the natively supported ones - otherwise fail
+            return await this.internalEthereumProviderService.routeSafeRPCRequest(
+              method,
+              params,
+              origin
+            )
+          }
+
           const id = this.addNetworkRequestId.toString()
 
           this.addNetworkRequestId += 1

--- a/ui/components/TopMenu/TopMenuProtocolList.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolList.tsx
@@ -6,6 +6,7 @@ import {
   BINANCE_SMART_CHAIN,
   ETHEREUM,
   GOERLI,
+  isBuiltInNetwork,
   OPTIMISM,
   POLYGON,
   ROOTSTOCK,
@@ -61,19 +62,27 @@ export default function TopMenuProtocolList({
     <div className="standard_width_padded center_horizontal">
       <div className={classNames(customNetworksEnabled && "networks_list")}>
         <ul>
-          {productionNetworks.map((network) => (
-            <TopMenuProtocolListItem
-              isSelected={sameNetwork(currentNetwork, network)}
-              key={network.name}
-              network={network}
-              info={
-                productionNetworkInfo[network.chainID] ||
-                t("protocol.compatibleChain")
+          {productionNetworks
+            .filter((network) => {
+              if (isEnabled(FeatureFlags.SUPPORT_CUSTOM_NETWORKS)) {
+                // Get rid of this whole filter once custom network support is fully in
+                return true
               }
-              onSelect={onProtocolChange}
-              isDisabled={disabledChainIDs.includes(network.chainID)}
-            />
-          ))}
+              return isBuiltInNetwork(network)
+            })
+            .map((network) => (
+              <TopMenuProtocolListItem
+                isSelected={sameNetwork(currentNetwork, network)}
+                key={network.name}
+                network={network}
+                info={
+                  productionNetworkInfo[network.chainID] ||
+                  t("protocol.compatibleChain")
+                }
+                onSelect={onProtocolChange}
+                isDisabled={disabledChainIDs.includes(network.chainID)}
+              />
+            ))}
           {showTestNetworks && testNetworks.length > 0 && (
             <>
               <li className="protocol_divider">


### PR DESCRIPTION
### To Test
- [ ] Go to chainlist.org
- [ ] Attempt to add a chain
- [ ] You should not see a tally popup asking you to confirm adding the chain

And Separately
- [ ] Checkout v0.25.0
- [ ] Import a wallet
- [ ] Add a network via chainlist
- [ ] Upgrade to this branch
- [ ] Ensure that you don't see the added network in the menu protocol list

Latest build: [extension-builds-3084](https://github.com/tahowallet/extension/suites/11191886046/artifacts/572044288) (as of Fri, 24 Feb 2023 19:50:40 GMT).