### PR TITLE
Disappear an insufficient funds warning

### DIFF
--- a/background/services/enrichment/transactions.ts
+++ b/background/services/enrichment/transactions.ts
@@ -244,7 +244,16 @@ export default async function resolveTransactionAnnotation(
   // If the wallet doesn't have enough base asset to cover gas, push a warning
   if (gasFee + (transaction.value ?? 0n) > baseAssetBalance) {
     txAnnotation.warnings ??= []
-    txAnnotation.warnings.push("insufficient-funds")
+    if (!txAnnotation.warnings.includes("insufficient-funds")) {
+      txAnnotation.warnings.push("insufficient-funds")
+    }
+  } else if (txAnnotation.warnings) {
+    const idx = txAnnotation.warnings.findIndex(
+      (warning) => warning === "insufficient-funds"
+    )
+    if (idx >= 0) {
+      delete txAnnotation.warnings[idx]
+    }
   }
 
   // If the transaction has been mined, get the block and set the timestamp


### PR DESCRIPTION
Closes #2921 

This PR disappears insufficient funds warning after gas settings are changed and there is enough base asset to pay for gas.

## UI

https://user-images.githubusercontent.com/23117945/221586264-4e84d0bd-9c5d-4a71-8694-568026dd566c.mov

