### PR TITLE
Load NFTs service state from database

### DIFF
--- a/background/services/nfts/db.ts
+++ b/background/services/nfts/db.ts
@@ -4,10 +4,26 @@ import { FeatureFlags, isEnabled } from "../../features"
 import { sameEVMAddress } from "../../lib/utils"
 import { NFT, NFTCollection } from "../../nfts"
 
+export type FreshCollectionsMap = {
+  [collectionID: string]: { [address: string]: boolean }
+}
+
+type Preferences = {
+  transfersLookupTimestamp: number | undefined
+  freshCollections: FreshCollectionsMap
+}
+
+const DEFAULT_PREFERENCES = {
+  transfersLookupTimestamp: undefined,
+  freshCollections: {},
+}
+
 export class NFTsDatabase extends Dexie {
   private nfts!: Dexie.Table<NFT, number>
 
   private collections!: Dexie.Table<NFTCollection, number>
+
+  private preferences!: Dexie.Table<Preferences>
 
   constructor() {
     super("tally/nfts")
@@ -18,6 +34,14 @@ export class NFTsDatabase extends Dexie {
         nfts: "&[id+collectionID+owner+network.chainID]",
         collections: "&[id+owner+network.chainID]",
       })
+
+      this.version(2)
+        .stores({
+          preferences: "++id",
+        })
+        .upgrade((tx) => {
+          tx.table("preferences").put(DEFAULT_PREFERENCES)
+        })
     }
   }
 
@@ -100,6 +124,22 @@ export class NFTsDatabase extends Dexie {
       .delete()
 
     await nftsToRemove.delete()
+  }
+
+  async setTransfersLookupTimestamp(
+    transfersLookupTimestamp: number
+  ): Promise<void> {
+    await this.preferences.toCollection().modify({ transfersLookupTimestamp })
+  }
+
+  async setFreshCollections(
+    freshCollections: FreshCollectionsMap
+  ): Promise<void> {
+    await this.preferences.toCollection().modify({ freshCollections })
+  }
+
+  async getPreferences(): Promise<Preferences> {
+    return (await this.preferences.reverse().first()) ?? DEFAULT_PREFERENCES
   }
 }
 

--- a/background/services/nfts/index.ts
+++ b/background/services/nfts/index.ts
@@ -12,7 +12,7 @@ import BaseService from "../base"
 import ChainService from "../chain"
 
 import { ServiceCreatorFunction, ServiceLifecycleEvents } from "../types"
-import { getOrCreateDB, NFTsDatabase } from "./db"
+import { getOrCreateDB, NFTsDatabase, FreshCollectionsMap } from "./db"
 import { getUNIXTimestamp, normalizeEVMAddress } from "../../lib/utils"
 import { MINUTE } from "../../constants"
 
@@ -30,9 +30,6 @@ interface Events extends ServiceLifecycleEvents {
 }
 
 type NextPageURLsMap = { [collectionID: string]: { [address: string]: string } }
-type FreshCollectionsMap = {
-  [collectionID: string]: { [address: string]: boolean }
-}
 
 export default class NFTsService extends BaseService<Events> {
   #nextPageUrls: NextPageURLsMap = {}
@@ -54,7 +51,7 @@ export default class NFTsService extends BaseService<Events> {
     private chainService: ChainService
   ) {
     super()
-    this.#transfersLookupTimestamp = getUNIXTimestamp()
+    this.#transfersLookupTimestamp = getUNIXTimestamp() // will be discarded when chainService starts
   }
 
   protected override async internalStartService(): Promise<void> {
@@ -75,10 +72,23 @@ export default class NFTsService extends BaseService<Events> {
   private async connectChainServiceEvents(): Promise<void> {
     this.chainService.emitter.once("serviceStarted").then(async () => {
       this.emitter.emit("isReloadingNFTs", true)
-      await this.initializeCollections()
-      this.#transfersLookupTimestamp = getUNIXTimestamp(Date.now() - 5 * MINUTE)
 
-      const collections = await this.db.getAllCollections()
+      const { transfersLookupTimestamp, freshCollections } =
+        await this.db.getPreferences()
+      let collections = await this.db.getAllCollections() // initialize redux from database if possible
+
+      if (!collections.length) {
+        // fetch collections for the first time
+        await this.initializeCollections()
+        collections = await this.db.getAllCollections()
+      }
+
+      // use latest lookup timestamp
+      this.#transfersLookupTimestamp =
+        transfersLookupTimestamp ?? (await this.setTransfersLookupTimestamp())
+
+      this.#freshCollections = freshCollections
+
       this.emitter.emit("initializeNFTs", collections)
       this.emitter.emit("isReloadingNFTs", false)
     })
@@ -137,6 +147,7 @@ export default class NFTsService extends BaseService<Events> {
     account: AddressOnNetwork
   ): Promise<void> {
     this.setFreshCollection(collectionID, account.address, false)
+    await this.db.setFreshCollections(this.#freshCollections)
     await this.fetchNFTsFromCollection(collectionID, account)
   }
 
@@ -246,6 +257,7 @@ export default class NFTsService extends BaseService<Events> {
 
     // if NFTs were fetched then mark as fresh
     this.setFreshCollection(collectionID, account.address, !!updatedNFTs.length)
+    await this.db.setFreshCollections(this.#freshCollections)
 
     const hasNextPage = !!Object.keys(nextPageURLs).length
 
@@ -285,6 +297,14 @@ export default class NFTsService extends BaseService<Events> {
       }
     })
     await this.db.removeNFTsForAddress(address)
+    await this.db.setFreshCollections(this.#freshCollections)
+  }
+
+  async setTransfersLookupTimestamp(): Promise<number> {
+    // indexing transfers can take some time, let's add some margin to the timestamp
+    const timestamp = getUNIXTimestamp(Date.now() - 2 * MINUTE)
+    await this.db.setTransfersLookupTimestamp(timestamp)
+    return timestamp
   }
 
   async fetchTransferredNFTs(
@@ -295,8 +315,7 @@ export default class NFTsService extends BaseService<Events> {
       this.#transfersLookupTimestamp
     )
 
-    // indexing transfers can take some time, let's add some margin to the timestamp
-    this.#transfersLookupTimestamp = getUNIXTimestamp(Date.now() - 2 * MINUTE)
+    this.#transfersLookupTimestamp = await this.setTransfersLookupTimestamp()
 
     // mark collections with transferred NFTs to be refetched
     transfers.forEach((transfer) => {
@@ -309,6 +328,7 @@ export default class NFTsService extends BaseService<Events> {
         this.setFreshCollection(collectionID, from, false)
       }
     })
+    await this.db.setFreshCollections(this.#freshCollections)
 
     const knownFromAddress = transfers.filter(
       (transfer) => transfer.isKnownFromAddress

--- a/background/services/nfts/index.ts
+++ b/background/services/nfts/index.ts
@@ -87,7 +87,9 @@ export default class NFTsService extends BaseService<Events> {
       this.#transfersLookupTimestamp =
         transfersLookupTimestamp ?? (await this.setTransfersLookupTimestamp())
 
-      this.#freshCollections = freshCollections
+      this.#freshCollections = Object.keys(freshCollections).length
+        ? freshCollections
+        : await this.db.setFreshCollectionsFromSavedData()
 
       this.emitter.emit("initializeNFTs", collections)
       this.emitter.emit("isReloadingNFTs", false)


### PR DESCRIPTION
### What

Persist info about loaded NFTs collections and transfers timestamp between extension reloads to reduce number of requests to SimpleHash.
Construct data for `freshCollections` cache based on already fetched NFTs in the database - this will ensure that NFTs already fetched for our users won't be refetched.

### Testing

1. Install extension from this branch, check NFTs and ensure everything works as expected. Checkout Network page in the background script, filter for SimpleHash requests and clear it. Then reload extension and check network page again - there should be 1 request for transfers and all collections previously loaded should be loaded from database.
2. Install extension from `main`, add accounts, check NFTs page and then upgrade to this branch - ensure there are no migration errors and NFTs previously loaded should be loaded from database.

Latest build: [extension-builds-3094](https://github.com/tahowallet/extension/suites/11301299089/artifacts/580041105) (as of Thu, 02 Mar 2023 09:09:06 GMT).