### PR TITLE
Fix price impact highlighting

### DIFF
--- a/ui/components/Shared/PriceDetails.tsx
+++ b/ui/components/Shared/PriceDetails.tsx
@@ -10,9 +10,9 @@ function formatPriceImpact(value: number): number {
 function getPriceImpactColor(value: number | undefined): string {
   if (value) {
     switch (true) {
-      case value < -5:
+      case Math.abs(value) > 5:
         return "error"
-      case value < 0 && value >= -5:
+      case Math.abs(value) > 2:
         return "attention"
       default:
         return "green-40"


### PR DESCRIPTION
Closes https://github.com/tahowallet/extension/issues/2741

cc @VladUXUI Are you OK with the thresholds here?  0-2% is not highlighted, 2-5% is yellow, 5+% is red.


<img width="360" alt="Screen Shot 2023-02-28 at 11 33 07 AM" src="https://user-images.githubusercontent.com/94649004/221946989-ec83d874-cc75-4ef4-baf8-8613c0740ee3.png">
<img width="360" alt="Screen Shot 2023-02-28 at 11 33 12 AM" src="https://user-images.githubusercontent.com/94649004/221946997-e426250e-857d-4fac-a230-26ba9a92a3ca.png">
<img width="367" alt="Screen Shot 2023-02-28 at 11 33 01 AM" src="https://user-images.githubusercontent.com/94649004/221947004-a0d41941-1ec1-4dbd-be90-8bf8b8f39736.png">


Latest build: [extension-builds-3096](https://github.com/tahowallet/extension/suites/11261059064/artifacts/577060605) (as of Tue, 28 Feb 2023 18:36:46 GMT).