### PR TITLE
Logging - Log UI errors caught by main error boundary

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -64,3 +64,9 @@ interface Window {
   ethereum?: WindowEthereum
   oldEthereum?: WindowEthereum
 }
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    NODE_ENV: "production" | "development" | "test"
+  }
+}

--- a/ui/pages/ErrorFallback.tsx
+++ b/ui/pages/ErrorFallback.tsx
@@ -1,9 +1,22 @@
+import logger from "@tallyho/tally-background/lib/logger"
 import React, { ReactElement } from "react"
+import { FallbackProps } from "react-error-boundary"
 import { useTranslation } from "react-i18next"
 import SharedButton from "../components/Shared/SharedButton"
+import { useOnMount } from "../hooks/react-hooks"
 
-export default function ErrorFallback(): ReactElement {
+export default function ErrorFallback(
+  props: Partial<FallbackProps>
+): ReactElement {
   const { t } = useTranslation("translation", { keyPrefix: "genericPages" })
+
+  useOnMount(() => {
+    // We only need the original stack trace available in production logs
+    if (process.env.NODE_ENV === "production") {
+      logger.error(props.error?.message, props.error?.stack)
+    }
+  })
+
   return (
     <>
       <div className="wrap">


### PR DESCRIPTION
This should help with debugging redux and state errors that aren't necessarily caused by background actions

## To Test
- [ ] Add a selector that will access an invalid nested property to the Wallet page, e.g . ```ts useBackgroundSelector((state) => (state as any).something.that.will.throw)```
- [ ] Create a production build
- [ ] Open the wallet page
- [ ] Export logs, you should see the Wallet page in the stack trace

Latest build: [extension-builds-3101](https://github.com/tahowallet/extension/suites/11291295174/artifacts/579279456) (as of Wed, 01 Mar 2023 21:22:40 GMT).