### PR TITLE
Signing - Prevent signing button from staying locked when attempting to sign data

### DIFF
--- a/ui/components/Signing/Signer/TransactionButton.tsx
+++ b/ui/components/Signing/Signer/TransactionButton.tsx
@@ -1,10 +1,12 @@
 import React, { ReactElement, useEffect, useRef, useState } from "react"
+import { selectSigningData } from "@tallyho/tally-background/redux-slices/signing"
 import { selectIsTransactionLoaded } from "@tallyho/tally-background/redux-slices/selectors/transactionConstructionSelectors"
 import { useBackgroundSelector, useDebounce } from "../../../hooks"
 import SharedButton, {
   Props as SharedButtonProps,
 } from "../../Shared/SharedButton"
 
+// TODO: Rename this to signing button
 export default function TransactionButton({
   type,
   size,
@@ -13,9 +15,12 @@ export default function TransactionButton({
   children,
   reactOnWindowFocus = false,
 }: SharedButtonProps & { reactOnWindowFocus?: boolean }): ReactElement {
-  const isTransactionDataReady = useBackgroundSelector(
-    selectIsTransactionLoaded
-  )
+  const hasTransactionLoaded = useBackgroundSelector(selectIsTransactionLoaded)
+
+  const hasSignDataRequest = useBackgroundSelector(selectSigningData)
+
+  const isTransactionDataReady = hasTransactionLoaded || hasSignDataRequest
+
   /*
     Prevent shenanigans by disabling the sign button for a bit
     when changing window focus.


### PR DESCRIPTION
Fixes a bug that would cause both reject and sign buttons to remain locked when attempting to sign a message

## To Test
- [x] Head to https://login.xyz, try to sign in with your wallet

Latest build: [extension-builds-3114](https://github.com/tahowallet/extension/suites/11352040150/artifacts/583581270) (as of Sat, 04 Mar 2023 21:05:20 GMT).