### PR TITLE
Add a back button for swap page

### DIFF
--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -48,6 +48,7 @@ import ApproveQuoteBtn from "../components/Swap/ApproveQuoteButton"
 import { isSameAsset, useSwapQuote } from "../utils/swap"
 import { useOnMount, usePrevious, useInterval } from "../hooks/react-hooks"
 import SharedLoadingDoggo from "../components/Shared/SharedLoadingDoggo"
+import SharedBackButton from "../components/Shared/SharedBackButton"
 
 const REFRESH_QUOTE_INTERVAL = 10 * SECOND
 
@@ -433,7 +434,10 @@ export default function Swap(): ReactElement {
               />
             )}
         </SharedSlideUpMenu>
-        <div className="standard_width swap_wrap">
+        <div className="standard_width">
+          <div className="back_button_wrap">
+            <SharedBackButton path="/" />
+          </div>
           <div className="header">
             <SharedActivityHeader label={t("swap.title")} activity="swap" />
             <ReadOnlyNotice isLite />
@@ -589,13 +593,11 @@ export default function Swap(): ReactElement {
       </CorePage>
       <style jsx>
         {`
-          .swap_wrap {
-            margin-top: -9px;
-          }
           .header {
             display: flex;
             align-items: center;
             justify-content: space-between;
+            margin-top: 13px;
           }
           .network_fee_group {
             display: flex;
@@ -656,6 +658,12 @@ export default function Swap(): ReactElement {
           }
           .settings_wrap {
             margin-top: 16px;
+          }
+          .back_button_wrap {
+            position: absolute;
+            margin-left: -1px;
+            margin-top: -4px;
+            z-index: 10;
           }
         `}
       </style>


### PR DESCRIPTION
Closes #3118 

This PR fixes UX bug and adds a back button on swap page.

**UI**
Before
![Screenshot 2023-03-07 at 08 54 52](https://user-images.githubusercontent.com/23117945/223359124-7bf4c147-b5c7-430f-8b13-19b2ae36f357.png)

After
![Screenshot 2023-03-07 at 08 51 37](https://user-images.githubusercontent.com/23117945/223359020-20c799a6-6da4-4eb3-9cd0-b12d605bd75b.png)

Latest build: [extension-builds-3123](https://github.com/tahowallet/extension/suites/11399855519/artifacts/586952103) (as of Tue, 07 Mar 2023 11:18:26 GMT).