### PR TITLE
Daylight - Only poll ablities for imported addresses

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -654,6 +654,8 @@ export default class Main extends BaseService<never> {
               network,
             }
             await this.chainService.addAccountToTrack(addressNetwork)
+            this.abilitiesService.getNewAccountAbilities(address)
+
             this.store.dispatch(loadAccount(addressNetwork))
           })
         )
@@ -1081,6 +1083,7 @@ export default class Main extends BaseService<never> {
           address,
           network,
         })
+        this.abilitiesService.getNewAccountAbilities(address)
       })
     })
 
@@ -1570,14 +1573,6 @@ export default class Main extends BaseService<never> {
     this.abilitiesService.emitter.on("deleteAccount", (address) => {
       this.store.dispatch(deleteAccountFilter(address))
     })
-
-    this.keyringService.emitter.on("address", (address) =>
-      this.abilitiesService.getNewAccountAbilities(address)
-    )
-
-    this.ledgerService.emitter.on("address", ({ address }) =>
-      this.abilitiesService.getNewAccountAbilities(address)
-    )
   }
 
   async getActivityDetails(txHash: string): Promise<ActivityDetail[]> {


### PR DESCRIPTION
Prevents abilities polling for all ledger addresses discovered instead of only selected addresses when adding new accounts

Closes #3100

Refs:
- https://github.com/tahowallet/extension/pull/3095#pullrequestreview-1319275833

## To Test
- [x] Onboard a ledger, before reaching the address selection screen, monitor the network requests
- [x] There should not be a request for every derived address
- [x] Everything else should work the same

Latest build: [extension-builds-3131](https://github.com/tahowallet/extension/suites/11447290997/artifacts/590431383) (as of Thu, 09 Mar 2023 07:49:11 GMT).