### PR TITLE
Fix CODEOWNERS teams and drop package.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,10 +2,9 @@
 # exfiltration and general "roll your own crypto" mistakes. Newer
 # contributions to keyring code should be assumed insecure, requiring
 # agreement across the team to merge.
-/background/services/keyring/* @shadowfiend @mhluongo
+/background/services/keyring/* @tahowallet/extension-security-auditors
 # Any changes to dependencies deserve extra scrutiny to help prevent supply
 # chain attacks
-package.json @greg-nagy @0xDaedalus @shadowfiend @mhluongo
-yarn.lock @tallyhowallet/extension-dependency-auditors
+yarn.lock @tahowallet/extension-dependency-auditors
 # Any changes to code owners deserve extra scrutiny
-.github/CODEOWNERS @shadowfiend @mhluongo
+.github/CODEOWNERS @tahowallet/extension-security-auditors


### PR DESCRIPTION
CODEOWNERS was still referencing tallyhowallet as the org name for teams, which is incorrect. This is now correctly tahowallet. While we're in here, add an extension-security-auditors group to handle ownership of CODEOWNERS itself as well as keyring code.

As a last adjustment, drop package.json, which was triggering CODEOWNERS during releases because of a simple bump for the top-level package version. Instead, yarn.lock remains under CODEOWNERS. Since CI requires yarn.lock be up to date by using `--frozen-lockfile`, the effect of requiring that dependency changes be audited by the extension-dependency-auditors group remains.

Latest build: [extension-builds-3143](https://github.com/tahowallet/extension/suites/11524342976/artifacts/596027626) (as of Mon, 13 Mar 2023 13:46:45 GMT).