### PR TITLE
Add possibility to sort abilities

### DIFF
--- a/background/abilities.ts
+++ b/background/abilities.ts
@@ -49,6 +49,7 @@ export type Ability = {
   imageUrl?: string
   openAt?: string
   closeAt?: string
+  createdAt: string
   completed: boolean
   removedFromUi: boolean
   address: NormalizedEVMAddress

--- a/background/redux-slices/abilities.ts
+++ b/background/redux-slices/abilities.ts
@@ -23,8 +23,11 @@ const isImportOrInternalAccount = (
 
 export type State = "open" | "completed" | "expired" | "deleted" | "all"
 
+export type Sort = "new" | "old" | "magic"
+
 export type Filter = {
   state: State
+  sort: Sort
   types: string[]
   accounts: string[]
 }
@@ -42,6 +45,7 @@ type AbilitiesState = {
 const initialState: AbilitiesState = {
   filter: {
     state: "open",
+    sort: "magic",
     types: [...ABILITY_TYPES_ENABLED],
     accounts: [],
   },
@@ -92,6 +96,9 @@ const abilitiesSlice = createSlice({
     updateState: (immerState, { payload: state }: { payload: State }) => {
       immerState.filter.state = state
     },
+    updateSort: (immerState, { payload: sort }: { payload: Sort }) => {
+      immerState.filter.sort = sort
+    },
     addType: (immerState, { payload: type }: { payload: string }) => {
       immerState.filter.types.push(type)
     },
@@ -120,6 +127,7 @@ export const {
   deleteAbility,
   toggleHideDescription,
   updateState,
+  updateSort,
   addType,
   deleteType,
   addAccount,

--- a/background/redux-slices/selectors/abilitiesSelectors.ts
+++ b/background/redux-slices/selectors/abilitiesSelectors.ts
@@ -1,7 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit"
 import { RootState } from ".."
-import { Ability } from "../../abilities"
-import { filterAbility } from "../utils/abilities-utils"
+import { filterAbility, getFilteredAbilities } from "../utils/abilities-utils"
 
 const selectAbilities = createSelector(
   (state: RootState) => state.abilities,
@@ -24,6 +23,11 @@ export const selectAbilityFilterState = createSelector(
   (abilitiesSlice) => abilitiesSlice.filter.state
 )
 
+export const selectAbilityFilterSort = createSelector(
+  (state: RootState) => state.abilities,
+  (abilitiesSlice) => abilitiesSlice.filter.sort
+)
+
 export const selectAbilityFilterTypes = createSelector(
   (state: RootState) => state.abilities,
   (abilitiesSlice) => abilitiesSlice.filter.types
@@ -35,29 +39,24 @@ export const selectAbilityFilterAccounts = createSelector(
 )
 
 /* Items selectors */
+const selectAllAbilities = createSelector(selectAbilities, (abilities) => {
+  return Object.values(abilities).flatMap((addressAbilities) =>
+    Object.values(addressAbilities)
+  )
+})
+
 export const selectFilteredAbilities = createSelector(
   selectAbilityFilter,
-  selectAbilities,
-  (filter, abilities) => {
-    const activeAbilities: Ability[] = []
-    Object.values(abilities).forEach((addressAbilities) => {
-      activeAbilities.push(
-        ...Object.values(addressAbilities).filter((ability) =>
-          filterAbility(ability, filter)
-        )
-      )
-    })
-    return activeAbilities
-  }
+  selectAllAbilities,
+  (filter, abilities) => getFilteredAbilities(abilities, filter)
 )
 
 /* Counting selectors  */
 export const selectOpenAbilityCount = createSelector(
   selectAbilityFilter,
-  selectAbilities,
+  selectAllAbilities,
   (filter, abilities) =>
-    Object.values(abilities)
-      .flatMap((address) => Object.values(address))
-      .filter((ability) => filterAbility(ability, { ...filter, state: "open" }))
-      .length
+    abilities.filter((ability) =>
+      filterAbility(ability, { ...filter, state: "open" })
+    ).length
 )

--- a/background/redux-slices/utils/abilities-utils.ts
+++ b/background/redux-slices/utils/abilities-utils.ts
@@ -1,5 +1,5 @@
 import { Ability, AbilityType } from "../../abilities"
-import { Filter, State } from "../abilities"
+import { Filter, Sort, State } from "../abilities"
 
 const isDeleted = (ability: Ability): boolean => ability.removedFromUi
 
@@ -44,4 +44,36 @@ export const filterAbility = (ability: Ability, filter: Filter): boolean => {
     filterByState(ability, filter.state) &&
     filterByType(ability.type, filter.types)
   )
+}
+
+export const sortAbilities = (
+  ability1: Ability,
+  ability2: Ability,
+  type: Sort
+): number => {
+  switch (type) {
+    case "new":
+      return (
+        new Date(ability2.createdAt).getTime() -
+        new Date(ability1.createdAt).getTime()
+      )
+    case "old":
+      return (
+        new Date(ability1.createdAt).getTime() -
+        new Date(ability2.createdAt).getTime()
+      )
+    default:
+      return 0
+  }
+}
+
+export const getFilteredAbilities = (
+  abilities: Ability[],
+  filter: Filter
+): Ability[] => {
+  return abilities
+    .filter((ability) => filterAbility(ability, filter))
+    .sort((ability1, ability2) =>
+      sortAbilities(ability1, ability2, filter.sort)
+    )
 }

--- a/background/redux-slices/utils/tests/abilities-utils.unit.test.ts
+++ b/background/redux-slices/utils/tests/abilities-utils.unit.test.ts
@@ -22,6 +22,7 @@ const ABILITY_DEFAULT: Ability = {
     type: "hold",
     address: "",
   },
+  createdAt: Date.now().toString(),
 }
 
 describe("Abilities utils", () => {

--- a/background/services/abilities/index.ts
+++ b/background/services/abilities/index.ts
@@ -60,6 +60,7 @@ const normalizeDaylightAbilities = (
       openAt: daylightAbility.openAt || undefined,
       closeAt: daylightAbility.closeAt || undefined,
       completed: daylightAbility.walletCompleted || false,
+      createdAt: daylightAbility.createdAt,
       removedFromUi: false,
       address: normalizeEVMAddress(address),
       requirement: normalizeDaylightRequirements(

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -833,6 +833,11 @@
         "deleted": "Deleted",
         "all": "All"
       },
+      "abilitySort": {
+        "magic": "The most interesting",
+        "new": "Newest added",
+        "old": "Oldest added"
+      },
       "abilityTypeDesc": {
         "vote": "A proposal that someone can vote on based on a token they hold.",
         "claim": "On-chain reward that someone can claim that is not a mint or airdrop.",
@@ -846,6 +851,7 @@
         "misc": "An ability that does not fall into any of these types."
       },
       "abilityStateTitle": "Show",
+      "abilitySortTitle": "Sort abilities",
       "abilitiesTypesTitle": "Notify me about abilities type",
       "accountsTitle": "Show/hide accounts",
       "accountsReadOnlyInfo": "Read-only accounts can’t see abilities. If you can, we recommend you import the address you want to see abilities for.",

--- a/ui/pages/Abilities/AbilityFilter.tsx
+++ b/ui/pages/Abilities/AbilityFilter.tsx
@@ -6,10 +6,13 @@ import {
   deleteType,
   addAccount,
   deleteAccount,
+  Sort,
+  updateSort,
 } from "@tallyho/tally-background/redux-slices/abilities"
 import { AccountType } from "@tallyho/tally-background/redux-slices/accounts"
 import {
   selectAbilityFilterAccounts,
+  selectAbilityFilterSort,
   selectAbilityFilterState,
   selectAbilityFilterTypes,
   selectAccountTotals,
@@ -24,10 +27,11 @@ import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import { i18n } from "../../_locales/i18n"
 import AbilityFilterCard from "./AbilityFilterCard"
 
-const RADIO_NAME = "sortType"
+const STATE_BTN_NAME = "stateBtn"
+const SORT_BTN_NAME = "sortBtn"
 const KEY_PREFIX = "abilities.filter"
 
-const RADIO_BTNS: { value: State; label: string }[] = [
+const STATE_BTNS: { value: State; label: string }[] = [
   {
     value: "open",
     label: i18n.t(`${KEY_PREFIX}.abilityState.open`),
@@ -50,6 +54,21 @@ const RADIO_BTNS: { value: State; label: string }[] = [
   },
 ]
 
+const SORT_BTNS: { value: Sort; label: string }[] = [
+  {
+    value: "magic",
+    label: i18n.t(`${KEY_PREFIX}.abilitySort.magic`),
+  },
+  {
+    value: "new",
+    label: i18n.t(`${KEY_PREFIX}.abilitySort.new`),
+  },
+  {
+    value: "old",
+    label: i18n.t(`${KEY_PREFIX}.abilitySort.old`),
+  },
+]
+
 const ABILITY_TYPE_DESC = {
   vote: i18n.t(`${KEY_PREFIX}.abilityTypeDesc.vote`),
   claim: i18n.t(`${KEY_PREFIX}.abilityTypeDesc.claim`),
@@ -68,6 +87,7 @@ export default function AbilityFilter(): ReactElement {
     keyPrefix: "abilities.filter",
   })
   const state = useBackgroundSelector(selectAbilityFilterState)
+  const sort = useBackgroundSelector(selectAbilityFilterSort)
   const types = useBackgroundSelector(selectAbilityFilterTypes)
   const accounts = useBackgroundSelector(selectAbilityFilterAccounts)
   const accountTotals = useBackgroundSelector(selectAccountTotals)
@@ -79,6 +99,13 @@ export default function AbilityFilter(): ReactElement {
   const handleUpdateState = useCallback(
     (value: State) => {
       dispatch(updateState(value))
+    },
+    [dispatch]
+  )
+
+  const handleUpdateSort = useCallback(
+    (value: Sort) => {
+      dispatch(updateSort(value))
     },
     [dispatch]
   )
@@ -110,14 +137,27 @@ export default function AbilityFilter(): ReactElement {
       <div className="filter">
         <div className="simple_text">
           <span className="filter_title">{t("abilityStateTitle")}</span>
-          {RADIO_BTNS.map(({ value, label }) => (
+          {STATE_BTNS.map(({ value, label }) => (
             <SharedRadio
               key={value}
               id={`radio_${value}`}
-              name={RADIO_NAME}
+              name={STATE_BTN_NAME}
               value={state === value}
               label={label}
               onChange={() => handleUpdateState(value)}
+            />
+          ))}
+        </div>
+        <div className="simple_text">
+          <span className="filter_title">{t("abilitySortTitle")}</span>
+          {SORT_BTNS.map(({ value, label }) => (
+            <SharedRadio
+              key={value}
+              id={`radio_${value}`}
+              name={SORT_BTN_NAME}
+              value={sort === value}
+              label={label}
+              onChange={() => handleUpdateSort(value)}
             />
           ))}
         </div>

--- a/ui/tests/factories.ts
+++ b/ui/tests/factories.ts
@@ -61,6 +61,7 @@ export const createAbility = (overrides: Partial<Ability> = {}): Ability => {
       type: "hold",
       address: "",
     },
+    createdAt: Date.now().toString(),
     ...overrides,
   }
 }


### PR DESCRIPTION
This PR adds a new filter for abilities. Abilities are sorted by default by using property `magic`. This means that the most interesting them should display first. Because of this, many users miss out on new activities. A [fix](https://github.com/tahowallet/extension/pull/3142) has also been prepared to make new incoming abilities display before old ones. However, an additional filter has been created to make it easier for users to browse abilities.

**UI**

![Screenshot 2023-03-13 at 15 29 19](https://user-images.githubusercontent.com/23117945/224759130-0ea10ae0-197f-4b66-b179-177ed3d9b9d9.png)

**TBD**
- Naming of filters
- Sorting by date of opening and closing abilities