### PR TITLE
Does not show price impact when data is not ready

### DIFF
--- a/ui/components/Shared/PriceDetails.tsx
+++ b/ui/components/Shared/PriceDetails.tsx
@@ -36,40 +36,44 @@ export default function PriceDetails(props: PriceDetailsProps): ReactElement {
 
   return (
     <div className="simple_text content_wrap">
-      {!isLoading && amountMainCurrency === undefined ? (
-        t("noAssetPrice")
-      ) : (
+      {!isLoading && (
         <>
-          {amountMainCurrency === "0.00" && "<"}
-          {mainCurrencySign}
-          {amountMainCurrency || "0.00"}
-          {!!priceImpact && priceImpact > 1 && (
-            <span
-              data-testid="price_impact_percent"
-              className="price_impact_percent"
-            >
-              ({formatPriceImpact(priceImpact)}%
-              <SharedTooltip
-                width={180}
-                height={27}
-                horizontalPosition="left"
-                IconComponent={() => (
-                  <SharedIcon
-                    width={16}
-                    icon="icons/m/info.svg"
-                    color={`var(--${getPriceImpactColor(priceImpact)})`}
-                    customStyles="margin-left: -5px;"
-                  />
-                )}
-              >
-                <div>
-                  {t("priceImpactTooltip.firstLine")}
-                  <br />
-                  {t("priceImpactTooltip.secondLine")}
-                </div>
-              </SharedTooltip>
-              )
-            </span>
+          {amountMainCurrency === undefined ? (
+            t("noAssetPrice")
+          ) : (
+            <>
+              {amountMainCurrency === "0.00" && "<"}
+              {mainCurrencySign}
+              {amountMainCurrency || "0.00"}
+              {!!priceImpact && priceImpact > 1 && (
+                <span
+                  data-testid="price_impact_percent"
+                  className="price_impact_percent"
+                >
+                  ({formatPriceImpact(priceImpact)}%
+                  <SharedTooltip
+                    width={180}
+                    height={27}
+                    horizontalPosition="left"
+                    IconComponent={() => (
+                      <SharedIcon
+                        width={16}
+                        icon="icons/m/info.svg"
+                        color={`var(--${getPriceImpactColor(priceImpact)})`}
+                        customStyles="margin-left: -5px;"
+                      />
+                    )}
+                  >
+                    <div>
+                      {t("priceImpactTooltip.firstLine")}
+                      <br />
+                      {t("priceImpactTooltip.secondLine")}
+                    </div>
+                  </SharedTooltip>
+                  )
+                </span>
+              )}
+            </>
           )}
         </>
       )}


### PR DESCRIPTION
Closes #3156 
This PR solves the problem of showing the impact of price when data isn't ready. Previously, when loading the data old price impact showed for 1 second. The changes involve showing the price detail when the data is loaded and up to date.

In the task noticed:
> Price information can't be calculated -> I believe a user should not be able to proceed with the swap:
> <img width="363" alt="225247416-934d1c0b-ffcc-4b21-bc47-132cf5de6984" src="https://user-images.githubusercontent.com/23117945/225285108-3d29ea2e-843b-4480-acb3-6603206fefcc.png">

However, I don't think we want that. Let me know what you think.

## UI
Before
https://user-images.githubusercontent.com/23117945/225283719-887f22e2-fc0d-48e2-999e-be4c0d94d2d9.mov

After
https://user-images.githubusercontent.com/23117945/225283623-8024cb87-d972-4aa3-bf44-4361f84e05a0.mov

