### PR TITLE
Handle case where there are no cached assets for given network

### DIFF
--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -447,8 +447,7 @@ export default class IndexingService extends BaseService<Events> {
             ({ smartContract: { contractAddress } }) => contractAddress
           )
         )
-        const cachedAssets =
-          this.cachedAssets[addressOnNetwork.network.chainID] ?? []
+        const cachedAssets = this.getCachedAssets(addressOnNetwork.network)
 
         const otherActiveAssets = cachedAssets
           .filter(isSmartContractFungibleAsset)

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -447,7 +447,8 @@ export default class IndexingService extends BaseService<Events> {
             ({ smartContract: { contractAddress } }) => contractAddress
           )
         )
-        const cachedAssets = this.cachedAssets[addressOnNetwork.network.chainID]
+        const cachedAssets =
+          this.cachedAssets[addressOnNetwork.network.chainID] ?? []
 
         const otherActiveAssets = cachedAssets
           .filter(isSmartContractFungibleAsset)

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -179,7 +179,7 @@ export default class IndexingService extends BaseService<Events> {
       // Push any assets we have cached in the db for all active networks
       trackedNetworks.forEach(async (network) => {
         await this.cacheAssetsForNetwork(network)
-        this.emitter.emit("assets", this.cachedAssets[network.chainID])
+        this.emitter.emit("assets", this.getCachedAssets(network))
       })
 
       // Load balances after token lists load
@@ -271,7 +271,7 @@ export default class IndexingService extends BaseService<Events> {
     network: EVMNetwork,
     contractAddress: HexString
   ): SmartContractFungibleAsset | undefined {
-    const knownAssets = this.cachedAssets[network.chainID]
+    const knownAssets = this.getCachedAssets(network)
 
     const searchResult = knownAssets.find(
       (asset): asset is SmartContractFungibleAsset =>
@@ -796,7 +796,7 @@ export default class IndexingService extends BaseService<Events> {
     // may be inactive.
     this.chainService.supportedNetworks.forEach(async (network) => {
       await this.cacheAssetsForNetwork(network)
-      this.emitter.emit("assets", this.cachedAssets[network.chainID])
+      this.emitter.emit("assets", this.getCachedAssets(network))
     })
 
     // TODO if tokenListPrefs.autoUpdate is true, pull the latest and update if


### PR DESCRIPTION
### What

Fix attempting to filter on `undefined` - while adding a new network with Chainlist there are no cached assets yet

### Testing

- [ ] flip `SUPPORT_CUSTOM_NETWORKS`
- [ ] open background page
- [ ] add new network with chainlist
- [ ] you shouldn't see an error in the console about the line changed in this PR

Latest build: [extension-builds-3160](https://github.com/tahowallet/extension/suites/11578827244/artifacts/599913023) (as of Wed, 15 Mar 2023 13:32:41 GMT).