### PR TITLE
Disable 429 Retry when querying CoinGecko API.

### DIFF
--- a/background/lib/prices.ts
+++ b/background/lib/prices.ts
@@ -42,7 +42,11 @@ export async function getPrices(
   const url = `${COINGECKO_API_ROOT}/simple/price?ids=${coinIds}&include_last_updated_at=true&vs_currencies=${currencySymbols}`
 
   try {
-    const json = await fetchJson(url)
+    const json = await fetchJson({
+      url,
+      // Prevent throttling
+      throttleCallback: async () => false,
+    })
     // TODO fix loss of precision from json
     // TODO: TESTME
 
@@ -118,7 +122,11 @@ export async function getTokenPrices(
   const url = `${COINGECKO_API_ROOT}/simple/token_price/${network.coingeckoPlatformID}?vs_currencies=${fiatSymbol}&include_last_updated_at=true&contract_addresses=${addys}`
 
   try {
-    const json = await fetchJson(url)
+    const json = await fetchJson({
+      url,
+      // Prevent throttling
+      throttleCallback: async () => false,
+    })
 
     // TODO Improve typing with Ajv validation.
     Object.entries(

--- a/background/services/indexing/tests/index.integration.test.ts
+++ b/background/services/indexing/tests/index.integration.test.ts
@@ -284,15 +284,12 @@ describe("IndexingService", () => {
 
       await spy.mock.results[0].value
 
-      expect(fetchJsonStub.getCalls()).toContainEqual(
-        expect.objectContaining({
-          args: [
-            expect.stringMatching(
-              /ethereum,matic-network,rootstock,avalanche-2,binancecoin/i
-            ),
-          ],
-        })
-      )
+      expect(
+        fetchJsonStub
+          .getCalls()
+          .toString()
+          .match(/ethereum,matic-network,rootstock,avalanche-2,binancecoin/i)
+      ).toBeTruthy()
     })
 
     it("should not retrieve token prices for custom assets", async () => {


### PR DESCRIPTION
Closes https://github.com/tahowallet/extension/issues/3164

This change was introduced to resolve an issue where 429 responses from CoinGecko would block swap functionality in the application.  This was happening because the fetchJson function we were using automatically waits and retries requests that come back with a 429 status code.  Due to the high likelihood of us being rate limited when hitting the coingecko api - this is actually undesirable functinality since we want to fail fast in the case that coingecko is unavailable.

By passing in a throttleCallback to fetchJson that always resolves to false  - we can rely on the (already existing) code around the function call to handle cases where we get a 429 or a bad response.  This results in a snappier user experience when querying prices - and does not break any existing functionality - all that is changing is that we now handle 429's how we would handle 400's and 500's - instead of special-casing them.


https://user-images.githubusercontent.com/94649004/225576313-ed20e9d2-cd81-4a51-80f4-9ef31f420b24.mov


### To Test
- [ ] Rapidly swap buy assets or sell asset amounts in the swap page
- [ ] The swap totals should load with `No Price Information` rather than hanging forever

Latest build: [extension-builds-3165](https://github.com/tahowallet/extension/suites/11602728521/artifacts/601621193) (as of Thu, 16 Mar 2023 10:48:43 GMT).