### PR TITLE
Switch wallet to newly added network

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -75,6 +75,7 @@ import {
   setAccountsSignerSettings,
   toggleCollectAnalytics,
   setShowAnalyticsNotification,
+  setSelectedNetwork,
 } from "./redux-slices/ui"
 import {
   estimatedFeesPerGas,
@@ -767,6 +768,10 @@ export default class Main extends BaseService<never> {
 
     this.chainService.emitter.on("supportedNetworks", (supportedNetworks) => {
       this.store.dispatch(setEVMNetworks(supportedNetworks))
+    })
+
+    this.chainService.emitter.on("selectedNetwork", (network) => {
+      this.store.dispatch(setSelectedNetwork(network))
     })
 
     this.chainService.emitter.on("block", (block) => {

--- a/background/services/chain/db.ts
+++ b/background/services/chain/db.ts
@@ -231,8 +231,8 @@ export class ChainDatabase extends Dexie {
     symbol: string
     assetName: string
     rpcUrls: string[]
-  }): Promise<void> {
-    await this.networks.put({
+  }): Promise<EVMNetwork> {
+    const network: EVMNetwork = {
       name: chainName,
       coingeckoPlatformID: CHAIN_ID_TO_COINGECKO_PLATFORM_ID[chainID],
       chainID,
@@ -243,11 +243,13 @@ export class ChainDatabase extends Dexie {
         name: assetName,
         chainID,
       },
-    })
+    }
+    await this.networks.put(network)
     // A bit awkward that we are adding the base asset to the network as well
     // as to its own separate table - but lets forge on for now.
     await this.addBaseAsset(assetName, symbol, chainID, decimals)
     await this.addRpcUrls(chainID, rpcUrls)
+    return network
   }
 
   async removeEVMNetwork(chainID: string): Promise<void> {

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -113,6 +113,7 @@ interface Events extends ServiceLifecycleEvents {
     source: "import" | "internal" | null
   }
   supportedNetworks: EVMNetwork[]
+  selectedNetwork: EVMNetwork
   accountsWithBalances: {
     /**
      * Retrieved balance for the network's base asset
@@ -1882,7 +1883,7 @@ export default class ChainService extends BaseService<Events> {
   async addCustomChain(
     chainInfo: ValidatedAddEthereumChainParameter
   ): Promise<void> {
-    await this.db.addEVMNetwork({
+    const network = await this.db.addEVMNetwork({
       chainName: chainInfo.chainName,
       chainID: chainInfo.chainId,
       decimals: chainInfo.nativeCurrency.decimals,
@@ -1898,6 +1899,8 @@ export default class ChainService extends BaseService<Events> {
     )
 
     await this.startTrackingNetworkOrThrow(chainInfo.chainId)
+
+    this.emitter.emit("selectedNetwork", network)
   }
 
   async removeCustomChain(chainID: string): Promise<void> {


### PR DESCRIPTION
Closes #3163 

This PR updates the network switching logic. When a new network is added, the wallet will be switched to it automatically. 

https://user-images.githubusercontent.com/23117945/227507265-2089b03b-80ab-4e67-a342-4f1a87b28dbf.mov


## To Test
- [ ] add a new custom network
- [ ] check if the wallet has been switched to it