### PR TITLE
Replace deprecated `set-output` command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Read .nvmrc
-        run: echo "::set-output name=NVMRC::$(cat ./.nvmrc)"
+        run: echo "NVMRC=$(cat ./.nvmrc)" >> $GITHUB_OUTPUT
         id: nvm
       - name: Use Node + Yarn
         uses: actions/setup-node@v3
@@ -76,7 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Read .nvmrc
-        run: echo "::set-output name=NVMRC::$(cat ./.nvmrc)"
+        run: echo "NVMRC=$(cat ./.nvmrc)" >> $GITHUB_OUTPUT
         id: nvm
       - name: Use Node + Yarn
         uses: actions/setup-node@v3
@@ -90,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Read .nvmrc
-        run: echo "::set-output name=NVMRC::$(cat ./.nvmrc)"
+        run: echo "NVMRC=$(cat ./.nvmrc)" >> $GITHUB_OUTPUT
         id: nvm
       - name: Use Node + Yarn
         uses: actions/setup-node@v3
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Read .nvmrc
-        run: echo "::set-output name=NVMRC::$(cat ./.nvmrc)"
+        run: echo "NVMRC=$(cat ./.nvmrc)" >> $GITHUB_OUTPUT
         id: nvm
       - name: Use Node + Yarn
         uses: actions/setup-node@v3


### PR DESCRIPTION
As explained in
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/, the `set-output` GH Action command will become deprecated after 31st May 2023. There's a new method for setting up outputs (described [here](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter)), which we will now use.