### PR TITLE
Token Balances - Fix base asset 0 balances not showing on custom networks

### DIFF
--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -11,7 +11,6 @@ import {
   enrichAssetAmountWithDecimalValues,
   enrichAssetAmountWithMainCurrencyValues,
   formatCurrencyAmount,
-  getBuiltInNetworkBaseAsset,
   heuristicDesiredDecimalsForUnitPrice,
   isNetworkBaseAsset,
 } from "../utils/asset-utils"
@@ -138,27 +137,11 @@ const computeCombinedAssetAmountsData = (
         return 1
       }
 
-      // Always display the current network's base asset first
-      const networkBaseAsset = currentNetwork.baseAsset
+      const leftIsBaseAsset = isNetworkBaseAsset(asset1.asset)
+      const rightIsBaseAsset = isNetworkBaseAsset(asset2.asset)
 
-      const leftIsNetworkBaseAsset =
-        networkBaseAsset.symbol === asset1.asset.symbol
-      const rightIsNetworkBaseAsset =
-        networkBaseAsset.symbol === asset2.asset.symbol
-
-      if (leftIsNetworkBaseAsset !== rightIsNetworkBaseAsset) {
-        return leftIsNetworkBaseAsset ? -1 : 1
-      }
-      const leftIsBaseAsset = !!getBuiltInNetworkBaseAsset(
-        asset1.asset.symbol,
-        networkBaseAsset.chainID
-      )
-      const rightIsBaseAsset = !!getBuiltInNetworkBaseAsset(
-        asset2.asset.symbol,
-        networkBaseAsset.chainID
-      )
-
-      // Always sort base assets above non-base assets.
+      // Always sort base assets above non-base assets. This also sorts the
+      // current network base asset above the rest
       if (leftIsBaseAsset !== rightIsBaseAsset) {
         return leftIsBaseAsset ? -1 : 1
       }

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -13,7 +13,7 @@ import {
   formatCurrencyAmount,
   getBuiltInNetworkBaseAsset,
   heuristicDesiredDecimalsForUnitPrice,
-  isBuiltInNetworkBaseAsset,
+  isNetworkBaseAsset,
 } from "../utils/asset-utils"
 import {
   AnyAsset,
@@ -37,7 +37,7 @@ import {
   selectSourcesByAddress,
 } from "./keyringsSelectors"
 import { AccountBalance, AddressOnNetwork } from "../../accounts"
-import { EVMNetwork, NetworkBaseAsset, sameNetwork } from "../../networks"
+import { EVMNetwork, sameNetwork } from "../../networks"
 import { NETWORK_BY_CHAIN_ID, TEST_NETWORK_BY_CHAIN_ID } from "../../constants"
 import { DOGGO } from "../../constants/assets"
 import { FeatureFlags, isEnabled } from "../../features"
@@ -63,19 +63,13 @@ const EXCEPTION_ASSETS_BY_SYMBOL = ["BTC", "sBTC", "WBTC", "tBTC"].map(
 const userValueDustThreshold = 2
 
 const shouldForciblyDisplayAsset = (
-  assetAmount: CompleteAssetAmount<AnyAsset>,
-  network: EVMNetwork,
-  baseAsset?: NetworkBaseAsset
+  assetAmount: CompleteAssetAmount<AnyAsset>
 ) => {
-  if (!baseAsset) {
-    return false
-  }
-
   const isDoggo =
     !isEnabled(FeatureFlags.HIDE_TOKEN_FEATURES) &&
     assetAmount.asset.symbol === DOGGO.symbol
 
-  return isDoggo || isBuiltInNetworkBaseAsset(baseAsset, network)
+  return isDoggo || isNetworkBaseAsset(assetAmount.asset)
 }
 
 const computeCombinedAssetAmountsData = (
@@ -120,16 +114,7 @@ const computeCombinedAssetAmountsData = (
       return fullyEnrichedAssetAmount
     })
     .filter((assetAmount) => {
-      const baseAsset = getBuiltInNetworkBaseAsset(
-        assetAmount.asset.symbol,
-        currentNetwork.chainID
-      )
-
-      const isForciblyDisplayed = shouldForciblyDisplayAsset(
-        assetAmount,
-        currentNetwork,
-        baseAsset
-      )
+      const isForciblyDisplayed = shouldForciblyDisplayAsset(assetAmount)
 
       const isNotDust =
         typeof assetAmount.mainCurrencyAmount === "undefined"

--- a/background/redux-slices/utils/asset-utils.ts
+++ b/background/redux-slices/utils/asset-utils.ts
@@ -43,7 +43,10 @@ export type AssetDecimalAmount = {
   localizedDecimalAmount: string
 }
 
-function hasChainID(asset: AnyAsset): asset is NetworkBaseAsset {
+/**
+ * All network base assets have a chainID property
+ */
+export function isNetworkBaseAsset(asset: AnyAsset): asset is NetworkBaseAsset {
   return "chainID" in asset
 }
 
@@ -51,7 +54,7 @@ function isOptimismBaseAsset(asset: AnyAsset) {
   const hasMatchingChainID =
     (isSmartContractFungibleAsset(asset) &&
       asset.homeNetwork.chainID === OPTIMISM.chainID) ||
-    (hasChainID(asset) && asset.chainID === OPTIMISM.chainID)
+    (isNetworkBaseAsset(asset) && asset.chainID === OPTIMISM.chainID)
 
   return (
     hasMatchingChainID &&
@@ -64,7 +67,7 @@ function isPolygonBaseAsset(asset: AnyAsset) {
   const hasMatchingChainID =
     (isSmartContractFungibleAsset(asset) &&
       asset.homeNetwork.chainID === POLYGON.chainID) ||
-    (hasChainID(asset) && asset.chainID === POLYGON.chainID)
+    (isNetworkBaseAsset(asset) && asset.chainID === POLYGON.chainID)
 
   return (
     hasMatchingChainID &&
@@ -96,7 +99,7 @@ export function isBuiltInNetworkBaseAsset(
   }
 
   return (
-    hasChainID(asset) &&
+    isNetworkBaseAsset(asset) &&
     asset.symbol === network.baseAsset.symbol &&
     asset.chainID === network.baseAsset.chainID &&
     asset.name === network.baseAsset.name
@@ -133,8 +136,8 @@ export function sameBuiltInNetworkBaseAsset(
   if (
     "homeNetwork" in asset1 ||
     "homeNetwork" in asset2 ||
-    !hasChainID(asset1) ||
-    !hasChainID(asset2)
+    !isNetworkBaseAsset(asset1) ||
+    !isNetworkBaseAsset(asset2)
   ) {
     return false
   }

--- a/background/redux-slices/utils/asset-utils.ts
+++ b/background/redux-slices/utils/asset-utils.ts
@@ -50,6 +50,13 @@ export function isNetworkBaseAsset(asset: AnyAsset): asset is NetworkBaseAsset {
   return "chainID" in asset
 }
 
+export function sameNetworkBaseAsset(
+  asset: NetworkBaseAsset,
+  other: NetworkBaseAsset
+): boolean {
+  return asset.chainID === other.chainID
+}
+
 function isOptimismBaseAsset(asset: AnyAsset) {
   const hasMatchingChainID =
     (isSmartContractFungibleAsset(asset) &&


### PR DESCRIPTION
Fixes display for custom network base assets, refactored existing checks for base assets to check for `chainID` since that's only a property included in network base assets.

## To Test
- [ ] Import an account
- [ ] Add a custom network and switch to it, you should not see the base asset in the asset list as long as the balance is 0
- [ ] Switch to this branch, the asset balance should appear now