### PR TITLE
Custom Networks - Display a warning when attempting to add an already supported network

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -647,7 +647,9 @@
     "rpc": "RPC",
     "explorer": "BlockExplorer",
     "submit": "Add network",
-    "cancel": "Reject"
+    "cancel": "Reject",
+    "warnAlreadyExistsHeader": "Network already added to Taho wallet.",
+    "warnAlreadyExistsBody": "You can switch to it from Network dropdown"
   },
   "swap": {
     "title": "Swap Assets",


### PR DESCRIPTION
Closes #3207 

Adds a warning to the new custom network confirmation screen

```
SUPPORT_CUSTOM_NETWORKS=true
SUPPORT_CUSTOM_RPCS=true
```

## To Test
- [x] Head to chainlist.org, add a network then attempt to add it again.
- [x] On chainlist.org, attempt to add a builtin in network such as Ethereum

Latest build: [extension-builds-3211](https://github.com/tahowallet/extension/suites/11915544816/artifacts/623964814) (as of Thu, 30 Mar 2023 12:17:05 GMT).