### PR TITLE
Add analytics for Onboarding

### DIFF
--- a/background/lib/posthog.ts
+++ b/background/lib/posthog.ts
@@ -9,6 +9,10 @@ export enum AnalyticsEvent {
   NEW_ACCOUNT_TO_TRACK = "Address added to tracking on network",
 }
 
+export enum OneTimeAnalyticsEvent {
+  ONBOARDING_STARTED = "Onboarding started",
+}
+
 const POSTHOG_PROJECT_ID = "11112"
 
 const PERSON_ENDPOINT = `https://app.posthog.com/api/projects/${POSTHOG_PROJECT_ID}/persons`

--- a/background/lib/posthog.ts
+++ b/background/lib/posthog.ts
@@ -10,7 +10,14 @@ export enum AnalyticsEvent {
 }
 
 export enum OneTimeAnalyticsEvent {
-  ONBOARDING_STARTED = "Onboarding started",
+  ONBOARDING_STARTED = "Onboarding Started",
+  ONBOARDING_FINISHED = "Onboarding Finished",
+}
+
+export const isOneTimeAnalyticsEvent = (
+  eventName: string
+): eventName is OneTimeAnalyticsEvent => {
+  return Object.values<string>(OneTimeAnalyticsEvent).includes(eventName)
 }
 
 const POSTHOG_PROJECT_ID = "11112"

--- a/background/main.ts
+++ b/background/main.ts
@@ -167,7 +167,7 @@ import {
   initAbilities,
 } from "./redux-slices/abilities"
 import { AddChainRequestData } from "./services/provider-bridge"
-import { AnalyticsEvent } from "./lib/posthog"
+import { AnalyticsEvent, OneTimeAnalyticsEvent } from "./lib/posthog"
 import { isBuiltInNetworkBaseAsset } from "./redux-slices/utils/asset-utils"
 
 // This sanitizer runs on store and action data before serializing for remote
@@ -1659,6 +1659,12 @@ export default class Main extends BaseService<never> {
 
     uiSliceEmitter.on("deleteAnalyticsData", () => {
       this.analyticsService.removeAnalyticsData()
+    })
+
+    uiSliceEmitter.on("onboardingStarted", () => {
+      this.analyticsService.sendOneTimeAnalyticsEvent(
+        OneTimeAnalyticsEvent.ONBOARDING_STARTED
+      )
     })
   }
 

--- a/background/main.ts
+++ b/background/main.ts
@@ -167,7 +167,7 @@ import {
   initAbilities,
 } from "./redux-slices/abilities"
 import { AddChainRequestData } from "./services/provider-bridge"
-import { AnalyticsEvent, OneTimeAnalyticsEvent } from "./lib/posthog"
+import { AnalyticsEvent, isOneTimeAnalyticsEvent } from "./lib/posthog"
 import { isBuiltInNetworkBaseAsset } from "./redux-slices/utils/asset-utils"
 
 // This sanitizer runs on store and action data before serializing for remote
@@ -1661,10 +1661,12 @@ export default class Main extends BaseService<never> {
       this.analyticsService.removeAnalyticsData()
     })
 
-    uiSliceEmitter.on("onboardingStarted", () => {
-      this.analyticsService.sendOneTimeAnalyticsEvent(
-        OneTimeAnalyticsEvent.ONBOARDING_STARTED
-      )
+    uiSliceEmitter.on("sendEvent", (event) => {
+      if (isOneTimeAnalyticsEvent(event)) {
+        this.analyticsService.sendOneTimeAnalyticsEvent(event)
+      } else {
+        this.analyticsService.sendAnalyticsEvent(event)
+      }
     })
   }
 

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -41,6 +41,7 @@ export type Events = {
   deleteAnalyticsData: never
   newDefaultWalletValue: boolean
   refreshBackgroundPage: null
+  onboardingStarted: null
   newSelectedAccount: AddressOnNetwork
   newSelectedAccountSwitched: AddressOnNetwork
   userActivityEncountered: AddressOnNetwork
@@ -286,6 +287,13 @@ export const refreshBackgroundPage = createBackgroundAsyncThunk(
   "ui/refreshBackgroundPage",
   async () => {
     await emitter.emit("refreshBackgroundPage", null)
+  }
+)
+
+export const onboardingStarted = createBackgroundAsyncThunk(
+  "ui/onboardingStarted",
+  async () => {
+    await emitter.emit("onboardingStarted", null)
   }
 )
 

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -2,6 +2,7 @@ import { createSlice, createSelector } from "@reduxjs/toolkit"
 import Emittery from "emittery"
 import { AddressOnNetwork } from "../accounts"
 import { ETHEREUM } from "../constants"
+import { AnalyticsEvent, OneTimeAnalyticsEvent } from "../lib/posthog"
 import { EVMNetwork } from "../networks"
 import { AnalyticsPreferences } from "../services/preferences/types"
 import { AccountSignerWithId } from "../signing"
@@ -41,7 +42,7 @@ export type Events = {
   deleteAnalyticsData: never
   newDefaultWalletValue: boolean
   refreshBackgroundPage: null
-  onboardingStarted: null
+  sendEvent: AnalyticsEvent | OneTimeAnalyticsEvent
   newSelectedAccount: AddressOnNetwork
   newSelectedAccountSwitched: AddressOnNetwork
   userActivityEncountered: AddressOnNetwork
@@ -290,10 +291,10 @@ export const refreshBackgroundPage = createBackgroundAsyncThunk(
   }
 )
 
-export const onboardingStarted = createBackgroundAsyncThunk(
-  "ui/onboardingStarted",
-  async () => {
-    await emitter.emit("onboardingStarted", null)
+export const sendEvent = createBackgroundAsyncThunk(
+  "ui/sendEvent",
+  async (event: AnalyticsEvent | OneTimeAnalyticsEvent) => {
+    await emitter.emit("sendEvent", event)
   }
 )
 

--- a/background/services/analytics/db.ts
+++ b/background/services/analytics/db.ts
@@ -7,6 +7,8 @@ export interface AnalyticsUUID {
 export class AnalyticsDatabase extends Dexie {
   private analyticsUUID!: Dexie.Table<AnalyticsUUID, number>
 
+  private oneTimeEvent!: Dexie.Table<{ name: string }, number>
+
   constructor() {
     super("tally/analytics")
 
@@ -18,6 +20,10 @@ export class AnalyticsDatabase extends Dexie {
       // https://dexie.org/docs/inbound#example-of-outbound-primary-key
       analyticsUUID: "++,uuid",
     })
+
+    this.version(2).stores({
+      oneTimeEvent: "++,name",
+    })
   }
 
   async getAnalyticsUUID(): Promise<string | undefined> {
@@ -26,6 +32,15 @@ export class AnalyticsDatabase extends Dexie {
 
   async setAnalyticsUUID(uuid: string): Promise<void> {
     await this.analyticsUUID.add({ uuid })
+  }
+
+  async oneTimeEventExists(name: string): Promise<boolean> {
+    const count = await this.oneTimeEvent.where("name").equals(name).count()
+    return !!count
+  }
+
+  async setOneTimeEvent(name: string): Promise<void> {
+    await this.oneTimeEvent.add({ name })
   }
 }
 export async function getOrCreateDB(): Promise<AnalyticsDatabase> {

--- a/ui/pages/Onboarding/Tabbed/ImportSeed.tsx
+++ b/ui/pages/Onboarding/Tabbed/ImportSeed.tsx
@@ -5,6 +5,8 @@ import { isValidMnemonic } from "@ethersproject/hdnode"
 import { FeatureFlags, isEnabled } from "@tallyho/tally-background/features"
 import { useTranslation } from "react-i18next"
 import { selectCurrentNetwork } from "@tallyho/tally-background/redux-slices/selectors"
+import { sendEvent } from "@tallyho/tally-background/redux-slices/ui"
+import { OneTimeAnalyticsEvent } from "@tallyho/tally-background/lib/posthog"
 import SharedButton from "../../../components/Shared/SharedButton"
 import OnboardingDerivationPathSelect, {
   DefaultPathIndex,
@@ -70,6 +72,7 @@ export default function ImportSeed(props: Props): ReactElement {
           source: "import",
         })
       )
+      dispatch(sendEvent(OneTimeAnalyticsEvent.ONBOARDING_FINISHED))
     } else {
       setErrorMessage(t("errors.invalidPhraseError"))
     }

--- a/ui/pages/Onboarding/Tabbed/Intro.tsx
+++ b/ui/pages/Onboarding/Tabbed/Intro.tsx
@@ -1,4 +1,5 @@
-import { onboardingStarted } from "@tallyho/tally-background/redux-slices/ui"
+import { OneTimeAnalyticsEvent } from "@tallyho/tally-background/lib/posthog"
+import { sendEvent } from "@tallyho/tally-background/redux-slices/ui"
 import React, { ReactElement } from "react"
 import { useTranslation } from "react-i18next"
 import SharedButton from "../../../components/Shared/SharedButton"
@@ -22,7 +23,9 @@ export default function Intro(): ReactElement {
           type="primary"
           size="large"
           linkTo={OnboardingRoutes.ADD_WALLET}
-          onClick={() => dispatch(onboardingStarted())}
+          onClick={() =>
+            dispatch(sendEvent(OneTimeAnalyticsEvent.ONBOARDING_STARTED))
+          }
           center
           style={{
             fontSize: "20px",
@@ -36,7 +39,9 @@ export default function Intro(): ReactElement {
           type="secondary"
           size="large"
           linkTo={OnboardingRoutes.NEW_SEED}
-          onClick={() => dispatch(onboardingStarted())}
+          onClick={() =>
+            dispatch(sendEvent(OneTimeAnalyticsEvent.ONBOARDING_STARTED))
+          }
           center
           style={{
             fontSize: "20px",

--- a/ui/pages/Onboarding/Tabbed/Intro.tsx
+++ b/ui/pages/Onboarding/Tabbed/Intro.tsx
@@ -1,12 +1,15 @@
+import { onboardingStarted } from "@tallyho/tally-background/redux-slices/ui"
 import React, { ReactElement } from "react"
 import { useTranslation } from "react-i18next"
 import SharedButton from "../../../components/Shared/SharedButton"
+import { useBackgroundDispatch } from "../../../hooks"
 import OnboardingRoutes from "./Routes"
 
 export default function Intro(): ReactElement {
   const { t } = useTranslation("translation", {
     keyPrefix: "onboarding.tabbed.intro",
   })
+  const dispatch = useBackgroundDispatch()
 
   return (
     <section className="fadeIn">
@@ -19,6 +22,7 @@ export default function Intro(): ReactElement {
           type="primary"
           size="large"
           linkTo={OnboardingRoutes.ADD_WALLET}
+          onClick={() => dispatch(onboardingStarted())}
           center
           style={{
             fontSize: "20px",
@@ -32,6 +36,7 @@ export default function Intro(): ReactElement {
           type="secondary"
           size="large"
           linkTo={OnboardingRoutes.NEW_SEED}
+          onClick={() => dispatch(onboardingStarted())}
           center
           style={{
             fontSize: "20px",

--- a/ui/pages/Onboarding/Tabbed/Ledger/Ledger.tsx
+++ b/ui/pages/Onboarding/Tabbed/Ledger/Ledger.tsx
@@ -4,6 +4,8 @@ import { ledgerUSBVendorId } from "@ledgerhq/devices"
 import { LedgerProductDatabase } from "@tallyho/tally-background/services/ledger"
 import { useTranslation } from "react-i18next"
 import { useHistory } from "react-router-dom"
+import { sendEvent } from "@tallyho/tally-background/redux-slices/ui"
+import { OneTimeAnalyticsEvent } from "@tallyho/tally-background/lib/posthog"
 import LedgerPanelContainer from "../../../../components/Ledger/LedgerPanelContainer"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../../../hooks"
 import LedgerImportAccounts from "./LedgerImportAccounts"
@@ -90,6 +92,7 @@ export default function Ledger(): ReactElement {
         <LedgerImportAccounts
           device={device}
           onConnect={() => {
+            dispatch(sendEvent(OneTimeAnalyticsEvent.ONBOARDING_FINISHED))
             history.push(OnboardingRoutes.ONBOARDING_COMPLETE)
           }}
         />

--- a/ui/pages/Onboarding/Tabbed/NewSeed/NewSeedVerify.tsx
+++ b/ui/pages/Onboarding/Tabbed/NewSeed/NewSeedVerify.tsx
@@ -1,9 +1,12 @@
+import { OneTimeAnalyticsEvent } from "@tallyho/tally-background/lib/posthog"
+import { sendEvent } from "@tallyho/tally-background/redux-slices/ui"
 import classNames from "classnames"
 import React, { ReactElement, useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 import SharedButton from "../../../../components/Shared/SharedButton"
 import SharedIcon from "../../../../components/Shared/SharedIcon"
+import { useBackgroundDispatch } from "../../../../hooks"
 import OnboardingTip from "../OnboardingTip"
 import OnboardingRoutes from "../Routes"
 
@@ -120,6 +123,8 @@ export default function NewSeedVerify({
     keyPrefix: "onboarding.tabbed.newWalletVerify",
   })
 
+  const dispatch = useBackgroundDispatch()
+
   const SEED_WORDS_TO_VERIFY = 8
 
   const randomIndexes = useMemo(
@@ -165,6 +170,10 @@ export default function NewSeedVerify({
 
     setSubmitted(true)
     setIsValidSeed(isValid)
+
+    if (isValid) {
+      dispatch(sendEvent(OneTimeAnalyticsEvent.ONBOARDING_FINISHED))
+    }
   }
 
   const handleAdd = (wordIndex: number) => {


### PR DESCRIPTION
This PR adds two analytics events:
- Onboarding Started - sent when a user clicks either the `Use Existing Wallet` or `Create new wallet` buttons in onboarding.
- Onboarding Finished - went when a user successfully creates a new wallet, imports a wallet, or connects via ledger.

Importantly the `Onboarding Finished` event is _not_ sent when a user adds a read_only address.

### To Test
- [x] Install Taho, create new wallet , make sure analytics events show up in posthog
- [x] Install Taho, import wallet , make sure analytics events show up in posthog
- [x] Install Taho, import ledger , make sure analytics events show up in posthog
- [x] After importing a wallet, import another wallet, there should not be a duplicate Onboarding Finished event in posthog
- [x] checkout main, import wallet, upgrade to onboarding-analytics version, there should not be an Onboarding Started or Onboarding Finished event sent.

Latest build: [extension-builds-3215](https://github.com/tahowallet/extension/suites/11954553841/artifacts/626844075) (as of Fri, 31 Mar 2023 21:08:37 GMT).