### PR TITLE
Add title to NFT market links

### DIFF
--- a/e2e-tests/utils/onboarding.ts
+++ b/e2e-tests/utils/onboarding.ts
@@ -45,7 +45,9 @@ export default class OnboardingHelper {
       expect(onboarding).toHaveURL(/onboarding/)
     }).toPass()
 
-    const onboarding = this.context.pages().at(-1)
+    const onboarding = this.context
+      .pages()
+      .find((page) => /onboarding/.test(page.url()))
 
     if (!onboarding) {
       // Should never happen

--- a/ui/components/NFTS_update/ExploreMarketLink.tsx
+++ b/ui/components/NFTS_update/ExploreMarketLink.tsx
@@ -200,9 +200,15 @@ function ExploreMarketIcon(props: ExploreMarketIconProps): ReactElement {
 export default function ExploreMarketLink(
   props: ExploreMarketLinkProps
 ): ReactElement {
-  const { type, url } = props
+  const { type, title, url } = props
   return (
-    <a className={type} href={url} rel="noreferrer" target="_blank">
+    <a
+      className={type}
+      title={title}
+      href={url}
+      rel="noreferrer"
+      target="_blank"
+    >
       {type === "button" ? (
         // As we know how props are going to look like let's spread them
         // eslint-disable-next-line react/jsx-props-no-spreading


### PR DESCRIPTION
The missing `title` was causing the NFT E2E test locator to fail

## To Test
- [x] E2E tests on this branch should pass

Latest build: [extension-builds-3234](https://github.com/tahowallet/extension/suites/11996957930/artifacts/629886232) (as of Mon, 03 Apr 2023 16:48:32 GMT).