### PR TITLE
Add analytics event when connecting to a Dapp

### DIFF
--- a/background/lib/posthog.ts
+++ b/background/lib/posthog.ts
@@ -7,6 +7,7 @@ export enum AnalyticsEvent {
   NEW_INSTALL = "New install",
   UI_SHOWN = "UI shown",
   NEW_ACCOUNT_TO_TRACK = "Address added to tracking on network",
+  DAPP_CONNECTED = "Dapp Connected",
 }
 
 export enum OneTimeAnalyticsEvent {

--- a/background/main.ts
+++ b/background/main.ts
@@ -1407,6 +1407,10 @@ export default class Main extends BaseService<never> {
     )
 
     providerBridgeSliceEmitter.on("grantPermission", async (permission) => {
+      this.analyticsService.sendAnalyticsEvent(AnalyticsEvent.DAPP_CONNECTED, {
+        origin: permission.origin,
+        chainId: permission.chainID,
+      })
       await Promise.all(
         this.chainService.supportedNetworks.map(async (network) => {
           await this.providerBridgeService.grantPermission({


### PR DESCRIPTION
### To Test
- [ ] Connect to a new dapp
- [ ] Observe the `Dapp Connected` event in posthog.  It should have the chain id and origin of the dapp sent along with the event.

Latest build: [extension-builds-3235](https://github.com/tahowallet/extension/suites/11998160789/artifacts/629966676) (as of Mon, 03 Apr 2023 17:36:50 GMT).