### PR TITLE
Add custom chain analytics event

### DIFF
--- a/background/lib/posthog.ts
+++ b/background/lib/posthog.ts
@@ -7,6 +7,7 @@ export enum AnalyticsEvent {
   NEW_INSTALL = "New install",
   UI_SHOWN = "UI shown",
   NEW_ACCOUNT_TO_TRACK = "Address added to tracking on network",
+  CUSTOM_CHAIN_ADDED = "Custom chain added",
 }
 
 export enum OneTimeAnalyticsEvent {

--- a/background/main.ts
+++ b/background/main.ts
@@ -1654,6 +1654,7 @@ export default class Main extends BaseService<never> {
                 This event is fired when a custom chain is added to the wallet.
                 `,
           chainInfo: chainInfo.chainName,
+          chainId: chainInfo.chainId,
         }
       )
     })

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -132,6 +132,7 @@ interface Events extends ServiceLifecycleEvents {
   block: AnyEVMBlock
   transaction: { forAccounts: string[]; transaction: AnyEVMTransaction }
   blockPrices: { blockPrices: BlockPrices; network: EVMNetwork }
+  customChainAdded: ValidatedAddEthereumChainParameter
 }
 
 export type QueuedTxToRetrieve = {
@@ -1898,6 +1899,8 @@ export default class ChainService extends BaseService<Events> {
     )
 
     await this.startTrackingNetworkOrThrow(chainInfo.chainId)
+
+    this.emitter.emit("customChainAdded", chainInfo)
   }
 
   async removeCustomChain(chainID: string): Promise<void> {

--- a/background/tests/factories.ts
+++ b/background/tests/factories.ts
@@ -138,10 +138,7 @@ export async function createAnalyticsService(overrides?: {
 }): Promise<AnalyticsService> {
   const preferenceService =
     overrides?.preferenceService ?? createPreferenceService()
-  return AnalyticsService.create(
-    overrides?.chainService ?? createChainService({ preferenceService }),
-    preferenceService
-  )
+  return AnalyticsService.create(preferenceService)
 }
 
 export const createSigningService = async (


### PR DESCRIPTION
### To Test
- [ ] Add a custom chain to the wallet
- [ ] Observe the `Custom Chain Added` event in posthog.

Latest build: [extension-builds-3236](https://github.com/tahowallet/extension/suites/12046398882/artifacts/633415473) (as of Wed, 05 Apr 2023 13:17:48 GMT).