### PR TITLE
Impersonate Metamask on kyberswap

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -58,6 +58,7 @@ const impersonateMetamaskWhitelist = [
   "alchemy.com",
   "cow.fi",
   "tally.xyz",
+  "kyberswap.com",
 ]
 
 const METAMASK_STATE_MOCK = {


### PR DESCRIPTION
Allows to use kyberswap.com with Taho

Latest build: [extension-builds-3239](https://github.com/tahowallet/extension/suites/12000893632/artifacts/630245077) (as of Mon, 03 Apr 2023 20:56:26 GMT).