### PR TITLE
Add plumbing to allow for tokens to be imported via contract address

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -37,7 +37,7 @@ import {
 } from "./services"
 
 import { HexString, KeyringTypes, NormalizedEVMAddress } from "./types"
-import { SignedTransaction } from "./networks"
+import { EVMNetwork, SignedTransaction } from "./networks"
 import { AccountBalance, AddressOnNetwork, NameOnNetwork } from "./accounts"
 import { Eligible } from "./services/doggo/types"
 
@@ -1727,6 +1727,16 @@ export default class Main extends BaseService<never> {
 
   async removeEVMNetwork(chainID: string): Promise<void> {
     return this.chainService.removeCustomChain(chainID)
+  }
+
+  async importTokenViaContractAddress(
+    contractAddress: HexString,
+    network: EVMNetwork
+  ): Promise<void> {
+    return this.indexingService.addTokenToTrackByContract(
+      network,
+      contractAddress
+    )
   }
 
   private connectPopupMonitor() {

--- a/background/redux-slices/assets.ts
+++ b/background/redux-slices/assets.ts
@@ -18,7 +18,7 @@ import {
   sameBuiltInNetworkBaseAsset,
 } from "./utils/asset-utils"
 import { getProvider } from "./utils/contract-utils"
-import { sameNetwork } from "../networks"
+import { EVMNetwork, sameNetwork } from "../networks"
 import { ERC20_INTERFACE } from "../lib/erc20"
 import logger from "../lib/logger"
 import {
@@ -26,6 +26,7 @@ import {
   FIAT_CURRENCIES_SYMBOL,
 } from "../constants"
 import { convertFixedPoint } from "../lib/fixed-point"
+import { HexString } from "../types"
 
 export type AssetWithRecentPrices<T extends AnyAsset = AnyAsset> = T & {
   recentPrices: {
@@ -277,5 +278,18 @@ export const selectAssetPricePoint = createSelector(
 
     // If no matching priced asset was found, return undefined.
     return undefined
+  }
+)
+
+export const importTokenViaContractAddress = createBackgroundAsyncThunk(
+  "assets/importTokenViaContractAddress",
+  async (
+    {
+      contractAddress,
+      network,
+    }: { contractAddress: HexString; network: EVMNetwork },
+    { extra: { main } }
+  ) => {
+    await main.importTokenViaContractAddress(contractAddress, network)
   }
 )

--- a/background/services/chain/db.ts
+++ b/background/services/chain/db.ts
@@ -278,6 +278,14 @@ export class ChainDatabase extends Dexie {
     return this.networks.where("family").equals("EVM").toArray()
   }
 
+  async getEVMNetworkByChainID(
+    chainID: string
+  ): Promise<EVMNetwork | undefined> {
+    return (await this.networks.where("family").equals("EVM").toArray()).find(
+      (network) => network.chainID === chainID
+    )
+  }
+
   private async addBaseAsset(
     name: string,
     symbol: string,

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -21,7 +21,7 @@ import {
   NetworkBaseAsset,
   sameChainID,
 } from "../../networks"
-import { AssetTransfer, SmartContractFungibleAsset } from "../../assets"
+import { AssetTransfer } from "../../assets"
 import {
   HOUR,
   ETHEREUM,
@@ -1917,16 +1917,5 @@ export default class ChainService extends BaseService<Events> {
 
     this.supportedNetworks = supportedNetworks
     this.emitter.emit("supportedNetworks", supportedNetworks)
-  }
-
-  async getTokenMetadata(
-    contractAddress: HexString,
-    network: EVMNetwork
-  ): Promise<SmartContractFungibleAsset | undefined> {
-    const assetMetadata = await this.assetData.getTokenMetadata({
-      homeNetwork: network,
-      contractAddress,
-    })
-    return assetMetadata
   }
 }

--- a/background/services/chain/tests/db.integration.test.ts
+++ b/background/services/chain/tests/db.integration.test.ts
@@ -335,4 +335,26 @@ describe("Chain Database ", () => {
       expect(assetTransferLookups[0].endBlock).toEqual(1n)
     })
   })
+
+  describe("addEVMNetwork", () => {
+    it("Should correctly add a network, baseAsset, and rpcURL(s) when adding an evm network", async () => {
+      await db.addEVMNetwork({
+        chainName: "Foo",
+        chainID: "12345",
+        decimals: 18,
+        symbol: "BAR",
+        assetName: "Foocoin",
+        rpcUrls: ["https://foo.com"],
+      })
+
+      expect(await db.getEVMNetworkByChainID("12345")).toBeTruthy()
+      expect(
+        (await db.getAllRpcUrls()).find((rpcUrl) =>
+          rpcUrl.rpcUrls.includes("https://foo.com")
+        )
+      ).toBeTruthy()
+
+      expect(await db.getBaseAssetForNetwork("12345")).toBeTruthy()
+    })
+  })
 })

--- a/background/services/chain/tests/index.integration.test.ts
+++ b/background/services/chain/tests/index.integration.test.ts
@@ -446,4 +446,45 @@ describe("ChainService", () => {
       ).toBe(CHAIN_NONCE)
     })
   })
+
+  describe("getNetworksToTrack", () => {
+    it("Should fetch built-in and custom networks to track", async () => {
+      await chainService.addCustomChain({
+        chainName: "Foo",
+        chainId: "12345",
+        nativeCurrency: {
+          name: "FooCoin",
+          symbol: "FOO",
+          decimals: 18,
+        },
+        rpcUrls: ["https://foo.com"],
+        blockExplorerUrl: "https://fooscanner.com",
+      })
+
+      await chainService.addAccountToTrack({
+        address: "0x123",
+        network: {
+          name: "Foo",
+          chainID: "12345",
+          family: "EVM",
+          baseAsset: {
+            decimals: 18,
+            symbol: "FOO",
+            name: "FooCoin",
+            chainID: "12345",
+          },
+        },
+      })
+
+      await chainService.addAccountToTrack({
+        address: "0x123",
+        network: ETHEREUM,
+      })
+      const networksToTrack = await chainService.getNetworksToTrack()
+
+      expect(
+        networksToTrack.find((network) => network.chainID === "12345")
+      ).toBeTruthy()
+    })
+  })
 })

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -587,7 +587,7 @@ export default class IndexingService extends BaseService<Events> {
    *        fungible asset. Useful in case this asset isn't found in existing
    *        metadata.
    */
-  private async addTokenToTrackByContract(
+  async addTokenToTrackByContract(
     network: EVMNetwork,
     contractAddress: string
   ): Promise<void> {


### PR DESCRIPTION
In addition to adding a path for importing tokens via _just_ their contract address - this PR fixes two important bugs related to custom networks.

1) Custom networks were not being returned from the `getNetworksToTrack` method. https://github.com/tahowallet/extension/commit/4382083c35bc5787be33cac75f2f1815cb609435
2) Balance checks on all networks were failing during the initial balance check on extension startup. https://github.com/tahowallet/extension/commit/63cbd8263c70df5ffebc198e32f3387d60d0c897

### To Test
- [ ] Import the moonbeam network into the wallet
Add the following snippet inside of `internalStartService` in `main.ts`.

```
    ;(window as any).chainService = this.chainService

    this.indexingService.addCustomAssetViaContractAddress(
      "0x4EdF8E0778967012D46968ceadb75436d0426f88",
      {
        chainID: "1284",
        coingeckoPlatformID: "moonbeam",
        family: "EVM",
        name: "Moonbeam",
      } as any
    )
```
- [ ] Refresh the extension
- [ ] You should see `BEPRO` token in the `customAssets` table of `indexingService`'s indexedDB instance.
- [ ] You should see the `indexingService.retrieveTokenBalances` get called with the BEPRO token contract address as one of the parameters when the balance alarm runs (you'll need to add logs to verify this, remember to keep moonbeam network active to keep the alarm running).
- [ ] Typing `chainService.getNetworksToTrack()` in the dev console should yield an array that includes the `Moonbeam` network.
- [ ] The initial call of `handleBalanceAlarm` should not be checking an empty array of token balances (will need to add logs to verify this as well).

Latest build: [extension-builds-3240](https://github.com/tahowallet/extension/suites/12025229006/artifacts/631884311) (as of Tue, 04 Apr 2023 16:55:49 GMT).