### PR TITLE
Custom Networks - Update Protocol List Footer

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -705,9 +705,7 @@
     "protocolList": {
       "testnetsSectionTitle": "Testnets",
       "customNetworksSectionTitle": "Custom networks",
-      "customRPCFooterTitle": "Activate or add networks",
-      "customRPCFooterDesc": "You can activate any network that is already added to Taho or you can add any other network.",
-      "networkSettingsBtn": "Network settings"
+      "networkSettingsBtn": "Add network"
     },
     "connectedDappInfo": {
       "modalClose": "Background close",

--- a/ui/components/Shared/SharedSlideUpMenu.tsx
+++ b/ui/components/Shared/SharedSlideUpMenu.tsx
@@ -25,6 +25,7 @@ type Props = {
   isDark?: boolean
   alwaysRenderChildren?: boolean
   testid?: string
+  customStyles?: React.CSSProperties & Record<string, string>
 }
 
 const menuHeights: Record<SharedSlideUpMenuSize, string | null> = {
@@ -46,6 +47,7 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
     isScrollable,
     alwaysRenderChildren,
     testid = "slide_up_menu",
+    customStyles = {},
   } = props
 
   const slideUpMenuRef = useRef(null)
@@ -71,7 +73,9 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
           closed: !isOpen,
         })}
         data-testid={testid}
-        style={{ "--menu-height": menuHeight } as CSSProperties}
+        style={
+          { "--menu-height": menuHeight, ...customStyles } as CSSProperties
+        }
         ref={isOpen ? slideUpMenuRef : null}
       >
         <div
@@ -144,11 +148,10 @@ export default function SharedSlideUpMenu(props: Props): ReactElement {
             pointer-events: none;
           }
           .slide_up_close {
-            position: sticky;
+            position: absolute;
             z-index: 2;
-            top: 0px;
+            top: 24px;
             right: 24px;
-            float: right;
           }
           .slide_up_close.hover_content {
             position: absolute;

--- a/ui/components/TopMenu/TopMenu.tsx
+++ b/ui/components/TopMenu/TopMenu.tsx
@@ -104,6 +104,7 @@ export default function TopMenu(): ReactElement {
       <SharedSlideUpMenu
         isOpen={isProtocolListOpen}
         isScrollable
+        customStyles={{ display: "flex", flexDirection: "column" }}
         close={() => {
           setIsProtocolListOpen(false)
         }}

--- a/ui/components/TopMenu/TopMenuProtocolList.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolList.tsx
@@ -63,94 +63,96 @@ export default function TopMenuProtocolList({
   )
 
   return (
-    <div className="standard_width_padded center_horizontal">
-      <div className={classNames(customNetworksEnabled && "networks_list")}>
-        <ul>
-          {builtinNetworks.map((network) => (
-            <TopMenuProtocolListItem
-              isSelected={sameNetwork(currentNetwork, network)}
-              key={network.name}
-              network={network}
-              info={
-                productionNetworkInfo[network.chainID] ||
-                t("protocol.compatibleChain")
-              }
-              onSelect={onProtocolChange}
-              isDisabled={disabledChainIDs.includes(network.chainID)}
-            />
-          ))}
-          {isEnabled(FeatureFlags.SUPPORT_CUSTOM_NETWORKS) &&
-            customNetworks.length > 0 && (
+    <>
+      <div className="standard_width_padded center_horizontal">
+        <div className={classNames(customNetworksEnabled && "networks_list")}>
+          <ul>
+            {builtinNetworks.map((network) => (
+              <TopMenuProtocolListItem
+                isSelected={sameNetwork(currentNetwork, network)}
+                key={network.name}
+                network={network}
+                info={
+                  productionNetworkInfo[network.chainID] ||
+                  t("protocol.compatibleChain")
+                }
+                onSelect={onProtocolChange}
+                isDisabled={disabledChainIDs.includes(network.chainID)}
+              />
+            ))}
+            {isEnabled(FeatureFlags.SUPPORT_CUSTOM_NETWORKS) &&
+              customNetworks.length > 0 && (
+                <>
+                  <li className="protocol_divider">
+                    <div className="divider_label">
+                      {t("topMenu.protocolList.customNetworksSectionTitle")}
+                    </div>
+                    <div className="divider_line" />
+                  </li>
+                  {customNetworks.map((network) => (
+                    <TopMenuProtocolListItem
+                      isSelected={sameNetwork(currentNetwork, network)}
+                      key={network.name}
+                      network={network}
+                      info={t("protocol.compatibleChain")}
+                      onSelect={onProtocolChange}
+                    />
+                  ))}
+                </>
+              )}
+            {showTestNetworks && testNetworks.length > 0 && (
               <>
                 <li className="protocol_divider">
                   <div className="divider_label">
-                    {t("topMenu.protocolList.customNetworksSectionTitle")}
+                    {t("topMenu.protocolList.testnetsSectionTitle")}
                   </div>
                   <div className="divider_line" />
                 </li>
-                {customNetworks.map((network) => (
+                {testNetworks.map((info) => (
                   <TopMenuProtocolListItem
-                    isSelected={sameNetwork(currentNetwork, network)}
-                    key={network.name}
-                    network={network}
-                    info={t("protocol.compatibleChain")}
+                    isSelected={sameNetwork(currentNetwork, info.network)}
+                    key={info.network.name}
+                    network={info.network}
+                    info={info.info}
                     onSelect={onProtocolChange}
+                    isDisabled={info.isDisabled ?? false}
                   />
                 ))}
               </>
             )}
-          {showTestNetworks && testNetworks.length > 0 && (
-            <>
-              <li className="protocol_divider">
-                <div className="divider_label">
-                  {t("topMenu.protocolList.testnetsSectionTitle")}
-                </div>
-                <div className="divider_line" />
-              </li>
-              {testNetworks.map((info) => (
-                <TopMenuProtocolListItem
-                  isSelected={sameNetwork(currentNetwork, info.network)}
-                  key={info.network.name}
-                  network={info.network}
-                  info={info.info}
-                  onSelect={onProtocolChange}
-                  isDisabled={info.isDisabled ?? false}
-                />
-              ))}
-            </>
-          )}
-        </ul>
+          </ul>
+        </div>
+        <style jsx>
+          {`
+            .networks_list {
+              overflow-y: auto;
+              overflow-x: hidden;
+              max-height: 464px;
+            }
+            .protocol_divider {
+              display: flex;
+              margin-bottom: 16px;
+              gap: 15px;
+              margin-top: 32px;
+              position: relative;
+            }
+            .divider_line {
+              flex-grow: 1;
+              align-self: center;
+              background: var(--green-120);
+              height: 1px;
+              margin-top: 1px;
+            }
+            .divider_label {
+              color: var(--green-40);
+              font-size: 16px;
+              font-weight: 500;
+              line-height: 24px;
+            }
+          `}
+        </style>
       </div>
       {customNetworksEnabled && <TopMenuProtocolListFooter />}
-      <style jsx>
-        {`
-          .networks_list {
-            overflow-y: auto;
-            overflow-x: hidden;
-            max-height: 319px;
-          }
-          .protocol_divider {
-            display: flex;
-            margin-bottom: 16px;
-            gap: 15px;
-            margin-top: 32px;
-            position: relative;
-          }
-          .divider_line {
-            flex-grow: 1;
-            align-self: center;
-            background: var(--green-120);
-            height: 1px;
-            margin-top: 1px;
-          }
-          .divider_label {
-            color: var(--green-40);
-            font-size: 16px;
-            font-weight: 500;
-            line-height: 24px;
-          }
-        `}
-      </style>
-    </div>
+    </>
   )
 }

--- a/ui/components/TopMenu/TopMenuProtocolListFooter.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolListFooter.tsx
@@ -1,17 +1,9 @@
 import React from "react"
-import {
-  ARBITRUM_NOVA,
-  ARBITRUM_ONE,
-  BINANCE_SMART_CHAIN,
-  OPTIMISM,
-  POLYGON,
-  ROOTSTOCK,
-} from "@tallyho/tally-background/constants"
+
 import { useTranslation } from "react-i18next"
 import { useHistory } from "react-router-dom"
 import SharedButton from "../Shared/SharedButton"
 import SharedIcon from "../Shared/SharedIcon"
-import { getNetworkIconName } from "../../utils/networks"
 
 export default function TopMenuProtocolListFooter(): JSX.Element {
   const history = useHistory()
@@ -19,33 +11,6 @@ export default function TopMenuProtocolListFooter(): JSX.Element {
 
   return (
     <footer>
-      <h2>{t("topMenu.protocolList.customRPCFooterTitle")}</h2>
-      <p>{t("topMenu.protocolList.customRPCFooterDesc")}</p>
-      <ul className="custom_rpc_icons">
-        {(
-          [
-            [OPTIMISM, 1],
-            [ARBITRUM_ONE, 0.8],
-            [BINANCE_SMART_CHAIN, 0.7],
-            [POLYGON, 0.5],
-            [ARBITRUM_NOVA, 0.3],
-            [ROOTSTOCK, 0.1],
-          ] as const
-        ).map(([network, opacity]) => {
-          const icon = getNetworkIconName(network)
-
-          return (
-            <img
-              key={icon}
-              width="24"
-              height="24"
-              alt={network.name}
-              src={`/images/networks/${icon}@2x.png`}
-              style={{ opacity }}
-            />
-          )
-        })}
-      </ul>
       <SharedButton
         size="medium"
         onClick={() => history.push("/settings/custom-networks")}
@@ -55,7 +20,7 @@ export default function TopMenuProtocolListFooter(): JSX.Element {
           width={16}
           height={16}
           customStyles="margin-right: 4px"
-          icon="icons/s/settings2.svg"
+          icon="icons/s/add.svg"
           color="currentColor"
         />
         {t("topMenu.protocolList.networkSettingsBtn")}
@@ -63,11 +28,12 @@ export default function TopMenuProtocolListFooter(): JSX.Element {
       <style jsx>
         {`
           footer {
+            background: var(--hunter-green);
             display: flex;
             flex-direction: column;
             gap: 8px;
-            margin-top: 8px;
-            margin-bottom: 16px;
+            margin-top: auto;
+            padding: 4px 24px;
           }
 
           footer ul {


### PR DESCRIPTION
Updates footer according to new design for custom networks v1

<img width="379" alt="image" src="https://user-images.githubusercontent.com/28708889/229748544-affe6d7b-845b-4775-9f08-4e4e6d16724e.png">


Closes #3149 

## Testing Env

```
SUPPORT_CUSTOM_NETWORKS=true
SUPPORT_CUSTOM_RPCS=true
```

## To test
- [x] Add a few custom networks
- [x] Check the top menu network switcher

Latest build: [extension-builds-3244](https://github.com/tahowallet/extension/suites/12015063375/artifacts/631180674) (as of Tue, 04 Apr 2023 10:13:53 GMT).