### PR TITLE
Remove sticky positioning from footer in network switcher

### DIFF
--- a/ui/components/TopMenu/TopMenuProtocolList.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolList.tsx
@@ -127,6 +127,9 @@ export default function TopMenuProtocolList({
           .networks_list {
             overflow-y: auto;
             overflow-x: hidden;
+            display: flex;
+            flex-direction: column;
+            min-height: 511px;
           }
 
           ul {
@@ -137,9 +140,9 @@ export default function TopMenuProtocolList({
 
           .protocol_divider {
             display: flex;
+            margin-top: 8px;
             margin-bottom: 16px;
             gap: 15px;
-            margin-top: 32px;
             position: relative;
           }
           .divider_line {

--- a/ui/components/TopMenu/TopMenuProtocolList.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolList.tsx
@@ -63,7 +63,7 @@ export default function TopMenuProtocolList({
   )
 
   return (
-    <div>
+    <div className="container">
       <div className={classNames(customNetworksEnabled && "networks_list")}>
         <ul className="standard_width center_horizontal">
           {builtinNetworks.map((network) => (
@@ -124,12 +124,16 @@ export default function TopMenuProtocolList({
       </div>
       <style jsx>
         {`
+          .container {
+            overflow-y: auto;
+          }
+
           .networks_list {
             overflow-y: auto;
             overflow-x: hidden;
             display: flex;
             flex-direction: column;
-            min-height: 511px;
+            min-height: 512px;
           }
 
           ul {

--- a/ui/components/TopMenu/TopMenuProtocolList.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolList.tsx
@@ -63,7 +63,7 @@ export default function TopMenuProtocolList({
   )
 
   return (
-    <div className="">
+    <div>
       <div className={classNames(customNetworksEnabled && "networks_list")}>
         <ul className="standard_width center_horizontal">
           {builtinNetworks.map((network) => (

--- a/ui/components/TopMenu/TopMenuProtocolList.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolList.tsx
@@ -63,96 +63,100 @@ export default function TopMenuProtocolList({
   )
 
   return (
-    <>
-      <div className="standard_width_padded center_horizontal">
-        <div className={classNames(customNetworksEnabled && "networks_list")}>
-          <ul>
-            {builtinNetworks.map((network) => (
-              <TopMenuProtocolListItem
-                isSelected={sameNetwork(currentNetwork, network)}
-                key={network.name}
-                network={network}
-                info={
-                  productionNetworkInfo[network.chainID] ||
-                  t("protocol.compatibleChain")
-                }
-                onSelect={onProtocolChange}
-                isDisabled={disabledChainIDs.includes(network.chainID)}
-              />
-            ))}
-            {isEnabled(FeatureFlags.SUPPORT_CUSTOM_NETWORKS) &&
-              customNetworks.length > 0 && (
-                <>
-                  <li className="protocol_divider">
-                    <div className="divider_label">
-                      {t("topMenu.protocolList.customNetworksSectionTitle")}
-                    </div>
-                    <div className="divider_line" />
-                  </li>
-                  {customNetworks.map((network) => (
-                    <TopMenuProtocolListItem
-                      isSelected={sameNetwork(currentNetwork, network)}
-                      key={network.name}
-                      network={network}
-                      info={t("protocol.compatibleChain")}
-                      onSelect={onProtocolChange}
-                    />
-                  ))}
-                </>
-              )}
-            {showTestNetworks && testNetworks.length > 0 && (
+    <div className="">
+      <div className={classNames(customNetworksEnabled && "networks_list")}>
+        <ul className="standard_width center_horizontal">
+          {builtinNetworks.map((network) => (
+            <TopMenuProtocolListItem
+              isSelected={sameNetwork(currentNetwork, network)}
+              key={network.name}
+              network={network}
+              info={
+                productionNetworkInfo[network.chainID] ||
+                t("protocol.compatibleChain")
+              }
+              onSelect={onProtocolChange}
+              isDisabled={disabledChainIDs.includes(network.chainID)}
+            />
+          ))}
+          {isEnabled(FeatureFlags.SUPPORT_CUSTOM_NETWORKS) &&
+            customNetworks.length > 0 && (
               <>
                 <li className="protocol_divider">
                   <div className="divider_label">
-                    {t("topMenu.protocolList.testnetsSectionTitle")}
+                    {t("topMenu.protocolList.customNetworksSectionTitle")}
                   </div>
                   <div className="divider_line" />
                 </li>
-                {testNetworks.map((info) => (
+                {customNetworks.map((network) => (
                   <TopMenuProtocolListItem
-                    isSelected={sameNetwork(currentNetwork, info.network)}
-                    key={info.network.name}
-                    network={info.network}
-                    info={info.info}
+                    isSelected={sameNetwork(currentNetwork, network)}
+                    key={network.name}
+                    network={network}
+                    info={t("protocol.compatibleChain")}
                     onSelect={onProtocolChange}
-                    isDisabled={info.isDisabled ?? false}
                   />
                 ))}
               </>
             )}
-          </ul>
-        </div>
-        <style jsx>
-          {`
-            .networks_list {
-              overflow-y: auto;
-              overflow-x: hidden;
-              max-height: 464px;
-            }
-            .protocol_divider {
-              display: flex;
-              margin-bottom: 16px;
-              gap: 15px;
-              margin-top: 32px;
-              position: relative;
-            }
-            .divider_line {
-              flex-grow: 1;
-              align-self: center;
-              background: var(--green-120);
-              height: 1px;
-              margin-top: 1px;
-            }
-            .divider_label {
-              color: var(--green-40);
-              font-size: 16px;
-              font-weight: 500;
-              line-height: 24px;
-            }
-          `}
-        </style>
+          {showTestNetworks && testNetworks.length > 0 && (
+            <>
+              <li className="protocol_divider">
+                <div className="divider_label">
+                  {t("topMenu.protocolList.testnetsSectionTitle")}
+                </div>
+                <div className="divider_line" />
+              </li>
+              {testNetworks.map((info) => (
+                <TopMenuProtocolListItem
+                  isSelected={sameNetwork(currentNetwork, info.network)}
+                  key={info.network.name}
+                  network={info.network}
+                  info={info.info}
+                  onSelect={onProtocolChange}
+                  isDisabled={info.isDisabled ?? false}
+                />
+              ))}
+            </>
+          )}
+        </ul>
+        {customNetworksEnabled && <TopMenuProtocolListFooter />}
       </div>
-      {customNetworksEnabled && <TopMenuProtocolListFooter />}
-    </>
+      <style jsx>
+        {`
+          .networks_list {
+            overflow-y: auto;
+            overflow-x: hidden;
+          }
+
+          ul {
+            display: flex;
+            padding: 0 24px;
+            flex-direction: column;
+          }
+
+          .protocol_divider {
+            display: flex;
+            margin-bottom: 16px;
+            gap: 15px;
+            margin-top: 32px;
+            position: relative;
+          }
+          .divider_line {
+            flex-grow: 1;
+            align-self: center;
+            background: var(--green-120);
+            height: 1px;
+            margin-top: 1px;
+          }
+          .divider_label {
+            color: var(--green-40);
+            font-size: 16px;
+            font-weight: 500;
+            line-height: 24px;
+          }
+        `}
+      </style>
+    </div>
   )
 }


### PR DESCRIPTION
Per @VladUXUI clarification, the footer in the network switcher should not be fixed at the bottom.

<img width="378" alt="image" src="https://user-images.githubusercontent.com/28708889/229808651-487dcfdd-cf00-4512-82e4-8e315fd3766e.png">

## To Test
- [x] Verify that the add network button appears at the end of the network list, rather than staying fixed at the bottom of the screen.

Latest build: [extension-builds-3246](https://github.com/tahowallet/extension/suites/12042306255/artifacts/633141626) (as of Wed, 05 Apr 2023 10:09:24 GMT).