### PR TITLE
More Analytics Events

### DIFF
--- a/background/lib/posthog.ts
+++ b/background/lib/posthog.ts
@@ -6,6 +6,7 @@ import logger from "./logger"
 export enum AnalyticsEvent {
   NEW_INSTALL = "New install",
   UI_SHOWN = "UI shown",
+  DEFAULT_WALLET_TOGGLED = "Default Wallet Toggled",
   TRANSACTION_SIGNED = "Transaction Signed",
   NEW_ACCOUNT_TO_TRACK = "Address added to tracking on network",
   DAPP_CONNECTED = "Dapp Connected",

--- a/background/lib/posthog.ts
+++ b/background/lib/posthog.ts
@@ -6,6 +6,7 @@ import logger from "./logger"
 export enum AnalyticsEvent {
   NEW_INSTALL = "New install",
   UI_SHOWN = "UI shown",
+  ACCOUNT_NAME_EDITED = "Account Name Edited",
   DEFAULT_WALLET_TOGGLED = "Default Wallet Toggled",
   TRANSACTION_SIGNED = "Transaction Signed",
   NEW_ACCOUNT_TO_TRACK = "Address added to tracking on network",

--- a/background/lib/posthog.ts
+++ b/background/lib/posthog.ts
@@ -7,6 +7,7 @@ export enum AnalyticsEvent {
   NEW_INSTALL = "New install",
   UI_SHOWN = "UI shown",
   ACCOUNT_NAME_EDITED = "Account Name Edited",
+  ANALYTICS_TOGGLED = "Analytics Toggled",
   DEFAULT_WALLET_TOGGLED = "Default Wallet Toggled",
   TRANSACTION_SIGNED = "Transaction Signed",
   NEW_ACCOUNT_TO_TRACK = "Address added to tracking on network",

--- a/background/lib/posthog.ts
+++ b/background/lib/posthog.ts
@@ -17,6 +17,7 @@ export enum AnalyticsEvent {
 export enum OneTimeAnalyticsEvent {
   ONBOARDING_STARTED = "Onboarding Started",
   ONBOARDING_FINISHED = "Onboarding Finished",
+  CHAIN_ADDED = "Chain Added",
 }
 
 export const isOneTimeAnalyticsEvent = (

--- a/background/lib/posthog.ts
+++ b/background/lib/posthog.ts
@@ -6,6 +6,7 @@ import logger from "./logger"
 export enum AnalyticsEvent {
   NEW_INSTALL = "New install",
   UI_SHOWN = "UI shown",
+  TRANSACTION_SIGNED = "Transaction Signed",
   NEW_ACCOUNT_TO_TRACK = "Address added to tracking on network",
   DAPP_CONNECTED = "Dapp Connected",
 }

--- a/background/main.ts
+++ b/background/main.ts
@@ -1662,6 +1662,13 @@ export default class Main extends BaseService<never> {
             analyticsPreferences.isEnabled
           )
         )
+
+        this.analyticsService.sendAnalyticsEvent(
+          AnalyticsEvent.ANALYTICS_TOGGLED,
+          {
+            analyticsEnabled: analyticsPreferences.isEnabled,
+          }
+        )
       }
     )
 

--- a/background/main.ts
+++ b/background/main.ts
@@ -863,7 +863,10 @@ export default class Main extends BaseService<never> {
             await this.signingService.signTransaction(request, accountSigner)
           await this.store.dispatch(transactionSigned(signedTransactionResult))
           this.analyticsService.sendAnalyticsEvent(
-            AnalyticsEvent.TRANSACTION_SIGNED
+            AnalyticsEvent.TRANSACTION_SIGNED,
+            {
+              chainId: request.chainID,
+            }
           )
         } catch (exception) {
           logger.error("Error signing transaction", exception)
@@ -1509,6 +1512,12 @@ export default class Main extends BaseService<never> {
 
         this.providerBridgeService.notifyContentScriptAboutConfigChange(
           newDefaultWalletValue
+        )
+        this.analyticsService.sendAnalyticsEvent(
+          AnalyticsEvent.DEFAULT_WALLET_TOGGLED,
+          {
+            setToDefault: newDefaultWalletValue,
+          }
         )
       }
     )

--- a/background/main.ts
+++ b/background/main.ts
@@ -601,6 +601,7 @@ export default class Main extends BaseService<never> {
       network,
       name,
     })
+    this.analyticsService.sendAnalyticsEvent(AnalyticsEvent.ACCOUNT_NAME_EDITED)
   }
 
   async removeAccount(

--- a/background/main.ts
+++ b/background/main.ts
@@ -862,6 +862,9 @@ export default class Main extends BaseService<never> {
           const signedTransactionResult =
             await this.signingService.signTransaction(request, accountSigner)
           await this.store.dispatch(transactionSigned(signedTransactionResult))
+          this.analyticsService.sendAnalyticsEvent(
+            AnalyticsEvent.TRANSACTION_SIGNED
+          )
         } catch (exception) {
           logger.error("Error signing transaction", exception)
           this.store.dispatch(

--- a/background/main.ts
+++ b/background/main.ts
@@ -167,7 +167,11 @@ import {
   initAbilities,
 } from "./redux-slices/abilities"
 import { AddChainRequestData } from "./services/provider-bridge"
-import { AnalyticsEvent, isOneTimeAnalyticsEvent } from "./lib/posthog"
+import {
+  AnalyticsEvent,
+  isOneTimeAnalyticsEvent,
+  OneTimeAnalyticsEvent,
+} from "./lib/posthog"
 import { isBuiltInNetworkBaseAsset } from "./redux-slices/utils/asset-utils"
 
 // This sanitizer runs on store and action data before serializing for remote
@@ -1649,6 +1653,17 @@ export default class Main extends BaseService<never> {
   async connectAnalyticsService(): Promise<void> {
     this.analyticsService.emitter.on("enableDefaultOn", () => {
       this.store.dispatch(setShowAnalyticsNotification(true))
+    })
+
+    this.chainService.emitter.on("networkSubscribed", (network) => {
+      this.analyticsService.sendOneTimeAnalyticsEvent(
+        OneTimeAnalyticsEvent.CHAIN_ADDED,
+        {
+          chainId: network.chainID,
+          name: network.name,
+          description: `This event is fired when a chain is subscribed to from the wallet for the first time.`,
+        }
+      )
     })
 
     this.preferenceService.emitter.on(

--- a/background/services/analytics/index.ts
+++ b/background/services/analytics/index.ts
@@ -102,7 +102,11 @@ export default class AnalyticsService extends BaseService<Events> {
     // @TODO: implement event batching
 
     const { isEnabled } = await this.preferenceService.getAnalyticsPreferences()
-    if (isEnabled) {
+    // We want to send the ANALYTICS_TOGGLED event to denote that the user
+    // has disabled analytics - and we send the event after disabling, so
+    // we have a special exception here to allow the event to send even
+    // after analytics have been set to disabled in the preferenceService.
+    if (eventName === AnalyticsEvent.ANALYTICS_TOGGLED || isEnabled) {
       const { uuid } = await this.getOrCreateAnalyticsUUID()
 
       sendPosthogEvent(uuid, eventName, payload)

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -124,6 +124,7 @@ interface Events extends ServiceLifecycleEvents {
     addressOnNetwork: AddressOnNetwork
   }
   transactionSend: HexString
+  networkSubscribed: EVMNetwork
   transactionSendFailure: undefined
   assetTransfers: {
     addressNetwork: AddressOnNetwork
@@ -419,6 +420,8 @@ export default class ChainService extends BaseService<Events> {
     } else {
       logger.error(`Couldn't find provider for network ${network.name}`)
     }
+
+    this.emitter.emit("networkSubscribed", network)
   }
 
   /**


### PR DESCRIPTION
### To Test
#### Chain Added Event
- [x] checkout `main`.
- [x] Add a wallet.
- [x] Activate a few networks other than `Ethereum` in that wallet.
- [x] Upgrade to this branch.
- [x] You should see events for the previously added network in posthog.
- [x] Add yet another network.
- [x] You should see an event in posthog corresponding to that network.

#### Transaction Signed Event
- [x] Sign a transaction, you should see a corresponding event in posthog.

#### Default Wallet Toggled Event
- [x] Toggle on and off of default a few times , you should see corresponding events in posthog.

#### Edit Account Name Event
- [x] Edit the name of one of your accounts, you should see a corresponding event in posthog.

#### Analytics Toggled Signed Event
- [x] Turn analytics off, you should see a corresponding event in posthog.

Latest build: [extension-builds-3251](https://github.com/tahowallet/extension/suites/12047061858/artifacts/633461910) (as of Wed, 05 Apr 2023 13:43:45 GMT).