### PR TITLE
Update link to the Discord channel for bug reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: >-
-        Thanks for taking the time to fill out this bug report! Note that bug reports should start [in Discord](https://discord.gg/wn3KDAF5eU). Please file them as issues only when suggested by a moderator so that issues can be kept organized.
+        Thanks for taking the time to fill out this bug report! Note that bug reports should start [in Discord](https://discord.gg/cw84Ae5UQt). Please file them as issues only when suggested by a moderator so that issues can be kept organized.
   - type: input
     id: discord-link
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: "Discord #feature-requests"
     url: https://discord.gg/hxeQC5wxzf
     about: Please discuss feature requests here before filing an issue.
-  - name: "Discord #feedback for bugs"
-    url: https://discord.gg/wn3KDAF5eU
+  - name: "Discord #bug-reports for bugs"
+    url: https://discord.gg/cw84Ae5UQt
     about: Please discuss bugs here before filing an issue.


### PR DESCRIPTION
We've been linking the `#feedback` Discord channel on the New GH Issue landing page. The channel no longer exists and the `#bug-report` channel is now a designated place for bug reporting in Discord.
Updating name of the channel and the invite link. The invite link does not have the expiry date and allows for unlimited use.

Latest build: [extension-builds-3258](https://github.com/tahowallet/extension/suites/12092805225/artifacts/636786921) (as of Fri, 07 Apr 2023 11:57:13 GMT).