### PR TITLE
Style update for portfolio

### DIFF
--- a/ui/components/Overview/OverviewAssetsTable.tsx
+++ b/ui/components/Overview/OverviewAssetsTable.tsx
@@ -129,9 +129,6 @@ export default function OverviewAssetsTable(props: Props): ReactElement {
           text-align: right;
           margin-top: 3px;
         }
-        .lighter_color {
-          color: var(--green-60);
-        }
         .asset_name {
           margin-left: 7px;
         }

--- a/ui/components/Overview/OverviewAssetsTable.tsx
+++ b/ui/components/Overview/OverviewAssetsTable.tsx
@@ -1,8 +1,6 @@
 import React, { ReactElement } from "react"
 import { useTranslation } from "react-i18next"
 import { CompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
-import { FeatureFlags, isEnabled } from "@tallyho/tally-background/features"
-import classNames from "classnames"
 import SharedAssetIcon from "../Shared/SharedAssetIcon"
 import SharedLoadingSpinner from "../Shared/SharedLoadingSpinner"
 
@@ -34,87 +32,62 @@ export default function OverviewAssetsTable(props: Props): ReactElement {
   }
 
   return (
-    <table
-      className={classNames(
-        "assets_table standard_width",
-        isEnabled(FeatureFlags.SUPPORT_NFT_TAB) && "nft-update"
-      )}
-    >
-      <thead>
-        <tr>
-          <th>
-            {isEnabled(FeatureFlags.SUPPORT_NFT_TAB)
-              ? `${t("overview.tableHeader.assets")} (${assets.length})`
-              : t("overview.tableHeader.asset")}
-          </th>
-          <th>{t("overview.tableHeader.price")}</th>
-          <th>{t("overview.tableHeader.balance")}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {assets.sort(assetSortCompare).map((asset) => (
-          <tr key={asset.asset.metadata?.coinGeckoID || asset.asset.symbol}>
-            <td>
-              <div className="asset_descriptor">
-                <SharedAssetIcon
-                  size="small"
-                  logoURL={asset?.asset?.metadata?.logoURL}
-                  symbol={asset?.asset?.symbol}
-                />
-                <span className="asset_name">{asset.asset.symbol}</span>
-              </div>
-            </td>
-            <td>
-              {asset.localizedUnitPrice ? (
-                <div>
-                  <span className="lighter_color">$</span>
-                  {asset.localizedUnitPrice}
-                </div>
-              ) : (
-                <div className="loading_wrap">
-                  {initializationLoadingTimeExpired ? (
-                    <></>
-                  ) : (
-                    <SharedLoadingSpinner size="small" />
-                  )}
-                </div>
-              )}
-            </td>
-            <td>
-              {asset.localizedMainCurrencyAmount && (
-                <div>
-                  <span className="lighter_color">$</span>
-                  {asset.localizedMainCurrencyAmount}
-                </div>
-              )}
-              <div className="balance_token_amount">
-                {asset.localizedDecimalAmount}
-              </div>
-            </td>
+    <div>
+      <span>{`${t("overview.tableHeader.asset")} (${assets.length})`}</span>
+      <table className="assets_table standard_width">
+        <thead>
+          <tr>
+            <th>{t("overview.tableHeader.assets")}</th>
+            <th>{t("overview.tableHeader.price")}</th>
+            <th>{t("overview.tableHeader.balance")}</th>
           </tr>
-        ))}
-      </tbody>
-      <style jsx>{`
+        </thead>
+        <tbody>
+          {assets.sort(assetSortCompare).map((asset) => (
+            <tr key={asset.asset.metadata?.coinGeckoID || asset.asset.symbol}>
+              <td>
+                <div className="asset_descriptor">
+                  <SharedAssetIcon
+                    size="small"
+                    logoURL={asset?.asset?.metadata?.logoURL}
+                    symbol={asset?.asset?.symbol}
+                  />
+                  <span className="asset_name">{asset.asset.symbol}</span>
+                </div>
+              </td>
+              <td>
+                {asset.localizedUnitPrice ? (
+                  <div>${asset.localizedUnitPrice}</div>
+                ) : (
+                  <div className="loading_wrap">
+                    {initializationLoadingTimeExpired ? (
+                      <></>
+                    ) : (
+                      <SharedLoadingSpinner size="small" />
+                    )}
+                  </div>
+                )}
+              </td>
+              <td>
+                {asset.localizedMainCurrencyAmount && (
+                  <div>${asset.localizedMainCurrencyAmount}</div>
+                )}
+                <div className="balance_token_amount">
+                  {asset.localizedDecimalAmount}
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <style jsx>{`
         .assets_table {
-          margin: 8px 0;
+          margin: 20px 0;
         }
         tr {
           height: 55px;
         }
         thead tr {
           height 32px;
-        }
-
-        .assets_table.nft-update{
-          margin: 0;
-        }
-
-        .assets_table.nft-update thead th:first-child{
-          font-family: 'Segment';
-          font-weight: 400;
-          font-size: 16px;
-          line-height: 24px;
-          color: var(--white);
         }
 
         td,
@@ -167,6 +140,7 @@ export default function OverviewAssetsTable(props: Props): ReactElement {
           justify-content: flex-end;
         }
       `}</style>
-    </table>
+      </table>
+    </div>
   )
 }


### PR DESCRIPTION
Closes #3098

This PR updates styles for the portfolio page.

Scope of changes:

1 All fonts in asset prices should have the same color. 
2 Move Asset(##) up a bit and add a table head with asset

## UI

Before
<img width="380" alt="Screenshot 2023-04-06 at 16 45 48" src="https://user-images.githubusercontent.com/23117945/230415438-d8d471be-2235-494c-bb55-c67b91d56778.png">

After 
<img width="387" alt="Screenshot 2023-04-06 at 16 33 25" src="https://user-images.githubusercontent.com/23117945/230412672-0b74f5ad-728c-4a72-a848-3c94707b6f52.png">


Latest build: [extension-builds-3260](https://github.com/tahowallet/extension/suites/12074766657/artifacts/635464158) (as of Thu, 06 Apr 2023 14:52:42 GMT).