### PR TITLE
Custom Token Import - Allow manually importing assets

### DIFF
--- a/background/lib/alchemy.ts
+++ b/background/lib/alchemy.ts
@@ -248,7 +248,7 @@ export async function getTokenBalances(
 export async function getTokenMetadata(
   provider: SerialFallbackProvider,
   { contractAddress, homeNetwork }: SmartContract
-): Promise<SmartContractFungibleAsset | undefined> {
+): Promise<SmartContractFungibleAsset> {
   const json: unknown = await provider.send("alchemy_getTokenMetadata", [
     contractAddress,
   ])

--- a/background/lib/logger.ts
+++ b/background/lib/logger.ts
@@ -170,6 +170,11 @@ class Logger {
     this.logEvent(LogLevel.error, input)
   }
 
+  buildError(...input: unknown[]): Error {
+    this.error(...input)
+    return new Error(input.join(" "))
+  }
+
   logEvent(level: Exclude<LogLevel, LogLevel.off>, input: unknown[]): void {
     if (logLevels[level] < this.#level) return
 

--- a/background/redux-slices/assets.ts
+++ b/background/redux-slices/assets.ts
@@ -26,7 +26,8 @@ import {
   FIAT_CURRENCIES_SYMBOL,
 } from "../constants"
 import { convertFixedPoint } from "../lib/fixed-point"
-import { HexString } from "../types"
+import { HexString, NormalizedEVMAddress } from "../types"
+import type { RootState } from "."
 
 export type AssetWithRecentPrices<T extends AnyAsset = AnyAsset> = T & {
   recentPrices: {
@@ -291,5 +292,23 @@ export const importTokenViaContractAddress = createBackgroundAsyncThunk(
     { extra: { main } }
   ) => {
     await main.importTokenViaContractAddress(contractAddress, network)
+  }
+)
+
+export const checkTokenContractDetails = createBackgroundAsyncThunk(
+  "assets/checkTokenContractDetails",
+  async (
+    { contractAddress }: { contractAddress: NormalizedEVMAddress },
+    { getState, extra: { main } }
+  ) => {
+    const state = getState() as RootState
+    const currentAccount = state.ui.selectedAccount
+
+    try {
+      return await main.queryCustomTokenDetails(contractAddress, currentAccount)
+    } catch (error) {
+      // FIXME: Rejected thunks return undefined instead of throwing
+      return null
+    }
   }
 )

--- a/background/services/chain/asset-data-helper.ts
+++ b/background/services/chain/asset-data-helper.ts
@@ -36,6 +36,37 @@ interface ProviderManager {
 export default class AssetDataHelper {
   constructor(private providerTracker: ProviderManager) {}
 
+  async getTokenBalance(
+    addressOnNetwork: AddressOnNetwork,
+    smartContractAddress: HexString
+  ): Promise<SmartContractAmount> {
+    const provider = this.providerTracker.providerForNetwork(
+      addressOnNetwork.network
+    )
+
+    if (!provider) {
+      throw logger.buildError(
+        "Could not find a provider for network",
+        addressOnNetwork.network
+      )
+    }
+
+    const balances = await getTokenBalances(
+      addressOnNetwork,
+      [smartContractAddress],
+      provider
+    )
+
+    if (balances.length < 1) {
+      throw logger.buildError(
+        "Unable to retrieve balances for contract",
+        smartContractAddress
+      )
+    }
+
+    return balances[0]
+  }
+
   async getTokenBalances(
     addressOnNetwork: AddressOnNetwork,
     smartContractAddresses?: HexString[]

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -753,7 +753,9 @@
       "contractCreation": "(Contract creation)",
       "transactionTo": "To:",
       "transactionFrom": "From:",
-      "loadingActivities": "Digging deeper..."
+      "loadingActivities": "Digging deeper...",
+      "addCustomAssetPrompt": "Can't find an asset?",
+      "addCustomAssetAction": "add custom asset"
     },
     "trustedAssets": {
       "notTrusted": "Asset isn't trusted",

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -490,6 +490,7 @@
     "language": "Language",
     "bugReport": "Bug report",
     "connectedWebsites": "Connected websites",
+    "addCustomAsset": "Add custom assets",
     "analytics": "Analytics",
     "needHelp": "Need Help?",
     "customNetworks": "Custom networks",
@@ -539,6 +540,17 @@
       "disconnected": "Website disconnected",
       "ariaLabel": "Manage connected websites",
       "emptyList": "Not connected to any websites"
+    },
+    "addCustomAssetSettings": {
+      "title": "Add custom asset",
+      "input.contractAddress.label": "Contract address",
+      "input.tooltip": " Visit your preferred block explorer and find the asset you want to import.<br>Copy and paste the contract address here.<br><br>For more information visit <url>Help Center</url>",
+      "warning.alreadyExists.title": "Asset already exists, you will see it once your balance is over 0",
+      "warning.alreadyExists.desc": "If you still have issues seeing an asset, turn off “hide balance 2$” from Settings",
+      "error.invalidToken": "Invalid contract address",
+      "submit": "Add asset",
+      "snackbar.success": "Asset added successfully",
+      "footer.hint": "How to add a custom asset?"
     },
     "customNetworksSettings": {
       "title": "Custom networks",

--- a/ui/components/Shared/SharedInput.tsx
+++ b/ui/components/Shared/SharedInput.tsx
@@ -118,7 +118,7 @@ export function SharedTypedInput<T = string>(props: Props<T>): ReactElement {
             height: 48px;
             border-radius: 4px;
             border: 2px solid var(--green-60);
-            padding: 0px 16px;
+            padding: var(--input-padding, 0px 16px);
             box-sizing: border-box;
             text-align: left;
           }

--- a/ui/components/Shared/SharedLink.tsx
+++ b/ui/components/Shared/SharedLink.tsx
@@ -4,19 +4,27 @@ type Props = {
   url: string
   children?: React.ReactNode
   text?: string
+  styles?: React.CSSProperties & Record<string, string>
 }
 
 export default function SharedLink({
   text,
   children,
   url,
+  styles = {},
 }: Props): ReactElement {
   return (
-    <a href={url} target="_blank" rel="noreferrer" className="link">
+    <a
+      style={styles}
+      href={url}
+      target="_blank"
+      rel="noreferrer"
+      className="link"
+    >
       {text ?? children}
       <style jsx>{`
         .link {
-          color: var(--trophy-gold);
+          color: var(--link-color, var(--trophy-gold));
         }
         .link:hover {
           color: var(--gold-40);

--- a/ui/components/Shared/SharedTooltip.tsx
+++ b/ui/components/Shared/SharedTooltip.tsx
@@ -14,6 +14,7 @@ interface Props {
   isOpen?: boolean
   disabled?: boolean
   children: React.ReactNode
+  customStyles?: React.CSSProperties & Record<string, string>
   // TODO: find a better way to tell the IconComponent that the tooltip it open
   IconComponent?: ({
     isShowingTooltip,
@@ -62,6 +63,7 @@ export default function SharedTooltip(props: Props): ReactElement {
     isOpen = false,
     disabled = false,
     IconComponent,
+    customStyles = {},
   } = props
   const [isShowingTooltip, setIsShowingTooltip] = useState(isOpen)
 
@@ -79,6 +81,7 @@ export default function SharedTooltip(props: Props): ReactElement {
       onMouseLeave={() => {
         setIsShowingTooltip(false)
       }}
+      style={customStyles}
     >
       {IconComponent ? (
         <IconComponent isShowingTooltip={isShowingTooltip} />
@@ -104,8 +107,9 @@ export default function SharedTooltip(props: Props): ReactElement {
             margin: -5px 0 -5px 8px;
           }
           .info_icon {
-            background: url("./images/info@2x.png");
-            background-size: cover;
+            mask-image: url("./images/icons/m/info.svg");
+            mask-size: cover;
+            background-color: var(--tooltip-icon-color, var(--green-40));
             width: 16px;
             height: 16px;
             display: block;

--- a/ui/components/Wallet/WalletAssetList.tsx
+++ b/ui/components/Wallet/WalletAssetList.tsx
@@ -1,8 +1,12 @@
 import React, { ReactElement, useState } from "react"
 import { CompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
 import { useTranslation } from "react-i18next"
+import { useHistory } from "react-router-dom"
+import { FeatureFlags, isEnabled } from "@tallyho/tally-background/features"
 import WalletAssetListItem from "./WalletAssetListItem"
 import AssetWarningSlideUp from "./AssetWarningSlideUp"
+import SharedButton from "../Shared/SharedButton"
+import SharedIcon from "../Shared/SharedIcon"
 
 type WalletAssetListProps = {
   assetAmounts: CompleteAssetAmount[]
@@ -15,6 +19,9 @@ export default function WalletAssetList(
   const { t } = useTranslation("translation", {
     keyPrefix: "wallet.activities",
   })
+
+  const history = useHistory()
+
   const { assetAmounts, initializationLoadingTimeExpired } = props
 
   const [warnedAsset, setWarnedAsset] = useState<
@@ -41,7 +48,42 @@ export default function WalletAssetList(
         {!initializationLoadingTimeExpired && (
           <li className="loading">{t("loadingActivities")}</li>
         )}
+        {isEnabled(FeatureFlags.SUPPORT_CUSTOM_NETWORKS) && (
+          <li className="add_custom_asset">
+            <span>{t("addCustomAssetPrompt")}</span>
+            <SharedButton
+              size="medium"
+              onClick={() => history.push("/settings/add-custom-asset")}
+              type="tertiary"
+            >
+              <SharedIcon
+                width={16}
+                height={16}
+                customStyles="margin-right: 4px"
+                icon="icons/s/add.svg"
+                color="currentColor"
+              />
+              {t("addCustomAssetAction")}
+            </SharedButton>
+          </li>
+        )}
         <style jsx>{`
+          .add_custom_asset {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            padding: 16px 0;
+          }
+
+          .add_custom_asset span {
+            font-size: 16px;
+            font-weight: 500;
+            line-height: 24px;
+            letter-spacing: 0em;
+            text-align: left;
+            color: var(--green-40);
+          }
+
           .loading {
             display: flex;
             justify-content: center;

--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -225,6 +225,18 @@ export default function Settings(): ReactElement {
     ),
   }
 
+  const addCustomAsset = {
+    title: "",
+    component: () => (
+      <SettingButton
+        link="/settings/add-custom-asset"
+        label={t("settings.addCustomAsset")}
+        ariaLabel={t("settings.connectedWebsitesSettings.ariaLabel")}
+        icon="continue"
+      />
+    ),
+  }
+
   const analytics = {
     title: "",
     component: () => (
@@ -265,6 +277,9 @@ export default function Settings(): ReactElement {
     ...(isEnabled(FeatureFlags.SUPPORT_MULTIPLE_LANGUAGES) ? [languages] : []),
     enableTestNetworks,
     dAppsSettings,
+    ...(isEnabled(FeatureFlags.SUPPORT_CUSTOM_NETWORKS)
+      ? [addCustomAsset]
+      : []),
     needHelp,
     bugReport,
     ...(isEnabled(FeatureFlags.ENABLE_ANALYTICS_DEFAULT_ON) ? [analytics] : []),

--- a/ui/pages/Settings/SettingsAddCustomAsset.tsx
+++ b/ui/pages/Settings/SettingsAddCustomAsset.tsx
@@ -17,10 +17,14 @@ import SharedAssetIcon from "../../components/Shared/SharedAssetIcon"
 import SharedButton from "../../components/Shared/SharedButton"
 import SharedIcon from "../../components/Shared/SharedIcon"
 import SharedInput from "../../components/Shared/SharedInput"
+import SharedLink from "../../components/Shared/SharedLink"
 import SharedPageHeader from "../../components/Shared/SharedPageHeader"
 import SharedTooltip from "../../components/Shared/SharedTooltip"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import { useSetState } from "../../hooks/react-hooks"
+
+const HELPDESK_CUSTOM_TOKENS_LINK =
+  "https://tahowallet.notion.site/Adding-Custom-Tokens-2facd9b82b5f4685a7d4766caeb05a4c"
 
 const PlaceholderIcon = () => (
   <div>
@@ -167,9 +171,11 @@ export default function SettingsAddCustomAsset(): ReactElement {
                 t={t}
                 i18nKey="input.tooltip"
                 components={{
-                  // FIXME: use correct link
                   url: (
-                    <a href="https://taho.xyz" rel="noopener noreferrer">
+                    <a
+                      href={HELPDESK_CUSTOM_TOKENS_LINK}
+                      rel="noopener noreferrer"
+                    >
                       Help Center
                     </a>
                   ),
@@ -251,7 +257,13 @@ export default function SettingsAddCustomAsset(): ReactElement {
           color: var(--green-40);
         }
       `}</style>
-      <footer>{t("footer.hint")}</footer>
+      <footer>
+        <SharedLink
+          text={t("footer.hint")}
+          url={HELPDESK_CUSTOM_TOKENS_LINK}
+          styles={{ "--link-color": "var(--green-40)" }}
+        />
+      </footer>
       <style jsx>{`
         form {
           all: unset;
@@ -321,7 +333,6 @@ export default function SettingsAddCustomAsset(): ReactElement {
           font-weight: 500;
           font-size: 16px;
           line-height: 24px;
-          color: var(--green-40);
         }
 
         .content {

--- a/ui/pages/Settings/SettingsAddCustomAsset.tsx
+++ b/ui/pages/Settings/SettingsAddCustomAsset.tsx
@@ -159,14 +159,7 @@ export default function SettingsAddCustomAsset(): ReactElement {
                 t={t}
                 i18nKey="input.tooltip"
                 components={{
-                  url: (
-                    <a
-                      href={HELPDESK_CUSTOM_TOKENS_LINK}
-                      rel="noopener noreferrer"
-                    >
-                      Help Center
-                    </a>
-                  ),
+                  url: <SharedLink url={HELPDESK_CUSTOM_TOKENS_LINK} />,
                 }}
               />
             </SharedTooltip>

--- a/ui/pages/Settings/SettingsAddCustomAsset.tsx
+++ b/ui/pages/Settings/SettingsAddCustomAsset.tsx
@@ -28,28 +28,16 @@ const HELPDESK_CUSTOM_TOKENS_LINK =
 
 const PlaceholderIcon = () => (
   <div>
-    <svg
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M9.8125 15.1273L13.2111 11.1623C13.4007 10.9411 13.7383 10.9282 13.9443 11.1341L17.9375 15.1273"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-      />
-      <path
-        d="M6.0625 15.1273L7.5916 13.0885C7.77416 12.8451 8.13 12.8198 8.34515 13.035L9.8125 14.5023"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-      />
-      <circle cx="9.5" cy="8.5" r="1.5" fill="currentColor" />
-    </svg>
+    <i />
     <style jsx>{`
+      i {
+        mask-image: url("/images/placeholder.svg");
+        mask-size: cover;
+        display: block;
+        width: 24px;
+        height: 24px;
+        background-color: var(--green-20);
+      }
       div {
         border-radius: 50%;
         display: flex;

--- a/ui/pages/Settings/SettingsAddCustomAsset.tsx
+++ b/ui/pages/Settings/SettingsAddCustomAsset.tsx
@@ -1,0 +1,335 @@
+import {
+  isProbablyEVMAddress,
+  normalizeEVMAddress,
+} from "@tallyho/tally-background/lib/utils"
+import {
+  checkTokenContractDetails,
+  importTokenViaContractAddress,
+} from "@tallyho/tally-background/redux-slices/assets"
+import { selectCurrentNetwork } from "@tallyho/tally-background/redux-slices/selectors"
+import { setSnackbarMessage } from "@tallyho/tally-background/redux-slices/ui"
+import { AsyncThunkFulfillmentType } from "@tallyho/tally-background/redux-slices/utils"
+import { HexString } from "@tallyho/tally-background/types"
+import React, { FormEventHandler, ReactElement, useRef } from "react"
+import { Trans, useTranslation } from "react-i18next"
+import { useHistory } from "react-router-dom"
+import SharedAssetIcon from "../../components/Shared/SharedAssetIcon"
+import SharedButton from "../../components/Shared/SharedButton"
+import SharedIcon from "../../components/Shared/SharedIcon"
+import SharedInput from "../../components/Shared/SharedInput"
+import SharedPageHeader from "../../components/Shared/SharedPageHeader"
+import SharedTooltip from "../../components/Shared/SharedTooltip"
+import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
+import { useSetState } from "../../hooks/react-hooks"
+
+const PlaceholderIcon = () => (
+  <div>
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9.8125 15.1273L13.2111 11.1623C13.4007 10.9411 13.7383 10.9282 13.9443 11.1341L17.9375 15.1273"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M6.0625 15.1273L7.5916 13.0885C7.77416 12.8451 8.13 12.8198 8.34515 13.035L9.8125 14.5023"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <circle cx="9.5" cy="8.5" r="1.5" fill="currentColor" />
+    </svg>
+    <style jsx>{`
+      div {
+        border-radius: 50%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        background: var(--green-60);
+        width: 40px;
+        color: var(--green-20);
+      }
+    `}</style>
+  </div>
+)
+
+export default function SettingsAddCustomAsset(): ReactElement {
+  const { t } = useTranslation("translation", {
+    keyPrefix: "settings.addCustomAssetSettings",
+  })
+
+  const history = useHistory()
+
+  type AssetData = AsyncThunkFulfillmentType<typeof checkTokenContractDetails>
+
+  const [{ loading, error, assetData }, setState] = useSetState<{
+    loading: boolean
+    error: boolean
+    assetData: AssetData | null
+  }>({
+    loading: false,
+    error: false,
+    assetData: null,
+  })
+
+  const dispatch = useBackgroundDispatch()
+  const currentNetwork = useBackgroundSelector(selectCurrentNetwork)
+
+  const requestIdRef = useRef(0)
+
+  const handleContractChange = async (addressLike: HexString) => {
+    requestIdRef.current += 1
+    const callId = requestIdRef.current
+
+    const contractAddress = addressLike.trim()
+
+    if (contractAddress.length < 1) {
+      setState({ loading: false, assetData: null, error: false })
+      return
+    }
+
+    if (!isProbablyEVMAddress(contractAddress)) {
+      setState({ loading: false, assetData: null, error: true })
+      return
+    }
+
+    const details = (await dispatch(
+      checkTokenContractDetails({
+        contractAddress: normalizeEVMAddress(contractAddress),
+      })
+    )) as unknown as AssetData
+
+    // async setState safeguard
+    if (requestIdRef.current === callId) {
+      setState({ loading: false, assetData: details, error: details === null })
+    }
+  }
+
+  const handleFormSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault()
+
+    if (!assetData) {
+      return
+    }
+
+    await dispatch(
+      importTokenViaContractAddress({
+        contractAddress: assetData.asset.contractAddress,
+        network: assetData.asset.homeNetwork,
+      })
+    )
+    await dispatch(setSnackbarMessage(t("snackbar.success")))
+    history.push("/")
+  }
+
+  return (
+    <div className="standard_width_padded wrapper">
+      <SharedPageHeader withoutBackText backPath="/settings">
+        {t(`title`)}
+      </SharedPageHeader>
+      <style jsx>{`
+        .tooltip_wrap {
+          position: absolute;
+          top: 16px;
+          right: 16px;
+        }
+
+        .tooltip_wrap a {
+          color: inherit;
+          text-decoration: underline;
+        }
+
+        .input_container {
+          position: relative;
+          --input-padding: 0 32px 0 16px;
+        }
+      `}</style>
+      <form onSubmit={handleFormSubmit}>
+        <div className="input_container">
+          <SharedInput
+            label={t("input.contractAddress.label")}
+            errorMessage={error ? t("error.invalidToken") : ""}
+            onChange={handleContractChange}
+          />
+          <div className="tooltip_wrap">
+            <SharedTooltip
+              width={219}
+              horizontalShift={100}
+              customStyles={{ "--tooltip-icon-color": "var(--green-20)" }}
+            >
+              <Trans
+                t={t}
+                i18nKey="input.tooltip"
+                components={{
+                  // FIXME: use correct link
+                  url: (
+                    <a href="https://taho.xyz" rel="noopener noreferrer">
+                      Help Center
+                    </a>
+                  ),
+                }}
+              />
+            </SharedTooltip>
+          </div>
+        </div>
+        <div className="form_controls">
+          <div className="token_details_container">
+            {assetData && !loading ? (
+              <SharedAssetIcon
+                size={40}
+                logoURL={assetData?.asset.metadata?.logoURL}
+                symbol={assetData.asset.symbol}
+              />
+            ) : (
+              <PlaceholderIcon />
+            )}
+            <div className="token_details">
+              <div className="balance">
+                <strong>{assetData?.balance ?? "Balance"}</strong>
+                <span className="symbol">
+                  {assetData?.asset?.symbol ?? "Name"}
+                </span>
+              </div>
+              <span className="network_name">{currentNetwork.name}</span>
+            </div>
+          </div>
+          <SharedButton
+            type="primary"
+            size="medium"
+            isFormSubmit
+            isDisabled={!assetData || loading || error || assetData.exists}
+            isLoading={loading}
+          >
+            {t("submit")}
+          </SharedButton>
+        </div>
+        {assetData?.exists && (
+          <div className="alert">
+            <SharedIcon
+              color="var(--success)"
+              width={24}
+              customStyles="min-width: 24px;"
+              icon="icons/m/notif-correct.svg"
+            />
+            <div className="alert_content">
+              <div className="title">{t("warning.alreadyExists.title")}</div>
+              <div className="desc">{t("warning.alreadyExists.desc")}</div>
+            </div>
+          </div>
+        )}
+      </form>
+      <style jsx>{`
+        .alert {
+          background: var(--green-120);
+          border-radius: 8px;
+          padding: 8px;
+          display: flex;
+          gap: 8px;
+        }
+
+        .alert .title {
+          color: var(--success);
+          font-size: 16px;
+          font-weight: 500;
+          line-height: 24px;
+          letter-spacing: 0em;
+          text-align: left;
+        }
+
+        .alert .desc {
+          font-size: 16px;
+          font-weight: 500;
+          line-height: 24px;
+          letter-spacing: 0em;
+          text-align: left;
+          color: var(--green-40);
+        }
+      `}</style>
+      <footer>{t("footer.hint")}</footer>
+      <style jsx>{`
+        form {
+          all: unset;
+          max-width: 100%;
+          margin: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 32px;
+        }
+        .form_controls {
+          display: flex;
+          justify-content: space-between;
+        }
+
+        .network_name {
+          font-size: 14px;
+          font-weight: 500;
+          line-height: 16px;
+          letter-spacing: 0.03em;
+          text-align: left;
+          color: var(--green-40);
+        }
+
+        .token_details_container {
+          display: flex;
+          gap: 16px;
+        }
+
+        .token_details {
+          display: flex;
+          flex-direction: column;
+        }
+
+        .balance {
+          display: flex;
+          gap: 4px;
+          align-items: baseline;
+        }
+
+        .balance strong {
+          font-style: normal;
+          font-weight: 600;
+          font-size: 18px;
+          line-height: 24px;
+          color: var(--white);
+        }
+
+        .symbol {
+          font-style: normal;
+          font-weight: 500;
+          font-size: 14px;
+          line-height: 16px;
+          letter-spacing: 0.03em;
+        }
+
+        .wrapper {
+          display: flex;
+          flex-direction: column;
+          gap: 32px;
+          height: 100%;
+          margin-bottom: 24px;
+        }
+
+        footer {
+          margin-top: auto;
+          font-style: normal;
+          font-weight: 500;
+          font-size: 16px;
+          line-height: 24px;
+          color: var(--green-40);
+        }
+
+        .content {
+          display: flex;
+          flex-direction: column;
+          gap: 32px;
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/ui/public/images/placeholder.svg
+++ b/ui/public/images/placeholder.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M9.8125 15.1273L13.2111 11.1623C13.4007 10.9411 13.7383 10.9282 13.9443 11.1341L17.9375 15.1273"
+        stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <path d="M6.0625 15.1273L7.5916 13.0885C7.77416 12.8451 8.13 12.8198 8.34515 13.035L9.8125 14.5023"
+        stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <circle cx="9.5" cy="8.5" r="1.5" fill="currentColor"></circle>
+</svg>

--- a/ui/routes/routes.tsx
+++ b/ui/routes/routes.tsx
@@ -30,6 +30,7 @@ import NFTs from "../pages/NFTs"
 import Abilities from "../pages/Abilities"
 import SettingsCustomNetworks from "../pages/Settings/SettingsCustomNetworks"
 import NewCustomNetworkRequest from "../pages/NewCustomNetworkRequest"
+import SettingsAddCustomAsset from "../pages/Settings/SettingsAddCustomAsset"
 
 interface PageList {
   path: string
@@ -165,6 +166,13 @@ const pageList: PageList[] = [
   {
     path: "/settings/custom-networks",
     Component: SettingsCustomNetworks,
+    hasTabBar: true,
+    hasTopBar: false,
+    persistOnClose: true,
+  },
+  {
+    path: "/settings/add-custom-asset",
+    Component: SettingsAddCustomAsset,
     hasTabBar: true,
     hasTopBar: false,
     persistOnClose: true,


### PR DESCRIPTION
Allows manually adding tokens from the asset list and the settings page

<img width="376" alt="image" src="https://user-images.githubusercontent.com/28708889/230504565-84da24e1-25b6-4590-99ae-ee0a9af0f996.png">


## Testing Env

```
SUPPORT_CUSTOM_NETWORKS=true
SUPPORT_CUSTOM_RPCS=true
```

## To test
- [ ] Add a custom network
- [ ] Scroll down the asset list, click on add custom asset
- [ ] Input a erc20 token address, check that balance and symbol appear
- [ ] Attempt to "add asset", check that a toast displays and the asset now appears in the asset list after a balance refresh
- [ ] Input the same erc20 token address, verify a warning shows up with "asset already added"
- [ ] Input an account address or an invalid address, you should see an error "invalid contract address"

Latest build: [extension-builds-3261](https://github.com/tahowallet/extension/suites/12160852252/artifacts/641691473) (as of Tue, 11 Apr 2023 15:24:07 GMT).