### PR TITLE
Separate assets in the asset list 

### DIFF
--- a/background/redux-slices/migrations/index.ts
+++ b/background/redux-slices/migrations/index.ts
@@ -23,12 +23,13 @@ import to23 from "./to-23"
 import to24 from "./to-24"
 import to25 from "./to-25"
 import to26 from "./to-26"
+import to27 from "./to-27"
 
 /**
  * The version of persisted Redux state the extension is expecting. Any previous
  * state without this version, or with a lower version, ought to be migrated.
  */
-export const REDUX_STATE_VERSION = 26
+export const REDUX_STATE_VERSION = 27
 
 /**
  * Common type for all migration functions.
@@ -64,6 +65,7 @@ const allMigrations: { [targetVersion: string]: Migration } = {
   24: to24,
   25: to25,
   26: to26,
+  27: to27,
 }
 
 /**

--- a/background/redux-slices/migrations/to-27.ts
+++ b/background/redux-slices/migrations/to-27.ts
@@ -1,0 +1,35 @@
+type OldState = {
+  ui: {
+    settings: {
+      [settingsKey: string]: unknown
+    }
+    [sliceKey: string]: unknown
+  }
+  [otherSlice: string]: unknown
+}
+
+type NewState = {
+  ui: {
+    settings: {
+      [settingsKey: string]: unknown
+      showHiddenAssets: boolean
+    }
+    [sliceKey: string]: unknown
+  }
+  [otherSlice: string]: unknown
+}
+
+export default (prevState: Record<string, unknown>): NewState => {
+  const typedPrevState = prevState as OldState
+
+  return {
+    ...prevState,
+    ui: {
+      ...typedPrevState.ui,
+      settings: {
+        ...typedPrevState.ui.settings,
+        showHiddenAssets: false,
+      },
+    },
+  }
+}

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -84,7 +84,7 @@ const computeCombinedAssetAmountsData = (
 } => {
   // Derive account "assets"/assetAmount which include USD values using
   // data from the assets slice
-  const [combinedAssetAmounts, hiddenAssetAmounts] = assetAmounts
+  const { combinedAssetAmounts, hiddenAssetAmounts } = assetAmounts
     .map<CompleteAssetAmount>((assetAmount) => {
       const assetPricePoint = selectAssetPricePoint(
         assets,
@@ -149,8 +149,11 @@ const computeCombinedAssetAmountsData = (
       // If only one asset has a main currency amount, it wins.
       return asset1.mainCurrencyAmount === undefined ? 1 : -1
     })
-    .reduce<[CompleteAssetAmount[], CompleteAssetAmount[]]>(
-      ([combinedAssets, hiddenAssets], assetAmount) => {
+    .reduce<{
+      combinedAssetAmounts: CompleteAssetAmount[]
+      hiddenAssetAmounts: CompleteAssetAmount[]
+    }>(
+      (acc, assetAmount) => {
         const isForciblyDisplayed = shouldForciblyDisplayAsset(assetAmount)
 
         const isNotDust =
@@ -167,13 +170,13 @@ const computeCombinedAssetAmountsData = (
           isForciblyDisplayed ||
           (isTrusted && (hideDust ? isNotDust && isPresent : isPresent))
         ) {
-          combinedAssets.push(assetAmount)
-        } else {
-          hiddenAssets.push(assetAmount)
+          acc.combinedAssetAmounts.push(assetAmount)
+        } else if (isPresent) {
+          acc.hiddenAssetAmounts.push(assetAmount)
         }
-        return [combinedAssets, hiddenAssets]
+        return acc
       },
-      [[], []]
+      { combinedAssetAmounts: [], hiddenAssetAmounts: [] }
     )
 
   // Keep a tally of the total user value; undefined if no main currency data

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -165,7 +165,7 @@ const computeCombinedAssetAmountsData = (
         // Hide dust, untrusted assets and missing amounts.
         if (
           isForciblyDisplayed ||
-          (hideDust ? isTrusted && isNotDust && isPresent : isPresent)
+          (isTrusted && (hideDust ? isNotDust && isPresent : isPresent))
         ) {
           combinedAssets.push(assetAmount)
         } else {

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -79,11 +79,12 @@ const computeCombinedAssetAmountsData = (
   hideDust: boolean
 ): {
   combinedAssetAmounts: CompleteAssetAmount[]
+  hiddenAssetAmounts: CompleteAssetAmount[]
   totalMainCurrencyAmount: number | undefined
 } => {
   // Derive account "assets"/assetAmount which include USD values using
   // data from the assets slice
-  const combinedAssetAmounts = assetAmounts
+  const [combinedAssetAmounts, hiddenAssetAmounts] = assetAmounts
     .map<CompleteAssetAmount>((assetAmount) => {
       const assetPricePoint = selectAssetPricePoint(
         assets,
@@ -111,22 +112,6 @@ const computeCombinedAssetAmountsData = (
       )
 
       return fullyEnrichedAssetAmount
-    })
-    .filter((assetAmount) => {
-      const isForciblyDisplayed = shouldForciblyDisplayAsset(assetAmount)
-
-      const isNotDust =
-        typeof assetAmount.mainCurrencyAmount === "undefined"
-          ? true
-          : assetAmount.mainCurrencyAmount > userValueDustThreshold
-      const isPresent = assetAmount.decimalAmount > 0
-      const isTrusted = !!(assetAmount.asset?.metadata?.tokenLists.length ?? 0)
-
-      // Hide dust, untrusted assets and missing amounts.
-      return (
-        isForciblyDisplayed ||
-        (hideDust ? isTrusted && isNotDust && isPresent : isPresent)
-      )
     })
     .sort((asset1, asset2) => {
       // Always sort DOGGO above everything.
@@ -164,6 +149,32 @@ const computeCombinedAssetAmountsData = (
       // If only one asset has a main currency amount, it wins.
       return asset1.mainCurrencyAmount === undefined ? 1 : -1
     })
+    .reduce<[CompleteAssetAmount[], CompleteAssetAmount[]]>(
+      ([combinedAssets, hiddenAssets], assetAmount) => {
+        const isForciblyDisplayed = shouldForciblyDisplayAsset(assetAmount)
+
+        const isNotDust =
+          typeof assetAmount.mainCurrencyAmount === "undefined"
+            ? true
+            : assetAmount.mainCurrencyAmount > userValueDustThreshold
+        const isPresent = assetAmount.decimalAmount > 0
+        const isTrusted = !!(
+          assetAmount.asset?.metadata?.tokenLists.length ?? 0
+        )
+
+        // Hide dust, untrusted assets and missing amounts.
+        if (
+          isForciblyDisplayed ||
+          (hideDust ? isTrusted && isNotDust && isPresent : isPresent)
+        ) {
+          combinedAssets.push(assetAmount)
+        } else {
+          hiddenAssets.push(assetAmount)
+        }
+        return [combinedAssets, hiddenAssets]
+      },
+      [[], []]
+    )
 
   // Keep a tally of the total user value; undefined if no main currency data
   // is available.
@@ -175,7 +186,7 @@ const computeCombinedAssetAmountsData = (
     }
   })
 
-  return { combinedAssetAmounts, totalMainCurrencyAmount }
+  return { combinedAssetAmounts, hiddenAssetAmounts, totalMainCurrencyAmount }
 }
 
 const getAccountState = (state: RootState) => state.account
@@ -218,7 +229,6 @@ export const selectAccountAndTimestampedActivities = createSelector(
     }
   }
 )
-
 export const selectCurrentAccountBalances = createSelector(
   getCurrentAccountState,
   getAssetsState,
@@ -234,17 +244,21 @@ export const selectCurrentAccountBalances = createSelector(
       (balance) => balance.assetAmount
     )
 
-    const { combinedAssetAmounts, totalMainCurrencyAmount } =
-      computeCombinedAssetAmountsData(
-        assetAmounts,
-        assets,
-        mainCurrencySymbol,
-        currentNetwork,
-        hideDust
-      )
+    const {
+      combinedAssetAmounts,
+      hiddenAssetAmounts,
+      totalMainCurrencyAmount,
+    } = computeCombinedAssetAmountsData(
+      assetAmounts,
+      assets,
+      mainCurrencySymbol,
+      currentNetwork,
+      hideDust
+    )
 
     return {
       assetAmounts: combinedAssetAmounts,
+      hiddenAssetAmounts,
       totalMainCurrencyValue: totalMainCurrencyAmount
         ? formatCurrencyAmount(
             mainCurrencySymbol,

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -17,6 +17,7 @@ export const defaultSettings = {
   collectAnalytics: false,
   showAnalyticsNotification: false,
   hideBanners: false,
+  showHiddenAssets: false,
 }
 
 export type UIState = {
@@ -30,6 +31,7 @@ export type UIState = {
     collectAnalytics: boolean
     showAnalyticsNotification: boolean
     hideBanners: boolean
+    showHiddenAssets: boolean
   }
   snackbarMessage: string
   routeHistoryEntries?: Partial<Location>[]
@@ -113,6 +115,16 @@ const uiSlice = createSlice({
         hideBanners,
       },
     }),
+    toggleShowHiddenAssets: (
+      state,
+      { payload: showHiddenAssets }: { payload: boolean }
+    ) => ({
+      ...state,
+      settings: {
+        ...state.settings,
+        showHiddenAssets,
+      },
+    }),
     setShowingActivityDetail: (
       state,
       { payload: transactionID }: { payload: string | null }
@@ -184,6 +196,7 @@ export const {
   toggleCollectAnalytics,
   setShowAnalyticsNotification,
   toggleHideBanners,
+  toggleShowHiddenAssets,
   setSelectedAccount,
   setSnackbarMessage,
   setDefaultWallet,
@@ -348,4 +361,9 @@ export const selectCollectAnalytics = createSelector(
 export const selectHideBanners = createSelector(
   selectSettings,
   (settings) => settings?.hideBanners
+)
+
+export const selectShowHiddenAssets = createSelector(
+  selectSettings,
+  (settings) => settings?.showHiddenAssets
 )

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -779,8 +779,8 @@
       "NFTs": "NFTs",
       "activity": "Activity"
     },
-    "stateOfHiddenAssets1": "Show",
-    "stateOfHiddenAssets2": "Hide",
+    "stateOfHiddenAssets1": "Hide",
+    "stateOfHiddenAssets2": "Show",
     "hiddenAssets": "{{stateOfHiddenAssets}} hidden assets ({{amount}})",
     "defaultToggle": {
       "snackbar": "You can change this in Settings later",

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -779,6 +779,9 @@
       "NFTs": "NFTs",
       "activity": "Activity"
     },
+    "stateOfHiddenAssets1": "Show",
+    "stateOfHiddenAssets2": "Hide",
+    "hiddenAssets": "{{stateOfHiddenAssets}} hidden assets ({{amount}})",
     "defaultToggle": {
       "snackbar": "You can change this in Settings later",
       "isDefault": "is now your default wallet",

--- a/ui/components/Wallet/WalletAssetList.tsx
+++ b/ui/components/Wallet/WalletAssetList.tsx
@@ -1,12 +1,8 @@
 import React, { ReactElement, useState } from "react"
 import { CompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
 import { useTranslation } from "react-i18next"
-import { useHistory } from "react-router-dom"
-import { FeatureFlags, isEnabled } from "@tallyho/tally-background/features"
 import WalletAssetListItem from "./WalletAssetListItem"
 import AssetWarningSlideUp from "./AssetWarningSlideUp"
-import SharedButton from "../Shared/SharedButton"
-import SharedIcon from "../Shared/SharedIcon"
 
 type WalletAssetListProps = {
   assetAmounts: CompleteAssetAmount[]
@@ -19,8 +15,6 @@ export default function WalletAssetList(
   const { t } = useTranslation("translation", {
     keyPrefix: "wallet.activities",
   })
-
-  const history = useHistory()
 
   const { assetAmounts, initializationLoadingTimeExpired } = props
 
@@ -48,42 +42,7 @@ export default function WalletAssetList(
         {!initializationLoadingTimeExpired && (
           <li className="loading">{t("loadingActivities")}</li>
         )}
-        {isEnabled(FeatureFlags.SUPPORT_CUSTOM_NETWORKS) && (
-          <li className="add_custom_asset">
-            <span>{t("addCustomAssetPrompt")}</span>
-            <SharedButton
-              size="medium"
-              onClick={() => history.push("/settings/add-custom-asset")}
-              type="tertiary"
-            >
-              <SharedIcon
-                width={16}
-                height={16}
-                customStyles="margin-right: 4px"
-                icon="icons/s/add.svg"
-                color="currentColor"
-              />
-              {t("addCustomAssetAction")}
-            </SharedButton>
-          </li>
-        )}
         <style jsx>{`
-          .add_custom_asset {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            padding: 16px 0;
-          }
-
-          .add_custom_asset span {
-            font-size: 16px;
-            font-weight: 500;
-            line-height: 24px;
-            letter-spacing: 0em;
-            text-align: left;
-            color: var(--green-40);
-          }
-
           .loading {
             display: flex;
             justify-content: center;

--- a/ui/components/Wallet/WalletHiddenAssets.tsx
+++ b/ui/components/Wallet/WalletHiddenAssets.tsx
@@ -9,6 +9,7 @@ import {
 import WalletAssetList from "./WalletAssetList"
 import SharedButton from "../Shared/SharedButton"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
+import { useIsMounted } from "../../hooks/react-hooks"
 
 type WalletHiddenAssetsProps = {
   assetAmounts: CompleteAssetAmount[]
@@ -20,6 +21,7 @@ export default function WalletHiddenAssets({
   const { t } = useTranslation("translation", {
     keyPrefix: "wallet",
   })
+  const mountedRef = useIsMounted()
   const hiddenAssetsRef = useRef<HTMLDivElement | null>(null)
   const buttonRef = useRef<HTMLDivElement | null>(null)
   const [maxHeight, setMaxHeight] = useState(0)
@@ -63,8 +65,9 @@ export default function WalletHiddenAssets({
 
       <div
         ref={hiddenAssetsRef}
-        className={classNames("hidden_assets", {
-          visible: showHiddenAssets,
+        className={classNames({
+          hidden_assets: mountedRef.current,
+          visible: mountedRef.current && showHiddenAssets,
         })}
       >
         <WalletAssetList

--- a/ui/components/Wallet/WalletHiddenAssets.tsx
+++ b/ui/components/Wallet/WalletHiddenAssets.tsx
@@ -1,0 +1,94 @@
+import React, { ReactElement, useEffect, useRef, useState } from "react"
+import { CompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
+import { useTranslation } from "react-i18next"
+import classNames from "classnames"
+import {
+  selectShowHiddenAssets,
+  toggleShowHiddenAssets,
+} from "@tallyho/tally-background/redux-slices/ui"
+import WalletAssetList from "./WalletAssetList"
+import SharedButton from "../Shared/SharedButton"
+import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
+
+type WalletHiddenAssetsProps = {
+  assetAmounts: CompleteAssetAmount[]
+}
+
+export default function WalletHiddenAssets({
+  assetAmounts,
+}: WalletHiddenAssetsProps): ReactElement {
+  const { t } = useTranslation("translation", {
+    keyPrefix: "wallet",
+  })
+  const hiddenAssetsRef = useRef<HTMLDivElement | null>(null)
+  const buttonRef = useRef<HTMLDivElement | null>(null)
+  const [maxHeight, setMaxHeight] = useState(0)
+
+  const dispatch = useBackgroundDispatch()
+  const showHiddenAssets = useBackgroundSelector(selectShowHiddenAssets)
+
+  const stateOfHiddenAssets = showHiddenAssets
+    ? t("stateOfHiddenAssets1")
+    : t("stateOfHiddenAssets2")
+
+  useEffect(() => {
+    if (hiddenAssetsRef.current) {
+      setMaxHeight(hiddenAssetsRef.current.scrollHeight)
+    }
+  }, [hiddenAssetsRef?.current?.scrollHeight])
+
+  return (
+    <>
+      <div className="hidden_assets_button" ref={buttonRef}>
+        <SharedButton
+          type="tertiaryGray"
+          size="small"
+          onClick={() => {
+            dispatch(toggleShowHiddenAssets(!showHiddenAssets))
+            setTimeout(() => {
+              if (!showHiddenAssets) {
+                buttonRef.current?.scrollIntoView({
+                  behavior: "smooth",
+                })
+              }
+            }, 500)
+          }}
+        >
+          {t("hiddenAssets", {
+            stateOfHiddenAssets,
+            amount: assetAmounts.length,
+          })}
+        </SharedButton>
+      </div>
+
+      <div
+        ref={hiddenAssetsRef}
+        className={classNames("hidden_assets", {
+          visible: showHiddenAssets,
+        })}
+      >
+        <WalletAssetList
+          assetAmounts={assetAmounts}
+          initializationLoadingTimeExpired
+        />
+      </div>
+      <style jsx>{`
+        .hidden_assets {
+          max-height: 0px;
+          overflow: hidden;
+          transition: max-height 500ms ease-out;
+        }
+        .hidden_assets.visible {
+          max-height: ${maxHeight}px;
+          transition: max-height 500ms ease-in;
+        }
+        .hidden_assets_button {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          padding: 8px 0 24px;
+        }
+      `}</style>
+    </>
+  )
+}

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -40,7 +40,7 @@ export default function Wallet(): ReactElement {
   const claimState = useBackgroundSelector((state) => state.claim)
   const selectedNetwork = useBackgroundSelector(selectCurrentNetwork)
   const showHiddenAssets = useBackgroundSelector(selectShowHiddenAssets)
-  const stateOfUntrustedAssets = showHiddenAssets
+  const stateOfHiddenAssets = showHiddenAssets
     ? t("wallet.stateOfHiddenAssets1")
     : t("wallet.stateOfHiddenAssets2")
 
@@ -133,7 +133,7 @@ export default function Wallet(): ReactElement {
                         }
                       >
                         {t("wallet.hiddenAssets", {
-                          stateOfUntrustedAssets,
+                          stateOfHiddenAssets,
                           amount: hiddenAssetAmounts.length,
                         })}
                       </SharedButton>

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -155,9 +155,7 @@ export default function Wallet(): ReactElement {
                     >
                       <WalletAssetList
                         assetAmounts={hiddenAssetAmounts}
-                        initializationLoadingTimeExpired={
-                          initializationLoadingTimeExpired
-                        }
+                        initializationLoadingTimeExpired
                       />
                     </div>
                   </>

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useRef, useState } from "react"
+import React, { ReactElement, useEffect, useState } from "react"
 import {
   selectCurrentAccountActivities,
   selectCurrentAccountBalances,
@@ -10,11 +10,7 @@ import { FeatureFlags, isEnabled } from "@tallyho/tally-background/features"
 import classNames from "classnames"
 import { useTranslation } from "react-i18next"
 import { NETWORKS_SUPPORTING_NFTS } from "@tallyho/tally-background/nfts"
-import {
-  selectShowAnalyticsNotification,
-  selectShowHiddenAssets,
-  toggleShowHiddenAssets,
-} from "@tallyho/tally-background/redux-slices/ui"
+import { selectShowAnalyticsNotification } from "@tallyho/tally-background/redux-slices/ui"
 import { useBackgroundDispatch, useBackgroundSelector } from "../hooks"
 import SharedPanelSwitcher from "../components/Shared/SharedPanelSwitcher"
 import WalletAssetList from "../components/Wallet/WalletAssetList"
@@ -27,13 +23,11 @@ import WalletToggleDefaultBanner from "../components/Wallet/WalletToggleDefaultB
 import WalletBanner from "../components/Wallet/Banner/WalletBanner"
 import WalletAnalyticsNotificationBanner from "../components/Wallet/WalletAnalyticsNotificationBanner"
 import NFTListCurrentWallet from "../components/NFTS_update/NFTListCurrentWallet"
-import SharedButton from "../components/Shared/SharedButton"
+import WalletHiddenAssets from "../components/Wallet/WalletHiddenAssets"
 
 export default function Wallet(): ReactElement {
   const { t } = useTranslation()
   const [panelNumber, setPanelNumber] = useState(0)
-  const hiddenAssetsRef = useRef<HTMLDivElement | null>(null)
-  const [maxHeight, setMaxHeight] = useState(0)
 
   const dispatch = useBackgroundDispatch()
 
@@ -41,10 +35,6 @@ export default function Wallet(): ReactElement {
   const accountData = useBackgroundSelector(selectCurrentAccountBalances)
   const claimState = useBackgroundSelector((state) => state.claim)
   const selectedNetwork = useBackgroundSelector(selectCurrentNetwork)
-  const showHiddenAssets = useBackgroundSelector(selectShowHiddenAssets)
-  const stateOfHiddenAssets = showHiddenAssets
-    ? t("wallet.stateOfHiddenAssets1")
-    : t("wallet.stateOfHiddenAssets2")
 
   useEffect(() => {
     dispatch(
@@ -60,12 +50,6 @@ export default function Wallet(): ReactElement {
       setPanelNumber(0)
     }
   }, [selectedNetwork.chainID])
-
-  useEffect(() => {
-    if (hiddenAssetsRef.current) {
-      setMaxHeight(hiddenAssetsRef.current.scrollHeight)
-    }
-  }, [hiddenAssetsRef?.current?.scrollHeight])
 
   const { assetAmounts, hiddenAssetAmounts, totalMainCurrencyValue } =
     accountData ?? {
@@ -131,34 +115,7 @@ export default function Wallet(): ReactElement {
                   }
                 />
                 {hiddenAssetAmounts.length > 0 && (
-                  <>
-                    <div className="hidden_assets_button">
-                      <SharedButton
-                        type="tertiaryGray"
-                        size="small"
-                        onClick={() =>
-                          dispatch(toggleShowHiddenAssets(!showHiddenAssets))
-                        }
-                      >
-                        {t("wallet.hiddenAssets", {
-                          stateOfHiddenAssets,
-                          amount: hiddenAssetAmounts.length,
-                        })}
-                      </SharedButton>
-                    </div>
-
-                    <div
-                      ref={hiddenAssetsRef}
-                      className={classNames("hidden_assets", {
-                        visible: showHiddenAssets,
-                      })}
-                    >
-                      <WalletAssetList
-                        assetAmounts={hiddenAssetAmounts}
-                        initializationLoadingTimeExpired
-                      />
-                    </div>
-                  </>
+                  <WalletHiddenAssets assetAmounts={hiddenAssetAmounts} />
                 )}
               </>
             )}
@@ -215,21 +172,6 @@ export default function Wallet(): ReactElement {
           }
           .no_padding {
             padding-top: 0;
-          }
-          .hidden_assets {
-            max-height: 0px;
-            overflow: hidden;
-            transition: max-height 500ms ease-out;
-          }
-          .hidden_assets.visible {
-            max-height: ${maxHeight}px;
-            transition: max-height 500ms ease-in;
-          }
-          .hidden_assets_button {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            padding: 8px 0 24px;
           }
         `}
       </style>

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -11,6 +11,7 @@ import classNames from "classnames"
 import { useTranslation } from "react-i18next"
 import { NETWORKS_SUPPORTING_NFTS } from "@tallyho/tally-background/nfts"
 import { selectShowAnalyticsNotification } from "@tallyho/tally-background/redux-slices/ui"
+import { useHistory } from "react-router-dom"
 import { useBackgroundDispatch, useBackgroundSelector } from "../hooks"
 import SharedPanelSwitcher from "../components/Shared/SharedPanelSwitcher"
 import WalletAssetList from "../components/Wallet/WalletAssetList"
@@ -24,12 +25,15 @@ import WalletBanner from "../components/Wallet/Banner/WalletBanner"
 import WalletAnalyticsNotificationBanner from "../components/Wallet/WalletAnalyticsNotificationBanner"
 import NFTListCurrentWallet from "../components/NFTS_update/NFTListCurrentWallet"
 import WalletHiddenAssets from "../components/Wallet/WalletHiddenAssets"
+import SharedButton from "../components/Shared/SharedButton"
+import SharedIcon from "../components/Shared/SharedIcon"
 
 export default function Wallet(): ReactElement {
   const { t } = useTranslation()
   const [panelNumber, setPanelNumber] = useState(0)
 
   const dispatch = useBackgroundDispatch()
+  const history = useHistory()
 
   //  accountLoading, hasWalletErrorCode
   const accountData = useBackgroundSelector(selectCurrentAccountBalances)
@@ -114,6 +118,29 @@ export default function Wallet(): ReactElement {
                     initializationLoadingTimeExpired
                   }
                 />
+                {isEnabled(FeatureFlags.SUPPORT_CUSTOM_NETWORKS) && (
+                  <div
+                    className={classNames("add_custom_asset", {
+                      line: hiddenAssetAmounts.length > 0,
+                    })}
+                  >
+                    <span>{t("wallet.activities.addCustomAssetPrompt")}</span>
+                    <SharedButton
+                      size="medium"
+                      onClick={() => history.push("/settings/add-custom-asset")}
+                      type="tertiary"
+                    >
+                      <SharedIcon
+                        width={16}
+                        height={16}
+                        customStyles="margin-right: 4px"
+                        icon="icons/s/add.svg"
+                        color="currentColor"
+                      />
+                      {t("wallet.activities.addCustomAssetAction")}
+                    </SharedButton>
+                  </div>
+                )}
                 {hiddenAssetAmounts.length > 0 && (
                   <WalletHiddenAssets assetAmounts={hiddenAssetAmounts} />
                 )}
@@ -172,6 +199,25 @@ export default function Wallet(): ReactElement {
           }
           .no_padding {
             padding-top: 0;
+          }
+          .add_custom_asset {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            padding: 16px 0;
+            margin: 0px 16px;
+          }
+          .add_custom_asset span {
+            font-size: 16px;
+            font-weight: 500;
+            line-height: 24px;
+            letter-spacing: 0em;
+            text-align: left;
+            color: var(--green-40);
+          }
+          .line {
+            border-bottom: 1px solid var(--green-80);
+            margin-bottom: 8px;
           }
         `}
       </style>

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from "react"
+import React, { ReactElement, useEffect, useRef, useState } from "react"
 import {
   selectCurrentAccountActivities,
   selectCurrentAccountBalances,
@@ -32,6 +32,8 @@ import SharedButton from "../components/Shared/SharedButton"
 export default function Wallet(): ReactElement {
   const { t } = useTranslation()
   const [panelNumber, setPanelNumber] = useState(0)
+  const hiddenAssetsRef = useRef<HTMLDivElement | null>(null)
+  const [maxHeight, setMaxHeight] = useState(0)
 
   const dispatch = useBackgroundDispatch()
 
@@ -58,6 +60,12 @@ export default function Wallet(): ReactElement {
       setPanelNumber(0)
     }
   }, [selectedNetwork.chainID])
+
+  useEffect(() => {
+    if (hiddenAssetsRef.current) {
+      setMaxHeight(hiddenAssetsRef.current.scrollHeight)
+    }
+  }, [hiddenAssetsRef?.current?.scrollHeight])
 
   const { assetAmounts, hiddenAssetAmounts, totalMainCurrencyValue } =
     accountData ?? {
@@ -138,14 +146,20 @@ export default function Wallet(): ReactElement {
                         })}
                       </SharedButton>
                     </div>
-                    {showHiddenAssets && (
+
+                    <div
+                      ref={hiddenAssetsRef}
+                      className={classNames("hidden_assets", {
+                        visible: showHiddenAssets,
+                      })}
+                    >
                       <WalletAssetList
                         assetAmounts={hiddenAssetAmounts}
                         initializationLoadingTimeExpired={
                           initializationLoadingTimeExpired
                         }
                       />
-                    )}
+                    </div>
                   </>
                 )}
               </>
@@ -204,11 +218,20 @@ export default function Wallet(): ReactElement {
           .no_padding {
             padding-top: 0;
           }
+          .hidden_assets {
+            max-height: 0px;
+            overflow: hidden;
+            transition: max-height 500ms ease-out;
+          }
+          .hidden_assets.visible {
+            max-height: ${maxHeight}px;
+            transition: max-height 500ms ease-in;
+          }
           .hidden_assets_button {
             display: flex;
             justify-content: center;
             align-items: center;
-            margin: 24px 0;
+            padding: 8px 0 24px;
           }
         `}
       </style>


### PR DESCRIPTION
Closes #3224 

This PR separates hidden assets from non-hidden assets in the asset list. The `Hide Asset Balances under $2` should no longer hide untrusted assets. All hidden assets should be separated and displayed together.

## UI
Before
<img width="381" alt="Screenshot 2023-04-10 at 11 34 28" src="https://user-images.githubusercontent.com/23117945/230875842-14d7e82b-f223-4c2a-882e-4992239ecc7e.png">

After
https://user-images.githubusercontent.com/23117945/231146605-98e9b23b-0b8c-4099-8d30-e39198d27c44.mov


<img width="250" alt="Screenshot 2023-04-12 at 11 20 59" src="https://user-images.githubusercontent.com/23117945/231415697-ac1e8b50-542b-40be-8399-30ec1dd41648.png">
<img width="250" alt="Screenshot 2023-04-12 at 11 19 14" src="https://user-images.githubusercontent.com/23117945/231415716-6f870100-75a3-47b9-8928-78c3c3beb174.png">




## To Test
- [x] untrusted assets should be separated
- [x] assets under $2 should be separated
- [x] `Hide Asset Balances under $2` should no longer hide untrusted assets

Latest build: [extension-builds-3263](https://github.com/tahowallet/extension/suites/12179823482/artifacts/643115140) (as of Wed, 12 Apr 2023 09:29:23 GMT).