### PR TITLE
Fix background blur issue

### DIFF
--- a/ui/components/Shared/SharedSecretText.tsx
+++ b/ui/components/Shared/SharedSecretText.tsx
@@ -44,12 +44,12 @@ export default function SharedSecretText(props: Props): ReactElement {
           overflow-wrap: anywhere;
           padding: 10px;
           opacity: 0.8;
+          filter: blur(6px);
         }
         .secret_blur {
           font-weight: 500;
           font-size: 14px;
           line-height: 16px;
-          backdrop-filter: blur(8px);
           opacity: 1;
         }
         .secret_container:hover .secret_blur {
@@ -58,6 +58,7 @@ export default function SharedSecretText(props: Props): ReactElement {
         }
         .secret_container:hover .secret_text {
           opacity: 1;
+          filter: blur(0px);
         }
         .centered {
           position: absolute;
@@ -72,7 +73,7 @@ export default function SharedSecretText(props: Props): ReactElement {
           flex-direction: column;
           align-items: center;
           justify-content: center;
-          transition: opacity 200ms ease-in-out;
+          transition: opacity 200ms ease-in-out, filter 200ms ease-in-out;
         }
       `}</style>
     </>


### PR DESCRIPTION
### What

Chrome has a problem with rendering backdrop blur when content is scrolled, sometimes blur just disappears which is unacceptable for SharedSecretText component that handles private keys and mnemonics. Let's use `filter: blur()` rule as it seems to be working much better.

### Testing
- export the mnemonic for HD wallet with a couple of accounts added, expand the accounts accordion so mnemonic's container is rendered out of the screen (at least partially)
- make sure blur is always present if you are not hovering the container with the mouse
- test private keys export flow as well

Latest build: [extension-builds-3265](https://github.com/tahowallet/extension/suites/12151916263/artifacts/641062230) (as of Tue, 11 Apr 2023 09:13:10 GMT).