### PR TITLE
CI - Fix new line handling in build env block detection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Dev build
         if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
         run: |
-          echo ${{ steps.env-block.outputs.result }} > .env
+          echo -e ${{ steps.env-block.outputs.result }} > .env
           echo 'USE_ANALYTICS_SOURCE="BETA"' >> .env
           yarn build
         env:


### PR DESCRIPTION
Closes #3262 

Fixes missing escaping of new line sequences '\n'

Before: 
![image](https://user-images.githubusercontent.com/28708889/231162412-b1f35402-f44b-4ef5-8552-86ebd678d4f4.png)


## Testing Env

```
SUPPORT_CUSTOM_NETWORKS=true
SUPPORT_CUSTOM_RPCS=true
```

## To test
- [ ] Check logs for build workflow
- [ ] You should see multiple env vars added correctly