### PR TITLE
Fix a snackbar position for tabbed onboarding

### DIFF
--- a/ui/components/Snackbar/Snackbar.tsx
+++ b/ui/components/Snackbar/Snackbar.tsx
@@ -1,11 +1,21 @@
-import React, { ReactElement, useCallback, useEffect, useRef } from "react"
+import React, {
+  ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import { useDispatch } from "react-redux"
 import classNames from "classnames"
 import {
   selectSnackbarMessage,
   clearSnackbarMessage,
 } from "@tallyho/tally-background/redux-slices/ui"
-import { useBackgroundSelector, useDelayContentChange } from "../../hooks"
+import {
+  useBackgroundSelector,
+  useDelayContentChange,
+  useIsOnboarding,
+} from "../../hooks"
 
 // Number of ms before a snackbar message dismisses; changing the message will
 // extend visibility by this much.
@@ -20,6 +30,10 @@ export default function Snackbar({
   isTabbedOnboarding?: boolean
 }): ReactElement {
   const dispatch = useDispatch()
+
+  // Snackbar for tabbed onboarding should be displayed under the button in the right container on the page
+  const [isOnboarding] = useState(useIsOnboarding())
+  const showInRightContainer = isTabbedOnboarding ? isOnboarding : false
 
   const snackbarMessage = useBackgroundSelector(selectSnackbarMessage)
   const shouldHide = snackbarMessage.trim() === ""
@@ -59,7 +73,7 @@ export default function Snackbar({
     <div
       className={classNames("snackbar_container", {
         hidden: shouldHide,
-        tab_container: isTabbedOnboarding,
+        right_container: showInRightContainer,
       })}
     >
       <div className="snackbar_wrap">{displayMessage}</div>
@@ -109,7 +123,7 @@ export default function Snackbar({
           }
 
           @media (min-width: 980px) {
-            .tab_container {
+            .right_container {
               right: -50%;
             }
           }

--- a/ui/components/Snackbar/Snackbar.tsx
+++ b/ui/components/Snackbar/Snackbar.tsx
@@ -14,7 +14,11 @@ const DISMISS_MS = 2500
 // dismissed.
 const DISMISS_ANIMATION_MS = 300
 
-export default function Snackbar(): ReactElement {
+export default function Snackbar({
+  isTabbedOnboarding = false,
+}: {
+  isTabbedOnboarding?: boolean
+}): ReactElement {
   const dispatch = useDispatch()
 
   const snackbarMessage = useBackgroundSelector(selectSnackbarMessage)
@@ -52,7 +56,12 @@ export default function Snackbar(): ReactElement {
   }, [clearSnackbarTimeout, dispatch])
 
   return (
-    <div className={classNames("snackbar_container", { hidden: shouldHide })}>
+    <div
+      className={classNames("snackbar_container", {
+        hidden: shouldHide,
+        tab_container: isTabbedOnboarding,
+      })}
+    >
       <div className="snackbar_wrap">{displayMessage}</div>
       <style jsx>
         {`
@@ -97,6 +106,12 @@ export default function Snackbar(): ReactElement {
           .snackbar_container.hidden .snackbar_wrap {
             padding: 0;
             transform: translateY(10px);
+          }
+
+          @media (min-width: 980px) {
+            .tab_container {
+              right: -50%;
+            }
           }
         `}
       </style>

--- a/ui/pages/Tab.tsx
+++ b/ui/pages/Tab.tsx
@@ -41,7 +41,7 @@ export default function Tab({ store }: { store: Store }): ReactElement {
             </Switch>
           </HashRouter>
         </Container>
-        <Snackbar />
+        <Snackbar isTabbedOnboarding />
       </Provider>
       <>
         <style jsx global>


### PR DESCRIPTION
Closes #3151 

This PR fixes a snackbar position for tabbed onboarding.  When we toggle default wallet on, the snackbar should be under the button and not centered.

### UI

https://user-images.githubusercontent.com/23117945/231990342-2ea58c25-1745-420f-adbf-bb3c293fdfbe.mov

Latest build: [extension-builds-3274](https://github.com/tahowallet/extension/suites/12281069291/artifacts/650518670) (as of Mon, 17 Apr 2023 10:12:25 GMT).