### PR TITLE
Bump Dexie to 3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "archiver": "^5.3.0",
     "babel-loader": "^8.2.2",
     "copy-webpack-plugin": "^9.0.0",
-    "dexie": "^3.0.3",
+    "dexie": "~3.0.4",
     "dotenv-defaults": "^2.0.2",
     "dotenv-webpack": "^7.0.3",
     "eslint": "^7.28.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6538,6 +6538,11 @@ dexie@^3.0.3:
   resolved "https://registry.yarnpkg.com/dexie/-/dexie-3.0.3.tgz#ede63849dfe5f07e13e99bb72a040e8ac1d29dab"
   integrity sha512-BSFhGpngnCl1DOr+8YNwBDobRMH0ziJs2vts69VilwetHYOtEDcLqo7d/XiIphM0tJZ2rPPyAGd31lgH2Ln3nw==
 
+dexie@~3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/dexie/-/dexie-3.0.4.tgz#18f5e124d525a413fa836716f2c37fbbc36a6662"
+  integrity sha512-rwS3k8BBstjGFJAS/yjYrsRZucqitnrP3NBhqghl9ihWcWABlT3I5f2dZV9T3pmXGAP7G9p1q00g/axcsuOT8A==
+
 dezalgo@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"


### PR DESCRIPTION
Though the underlying fix isn't to something we directly call, better safe than sorry on the data layer.

Should be an easy merge here, supersedes #2850 .