### PR TITLE
Fix unhiding removed accounts

### DIFF
--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -408,6 +408,7 @@ export default class KeyringService extends BaseService<Events> {
 
     if (!address) return null
 
+    this.#hiddenAccounts[address] = false
     await this.persistKeyrings()
     this.emitter.emit("address", address)
     this.emitKeyrings()


### PR DESCRIPTION
Resolves https://github.com/tahowallet/extension/issues/3276

### What
If the account is added again, it should no longer be hidden, whether it was added with a private key or mnemonic.

### Testing

Follow the steps described in the linked task or:

- add account with private key (first you have to export this private key in Metamask from the HD wallet with mnemonic you know)
- remove that account
- add HD wallet with mnemonic you used to export private key

You should be able to add the same address with both private key and mnemonic

Latest build: [extension-builds-3282](https://github.com/tahowallet/extension/suites/12315887155/artifacts/653029617) (as of Tue, 18 Apr 2023 14:45:36 GMT).