### PR TITLE
Submit swap button should be disabled if there is a setup error

### DIFF
--- a/ui/components/Shared/SharedAssetInput.tsx
+++ b/ui/components/Shared/SharedAssetInput.tsx
@@ -422,6 +422,7 @@ interface SharedAssetInputProps<AssetType extends AnyAsset> {
   onFocus?: () => void
   onBlur?: () => void
   onAmountChange?: (value: string, errorMessage: string | undefined) => void
+  onErrorMessageChange?: (errorMessage: string) => void
   NFTCollections?: NFTCollectionCached[]
   onSelectNFT?: (nft: NFTCached) => void
   selectedNFT?: NFTCached
@@ -470,6 +471,7 @@ export default function SharedAssetInput<T extends AnyAsset>(
     onAmountChange,
     onFocus = () => {},
     onBlur = () => {},
+    onErrorMessageChange = () => {},
     NFTCollections,
     onSelectNFT,
     selectedNFT,
@@ -543,9 +545,10 @@ export default function SharedAssetInput<T extends AnyAsset>(
   }
 
   useEffect(() => {
-    const error = getErrorMessage(amount)
-    setErrorMessage(error ?? "")
-  }, [amount, getErrorMessage])
+    const error = getErrorMessage(amount) ?? ""
+    setErrorMessage(error)
+    onErrorMessageChange(error)
+  }, [amount, getErrorMessage, onErrorMessageChange])
 
   const setMaxBalance = () => {
     if (

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -71,6 +71,8 @@ export default function Swap(): ReactElement {
 
   const mainCurrencySign = useBackgroundSelector(selectMainCurrencySign)
 
+  const [hasError, setHasError] = useState(false)
+
   // TODO We're special-casing ETH here in an odd way. Going forward, we should
   // filter by current chain and better handle network-native base assets
   const ownedSellAssetAmounts =
@@ -489,6 +491,7 @@ export default function Swap(): ReactElement {
                 onAssetSelect={updateSellAsset}
                 onFocus={() => setAmountInputHasFocus(true)}
                 onBlur={() => setAmountInputHasFocus(false)}
+                onErrorMessageChange={(error) => setHasError(!!error)}
                 mainCurrencySign={mainCurrencySign}
                 onAmountChange={(newAmount, error) => {
                   setSellAmount(newAmount)
@@ -567,7 +570,7 @@ export default function Swap(): ReactElement {
               {quoteAppliesToCurrentAssets && quote?.needsApproval ? (
                 <ApproveQuoteBtn
                   isApprovalInProgress={!!isApprovalInProgress}
-                  isDisabled={isReadOnlyAccount || !quote}
+                  isDisabled={isReadOnlyAccount || !quote || hasError}
                   onApproveClick={approveAsset}
                   isLoading={confirmationMenu}
                 />
@@ -579,7 +582,8 @@ export default function Swap(): ReactElement {
                     isReadOnlyAccount ||
                     !quote ||
                     !quoteAppliesToCurrentAssets ||
-                    !quoteAppliesToCurrentAmounts
+                    !quoteAppliesToCurrentAmounts ||
+                    hasError
                   }
                   onClick={getFinalQuote}
                   showLoadingOnClick={!confirmationMenu}


### PR DESCRIPTION
Closes #3230 

This PR fixes the issue with submit swap button. The user should not be able to click button if there is an error like "insufficient balance". 

### UI
<img width="250" alt="Screenshot 2023-04-19 at 15 55 08" src="https://user-images.githubusercontent.com/23117945/233097402-3973589e-52c5-4ac3-a027-f0370857e7ca.png">

### To Test
- [ ] Check if submit swap button is disabled in case of setup error