### PR TITLE
Check all asset amount balances in Swap page

### DIFF
--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -74,7 +74,7 @@ export default function Swap(): ReactElement {
   // TODO We're special-casing ETH here in an odd way. Going forward, we should
   // filter by current chain and better handle network-native base assets
   const ownedSellAssetAmounts =
-    accountBalances?.assetAmounts.filter(
+    accountBalances?.allAssetAmounts.filter(
       (assetAmount): assetAmount is CompleteAssetAmount<SwappableAsset> =>
         isSmartContractFungibleAsset(assetAmount.asset) ||
         assetAmount.asset.symbol === currentNetwork.baseAsset.symbol


### PR DESCRIPTION
Fixes the following issue: https://github.com/tahowallet/extension/pull/3147#issuecomment-1514254469

Hidden asset balances where not being loaded in the Swap page, after attempting to swap them by clicking an action from the wallet asset list the user would be redirected to the Swap page in an empty state.

## To Test
- [ ] Load an account with hidden assets, (untrusted assets, dust balances)
- [ ] On the wallet asset list, click on the swap quick action on any hidden asset
- [ ] You should be redirected to the Swap page with the asset you clicked pre-selected as the from asset

Latest build: [extension-builds-3288](https://github.com/tahowallet/extension/suites/12351450295/artifacts/655656750) (as of Wed, 19 Apr 2023 19:53:15 GMT).