### PR TITLE
Update hover-color of delete network icon

### DIFF
--- a/ui/pages/Settings/SettingsCustomNetworks.tsx
+++ b/ui/pages/Settings/SettingsCustomNetworks.tsx
@@ -66,6 +66,7 @@ export default function SettingsCustomNetworks(): ReactElement {
                       onClick={() => dispatch(removeCustomChain(item.chainID))}
                       icon="icons/s/garbage.svg"
                       color="var(--green-40)"
+                      hoverColor="var(--trophy-gold)"
                     />
                   </div>
                 </li>


### PR DESCRIPTION
### To test
- [ ] Hover over the trashcan icon of a custom network in the `Custom Networks` settings menu - it should turn gold.

<img width="393" alt="image" src="https://user-images.githubusercontent.com/94649004/233202769-e2bd2347-2796-4924-a675-1b3f671afdec.png">


Latest build: [extension-builds-3289](https://github.com/tahowallet/extension/suites/12353412413/artifacts/655804870) (as of Wed, 19 Apr 2023 21:23:51 GMT).