### PR TITLE
Mark imported assets as trusted

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -1859,7 +1859,14 @@ export default class Main extends BaseService<never> {
     asset: SmartContractFungibleAsset
     addressNetwork: AddressOnNetwork
   }): Promise<void> {
-    await this.indexingService.importAccountCustomToken(asset, addressNetwork)
+    const { metadata = {} } = asset
+    // Manually imported tokens are trusted
+    metadata.trusted = true
+
+    await this.indexingService.importAccountCustomToken(
+      { ...asset, metadata },
+      addressNetwork
+    )
   }
 
   private connectPopupMonitor() {

--- a/background/redux-slices/utils/asset-utils.ts
+++ b/background/redux-slices/utils/asset-utils.ts
@@ -341,6 +341,10 @@ export function heuristicDesiredDecimalsForUnitPrice(
  */
 export function isUntrustedAsset(asset: AnyAsset | undefined): boolean {
   if (asset) {
+    if (asset.metadata?.trusted === true) {
+      return false
+    }
+
     const numTokenLists = asset?.metadata?.tokenLists?.length ?? 0
     const baseAsset = isNetworkBaseAsset(asset)
 

--- a/ui/pages/Settings/SettingsCustomNetworks.tsx
+++ b/ui/pages/Settings/SettingsCustomNetworks.tsx
@@ -31,9 +31,7 @@ export default function SettingsCustomNetworks(): ReactElement {
 
   return (
     <div className="standard_width_padded wrapper">
-      <SharedPageHeader withoutBackText backPath="/settings">
-        {t(`title`)}
-      </SharedPageHeader>
+      <SharedPageHeader withoutBackText>{t(`title`)}</SharedPageHeader>
       {customNetworksListItems.length > 0 && (
         <section className="content">
           <h2 className="subheader">{t("subtitleAdded")}</h2>


### PR DESCRIPTION
This somehow got reverted after merging main into #3233

Also includes a fix for the back button at custom networks settings page

## Testing Env

```
SUPPORT_CUSTOM_NETWORKS=true
SUPPORT_CUSTOM_RPCS=true
```

## To Test
- [x] Import a token, should not appear in hidden assets or display a warning sign in the asset list
- [ ] Open the top menu network switcher, scroll down and click on add network. Click the back button, you should be where you started.
- [x] Go to settings -> custom networks, then test the back button works correctly

Latest build: [extension-builds-3290](https://github.com/tahowallet/extension/suites/12366435754/artifacts/656801830) (as of Thu, 20 Apr 2023 11:10:14 GMT).