### PR TITLE
Make input label's background transparent

### DIFF
--- a/ui/components/Keyring/KeyringUnlock.tsx
+++ b/ui/components/Keyring/KeyringUnlock.tsx
@@ -95,7 +95,6 @@ export default function KeyringUnlock({
                 setErrorMessage("")
               }}
               errorMessage={errorMessage}
-              focusedLabelBackgroundColor="var(--green-95)"
             />
           </div>
           <div>

--- a/ui/components/NetworkFees/NetworkSettingsSelect.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelect.tsx
@@ -294,7 +294,6 @@ export default function NetworkSettingsSelect({
               }}
               label={t("networkFees.gasLimit")}
               type="number"
-              focusedLabelBackgroundColor="var(--green-95)"
               step={1000}
             />
           </div>

--- a/ui/components/NetworkFees/NetworkSettingsSelectArbitrum.tsx
+++ b/ui/components/NetworkFees/NetworkSettingsSelectArbitrum.tsx
@@ -219,7 +219,6 @@ export default function NetworkSettingsSelectArbitrum({
             }}
             label="Gas limit"
             type="number"
-            focusedLabelBackgroundColor="var(--green-95)"
             step={1000}
           />
         </div>

--- a/ui/components/Onboarding/OnboardingDerivationPathSelect.tsx
+++ b/ui/components/Onboarding/OnboardingDerivationPathSelect.tsx
@@ -160,7 +160,6 @@ export default function OnboardingDerivationPathSelect({
                 id="custom_path_label"
                 label={t("pathLabel")}
                 onChange={(value) => setCustomPathLabel(value)}
-                focusedLabelBackgroundColor="var(--green-120)"
                 value={customPathLabel}
               />
             </div>
@@ -169,7 +168,6 @@ export default function OnboardingDerivationPathSelect({
                 id="custom_path_value"
                 label={`${t("customPath")} (m/44'/0'/0)`}
                 onFocus={() => setModalStep(2)}
-                focusedLabelBackgroundColor="var(--green-120)"
                 value={customPathValue}
               />
             </div>

--- a/ui/components/Shared/SharedInput.tsx
+++ b/ui/components/Shared/SharedInput.tsx
@@ -8,7 +8,6 @@ interface Props<T> {
   label?: string
   name?: string
   maxLength?: number
-  focusedLabelBackgroundColor: string
   placeholder?: string
   type: "password" | "text" | "number"
   value?: string | undefined
@@ -32,7 +31,6 @@ export function SharedTypedInput<T = string>(props: Props<T>): ReactElement {
     label,
     placeholder,
     maxLength,
-    focusedLabelBackgroundColor,
     type,
     name,
     onChange,
@@ -158,6 +156,7 @@ export function SharedTypedInput<T = string>(props: Props<T>): ReactElement {
             color: var(--green-40);
             transition: font-size 0.2s ease, transform 0.2s ease,
               font-weight 0.2s ease, padding 0.2s ease;
+            backdrop-filter: blur(100px);
           }
           input:disabled {
             color: var(--green-40);
@@ -180,7 +179,6 @@ export function SharedTypedInput<T = string>(props: Props<T>): ReactElement {
             font-size: 12px;
             font-weight: 500;
             padding: 0px 6px;
-            background-color: ${focusedLabelBackgroundColor};
           }
           .error ~ label,
           input.error:focus ~ label {
@@ -207,7 +205,6 @@ export function SharedTypedInput<T = string>(props: Props<T>): ReactElement {
 
 SharedTypedInput.defaultProps = {
   type: "text",
-  focusedLabelBackgroundColor: "var(--hunter-green)",
 }
 
 export default function SharedInput(


### PR DESCRIPTION
Resolves https://github.com/tahowallet/extension/issues/3269

### What
Try to make transparent background that will ignore input border by using blur effect.

WIP - Animation is not perfect as blur catches border color during the transition.

![image](https://user-images.githubusercontent.com/20949277/233369137-7026bd5e-e8d8-4472-ad93-905927dba2be.png)


https://user-images.githubusercontent.com/20949277/233369054-187cae70-a046-43ce-88d1-dbf40176278b.mov



Latest build: [extension-builds-3291](https://github.com/tahowallet/extension/suites/12368619258/artifacts/656954723) (as of Thu, 20 Apr 2023 12:47:03 GMT).