### PR TITLE
Change expect timeout on CI to handle loading NFTs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,7 @@ const config: PlaywrightTestConfig = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: (CI_ENV ? 30 : 15) * SECOND,
+    timeout: (CI_ENV ? 60 : 15) * SECOND,
   },
   /* Run tests in files in parallel */
   fullyParallel: false,


### PR DESCRIPTION
### What
We have a problem with the E2E test that was checking NFTs balance after a wallet was loaded.
Seems like this request may take longer than 30s but CI wasn't waiting long enough. Let's try making `expect` timeout 60s. Tried 5 times on this PR and it seems fine.

Latest build: [extension-builds-3300](https://github.com/tahowallet/extension/suites/12437097546/artifacts/661990529) (as of Mon, 24 Apr 2023 10:28:04 GMT).