### PR TITLE
Fix the issue with the position of the abilities tooltip

### DIFF
--- a/ui/pages/Abilities.tsx
+++ b/ui/pages/Abilities.tsx
@@ -34,9 +34,11 @@ export default function Abilities(): ReactElement {
           <h1>{t("header")}</h1>
           <div className="filters_container">
             <SharedTooltip
-              horizontalPosition="left"
               width={36}
+              height={32}
               verticalPosition="bottom"
+              horizontalPosition="center"
+              horizontalShift={8}
               type="dark"
               isOpen={openFilterMenu}
               IconComponent={() => (


### PR DESCRIPTION
This PR improves the tooltip position on the abilities page.

### UI

Before
![image](https://user-images.githubusercontent.com/23117945/233647447-3174a2c3-efd3-4d23-8db8-4cb3164a0d3e.png)

After
![Screenshot 2023-04-21 at 15 23 17](https://user-images.githubusercontent.com/23117945/233647355-f1aaf126-7e82-4891-b711-df2a0f59a062.png)
