### PR TITLE
Fix the issue with showing an incorrect asset swap preview

### DIFF
--- a/ui/components/Signing/SignatureDetails/TransactionSignatureDetails/TransactionSignatureSummary/SwapAssetSummary.tsx
+++ b/ui/components/Signing/SignatureDetails/TransactionSignatureDetails/TransactionSignatureSummary/SwapAssetSummary.tsx
@@ -44,16 +44,14 @@ export default function SwapAssetSummary({
     enrichAssetAmountWithMainCurrencyValues(toAssetAmount, toAssetPricePoint, 2)
       .localizedMainCurrencyAmount ?? "-"
 
-  const { sellAmount, buyAmount } = {
-    sellAmount: utils.formatUnits(
-      fromAssetAmount.amount,
-      fromAssetAmount.asset.decimals
-    ),
-    buyAmount: utils.formatUnits(
-      toAssetAmount.amount,
-      toAssetAmount.asset.decimals
-    ),
-  }
+  const sellAmount = utils.formatUnits(
+    fromAssetAmount.amount,
+    fromAssetAmount.asset.decimals
+  )
+  const buyAmount = utils.formatUnits(
+    toAssetAmount.amount,
+    toAssetAmount.asset.decimals
+  )
 
   return (
     <>

--- a/ui/components/Signing/SignatureDetails/TransactionSignatureDetails/TransactionSignatureSummary/SwapAssetSummary.tsx
+++ b/ui/components/Signing/SignatureDetails/TransactionSignatureDetails/TransactionSignatureSummary/SwapAssetSummary.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tallyho/tally-background/redux-slices/selectors"
 import { selectAssetPricePoint } from "@tallyho/tally-background/redux-slices/assets"
 import { useTranslation } from "react-i18next"
+import { utils } from "ethers"
 import { TransactionSignatureSummaryProps } from "./TransactionSignatureSummaryProps"
 import { useBackgroundSelector } from "../../../../../hooks"
 import SigningDataTransactionSummaryBody from "./TransactionSignatureSummaryBody"
@@ -43,6 +44,17 @@ export default function SwapAssetSummary({
     enrichAssetAmountWithMainCurrencyValues(toAssetAmount, toAssetPricePoint, 2)
       .localizedMainCurrencyAmount ?? "-"
 
+  const { sellAmount, buyAmount } = {
+    sellAmount: utils.formatUnits(
+      fromAssetAmount.amount,
+      fromAssetAmount.asset.decimals
+    ),
+    buyAmount: utils.formatUnits(
+      toAssetAmount.amount,
+      toAssetAmount.asset.decimals
+    ),
+  }
+
   return (
     <>
       <h1 className="serif_header title">Swap assets</h1>
@@ -64,13 +76,13 @@ export default function SwapAssetSummary({
           <SwapQuoteAssetCard
             label={t("sellAsset")}
             asset={fromAssetAmount.asset}
-            amount={fromAssetAmount.localizedDecimalAmount}
+            amount={sellAmount}
           />
           <span className="icon_switch" />
           <SwapQuoteAssetCard
             label={t("buyAsset")}
             asset={toAssetAmount.asset}
-            amount={toAssetAmount.localizedDecimalAmount}
+            amount={buyAmount}
           />
         </div>
         <span className="label label_right">


### PR DESCRIPTION
Closes #2651 

### What
"Swap Assets" transaction confirmation screen shows an incorrect asset swap preview

### UI
Before
![Screenshot 2023-04-24 at 13 44 56](https://user-images.githubusercontent.com/23117945/233987141-4557fc48-59a7-47a3-9beb-f6a63f371df3.png)

After
https://user-images.githubusercontent.com/23117945/233987911-98c35439-6814-41b6-88fd-08221fe60161.mov

Latest build: [extension-builds-3305](https://github.com/tahowallet/extension/suites/12439280615/artifacts/662140865) (as of Mon, 24 Apr 2023 12:02:04 GMT).