### PR TITLE
Display a warning message when custom asset balance is dust

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -1870,10 +1870,14 @@ export default class Main extends BaseService<never> {
 
     const priceData = await getTokenPrices([contractAddress], USD, network)
 
-    const convertedAssetAmount = convertAssetAmountViaPricePoint(
-      assetData,
-      getPricePoint(assetData.asset, priceData[contractAddress])
-    )
+    const convertedAssetAmount =
+      contractAddress in priceData
+        ? convertAssetAmountViaPricePoint(
+            assetData,
+            getPricePoint(assetData.asset, priceData[contractAddress])
+          )
+        : undefined
+
     const mainCurrencyAmount = convertedAssetAmount
       ? assetAmountToDesiredDecimals(convertedAssetAmount, 2)
       : undefined

--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -59,7 +59,7 @@ const EXCEPTION_ASSETS_BY_SYMBOL = ["BTC", "sBTC", "WBTC", "tBTC"].map(
 )
 
 // TODO Make this a setting.
-const userValueDustThreshold = 2
+export const userValueDustThreshold = 2
 
 const shouldForciblyDisplayAsset = (
   assetAmount: CompleteAssetAmount<AnyAsset>

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -551,6 +551,7 @@
       "networkSelect.title": "Select Network",
       "warning.alreadyExists.title": "Asset already exists, you will see it once your balance is over 0",
       "warning.alreadyExists.desc": "If you still have issues seeing an asset, turn off “hide balance 2$” from Settings",
+      "warning.dust.title": "Asset balance is under <$2, you wil see it once your balance is over $2",
       "error.invalidToken": "Invalid contract address",
       "submit": "Add asset",
       "snackbar.success": "Asset added successfully",

--- a/ui/pages/Settings/SettingsAddCustomAsset.tsx
+++ b/ui/pages/Settings/SettingsAddCustomAsset.tsx
@@ -88,9 +88,6 @@ export default function SettingsAddCustomAsset(): ReactElement {
   const [tokenAddress, setTokenAddress] = useState("")
 
   const dispatch = useBackgroundDispatch()
-
-  const hideDustEnabled = useBackgroundSelector(selectHideDust)
-
   const currentNetwork = useBackgroundSelector(selectCurrentNetwork)
   const allNetworks = useBackgroundSelector(selectEVMNetworks)
   const showTestNetworks = useBackgroundSelector(selectShowTestNetworks)
@@ -149,6 +146,12 @@ export default function SettingsAddCustomAsset(): ReactElement {
     await dispatch(setSnackbarMessage(t("snackbar.success")))
     history.push("/")
   }
+
+  const hideDustEnabled = useBackgroundSelector(selectHideDust)
+  const showWarningAboutDust =
+    hideDustEnabled &&
+    assetData?.mainCurrencyAmount !== undefined &&
+    assetData?.mainCurrencyAmount < userValueDustThreshold
 
   return (
     <div className="standard_width_padded wrapper">
@@ -327,26 +330,21 @@ export default function SettingsAddCustomAsset(): ReactElement {
           </div>
         ) : (
           <>
-            {hideDustEnabled &&
-              assetData?.mainCurrencyAmount !== undefined &&
-              assetData?.mainCurrencyAmount < userValueDustThreshold && (
-                <div className="alert">
-                  <SharedIcon
-                    color="var(--attention)"
-                    width={24}
-                    customStyles="min-width: 24px;"
-                    icon="icons/m/notif-attention.svg"
-                  />
-                  <div className="alert_content">
-                    <div
-                      className="title"
-                      style={{ color: "var(--attention)" }}
-                    >
-                      {t("warning.dust.title")}
-                    </div>
+            {showWarningAboutDust && (
+              <div className="alert">
+                <SharedIcon
+                  color="var(--attention)"
+                  width={24}
+                  customStyles="min-width: 24px;"
+                  icon="icons/m/notif-attention.svg"
+                />
+                <div className="alert_content">
+                  <div className="title" style={{ color: "var(--attention)" }}>
+                    {t("warning.dust.title")}
                   </div>
                 </div>
-              )}
+              </div>
+            )}
           </>
         )}
       </form>

--- a/ui/pages/Settings/SettingsAddCustomAsset.tsx
+++ b/ui/pages/Settings/SettingsAddCustomAsset.tsx
@@ -8,7 +8,10 @@ import {
   checkTokenContractDetails,
   importAccountCustomToken,
 } from "@tallyho/tally-background/redux-slices/assets"
-import { selectCurrentNetwork } from "@tallyho/tally-background/redux-slices/selectors"
+import {
+  selectCurrentNetwork,
+  userValueDustThreshold,
+} from "@tallyho/tally-background/redux-slices/selectors"
 import { selectEVMNetworks } from "@tallyho/tally-background/redux-slices/selectors/networks"
 import {
   selectShowTestNetworks,
@@ -319,22 +322,26 @@ export default function SettingsAddCustomAsset(): ReactElement {
           </div>
         ) : (
           <>
-            {/* TODO change condition */}
-            {assetData?.balance && true && (
-              <div className="alert">
-                <SharedIcon
-                  color="var(--attention)"
-                  width={24}
-                  customStyles="min-width: 24px;"
-                  icon="icons/m/notif-attention.svg"
-                />
-                <div className="alert_content">
-                  <div className="title" style={{ color: "var(--attention)" }}>
-                    {t("warning.dust.title")}
+            {/* TODO change condition, check the price in $ */}
+            {assetData?.balance !== undefined &&
+              assetData?.balance < userValueDustThreshold && (
+                <div className="alert">
+                  <SharedIcon
+                    color="var(--attention)"
+                    width={24}
+                    customStyles="min-width: 24px;"
+                    icon="icons/m/notif-attention.svg"
+                  />
+                  <div className="alert_content">
+                    <div
+                      className="title"
+                      style={{ color: "var(--attention)" }}
+                    >
+                      {t("warning.dust.title")}
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
           </>
         )}
       </form>

--- a/ui/pages/Settings/SettingsAddCustomAsset.tsx
+++ b/ui/pages/Settings/SettingsAddCustomAsset.tsx
@@ -304,7 +304,7 @@ export default function SettingsAddCustomAsset(): ReactElement {
             {t("submit")}
           </SharedButton>
         </div>
-        {assetData?.exists && (
+        {assetData?.exists ? (
           <div className="alert">
             <SharedIcon
               color="var(--success)"
@@ -317,6 +317,25 @@ export default function SettingsAddCustomAsset(): ReactElement {
               <div className="desc">{t("warning.alreadyExists.desc")}</div>
             </div>
           </div>
+        ) : (
+          <>
+            {/* TODO change condition */}
+            {assetData?.balance && true && (
+              <div className="alert">
+                <SharedIcon
+                  color="var(--attention)"
+                  width={24}
+                  customStyles="min-width: 24px;"
+                  icon="icons/m/notif-attention.svg"
+                />
+                <div className="alert_content">
+                  <div className="title" style={{ color: "var(--attention)" }}>
+                    {t("warning.dust.title")}
+                  </div>
+                </div>
+              </div>
+            )}
+          </>
         )}
       </form>
       <style jsx>{`

--- a/ui/pages/Settings/SettingsAddCustomAsset.tsx
+++ b/ui/pages/Settings/SettingsAddCustomAsset.tsx
@@ -14,6 +14,7 @@ import {
 } from "@tallyho/tally-background/redux-slices/selectors"
 import { selectEVMNetworks } from "@tallyho/tally-background/redux-slices/selectors/networks"
 import {
+  selectHideDust,
   selectShowTestNetworks,
   setSnackbarMessage,
 } from "@tallyho/tally-background/redux-slices/ui"
@@ -87,9 +88,13 @@ export default function SettingsAddCustomAsset(): ReactElement {
   const [tokenAddress, setTokenAddress] = useState("")
 
   const dispatch = useBackgroundDispatch()
+
+  const hideDustEnabled = useBackgroundSelector(selectHideDust)
+
   const currentNetwork = useBackgroundSelector(selectCurrentNetwork)
   const allNetworks = useBackgroundSelector(selectEVMNetworks)
   const showTestNetworks = useBackgroundSelector(selectShowTestNetworks)
+
   const networks = allNetworks.filter(
     (network) =>
       !TEST_NETWORK_BY_CHAIN_ID.has(network.chainID) ||
@@ -287,7 +292,7 @@ export default function SettingsAddCustomAsset(): ReactElement {
             )}
             <div className="token_details">
               <div className="balance">
-                <strong>
+                <strong title={String(assetData?.balance)}>
                   {assetData?.balance ?? t("asset.label.balance")}
                 </strong>
                 <span className="symbol">
@@ -322,9 +327,9 @@ export default function SettingsAddCustomAsset(): ReactElement {
           </div>
         ) : (
           <>
-            {/* TODO change condition, check the price in $ */}
-            {assetData?.balance !== undefined &&
-              assetData?.balance < userValueDustThreshold && (
+            {hideDustEnabled &&
+              assetData?.mainCurrencyAmount !== undefined &&
+              assetData?.mainCurrencyAmount < userValueDustThreshold && (
                 <div className="alert">
                   <SharedIcon
                     color="var(--attention)"
@@ -429,6 +434,10 @@ export default function SettingsAddCustomAsset(): ReactElement {
           font-size: 18px;
           line-height: 24px;
           color: var(--white);
+          text-overflow: ellipsis;
+          overflow-x: hidden;
+          white-space: pre;
+          max-width: 100px;
         }
 
         .symbol {


### PR DESCRIPTION
Shows a warning message when the user has enabled "Hide assets under 2$" and attempts to add a token which balance is below the threshold.

<img width="384" alt="image" src="https://user-images.githubusercontent.com/28708889/234117749-b923d45f-962c-4f4a-8e89-a233d1553282.png">

## To Test
- [x] Apply [this patch](https://gist.github.com/hyphenized/3c513e7399b2b7d82c1142a9919ac107)
- [x] Reinstall the extension, import `bnbspider2.crypto` as a readonly account
- [x] On settings, enable "Hide assets under 2$"
- [ ] Go to the add custom token screen and attempt to add:
		- `0xdbdb4d16eda451d0503b854cf79d55697f90c8df` You should see the dust balance warning
		- `0x8965349fb649a33a30cbfda057d8ec2c48abe2a2` You should not see the warning as there's no price data
		- `0x6c28AeF8977c9B773996d0e8376d2EE379446F2f` You should not see the warning since the $ value exceeds the threshold
- [x] With the hide dust setting turned off it should not display the warning for all previous test cases

Latest build: [extension-builds-3307](https://github.com/tahowallet/extension/suites/12466162180/artifacts/664180075) (as of Tue, 25 Apr 2023 11:12:04 GMT).