### PR TITLE
Fixing the account name issue when adding it again

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -644,6 +644,8 @@ export default class Main extends BaseService<never> {
     await this.providerBridgeService.revokePermissionsForAddress(address)
     // TODO Adjust to handle specific network.
     await this.signingService.removeAccount(address, signer.type)
+
+    this.nameService.removeAccount(address)
   }
 
   async importLedgerAccounts(

--- a/background/services/name/index.ts
+++ b/background/services/name/index.ts
@@ -310,6 +310,14 @@ export default class NameService extends BaseService<Events> {
     }
   }
 
+  removeAccount(address: HexString): void {
+    const chainIds = Object.keys(this.cachedResolvedNames.EVM)
+
+    chainIds.forEach((chainId) => {
+      this.clearNameCacheEntry(chainId, address)
+    })
+  }
+
   async lookUpAvatar(
     addressOnNetwork: AddressOnNetwork
   ): Promise<ResolvedAvatarRecord | undefined> {


### PR DESCRIPTION
Closes  #2097

### What
When we add an account and then remove it, we do not clear the data in the name service. After re-adding, we do not update the names because they are still stored in `cachedResolvedNames`.  Check this part of the [code](https://github.com/tahowallet/extension/blob/main/background/services/name/index.ts#L299:L302). 

If you know of other steps to reproduce this issue let us know below.

### UI

Before

https://user-images.githubusercontent.com/23117945/234500672-711e1e7e-438f-414f-9126-5ac96a487816.mov

<img width="381" alt="Screenshot 2023-04-26 at 09 34 16" src="https://user-images.githubusercontent.com/23117945/234503004-02688099-6649-4ae1-8a6e-d8fdd33a2bb5.png">

After

https://user-images.githubusercontent.com/23117945/234503355-33542e67-41a2-4b92-9459-0ccd31e17dc0.mov
<img width="387" alt="Screenshot 2023-04-26 at 09 36 34" src="https://user-images.githubusercontent.com/23117945/234503532-06d08133-a291-418e-859d-942863dbc932.png">


### To Test
- [ ] import account with ENS, remove it, add it again
- [ ] add read-only account with ENS, remove it, add it again - no ENS resolution

Latest build: [extension-builds-3308](https://github.com/tahowallet/extension/suites/12470066557/artifacts/664454250) (as of Tue, 25 Apr 2023 13:49:58 GMT).