### PR TITLE
Custom Networks - Copy changes

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -545,22 +545,22 @@
     "addCustomAssetSettings": {
       "title": "Add custom asset",
       "input.contractAddress.label": "Contract address",
-      "input.tooltip": " Visit your preferred block explorer and find the asset you want to import.<br>Copy and paste the contract address here.<br><br>For more information visit <url>Help Center</url>",
+      "input.tooltip": "Find the asset on your favorite block explorer, then copy the contract address here.<br><br>Haven't done this before? Check out <url>Knowledge Center</url> first.",
       "asset.label.balance": "Balance",
       "asset.label.symbol": "Name",
       "networkSelect.title": "Select Network",
       "warning.alreadyExists.title": "Asset already exists, you will see it once your balance is over 0",
-      "warning.alreadyExists.desc": "If you still have issues seeing an asset, turn off “hide balance 2$” from Settings",
+      "warning.alreadyExists.desc": "If you still have issues seeing an asset, turn off “Hide asset balances under 2$” from Settings",
       "warning.dust.title": "Asset balance is under <$2, you wil see it once your balance is over $2",
       "error.invalidToken": "Invalid contract address",
       "submit": "Add asset",
       "snackbar.success": "Asset added successfully",
-      "footer.hint": "How to add a custom asset?"
+      "footer.hint": "How to add a custom asset"
     },
     "customNetworksSettings": {
       "title": "Custom networks",
       "ariaLabel": "Open custom networks page",
-      "subtitleAdded": "Added chains",
+      "subtitleAdded": "Manage chains",
       "subtitleAddMore": "Add more chains",
       "deleteModal.title": "Remove custom network?",
       "deleteModal.desc": "You are removing <name>{{name}}</name> network. This means you won't be able to see assets from it and it won't be in your network selection list. ",
@@ -569,7 +569,7 @@
         "typeCustom": "Custom network"
       },
       "chainList": {
-        "description": "Fastest and safest way of adding a custom network is by visiting <url></url>, connecting your wallet and adding the chains you wish to see.",
+        "description": "<url></url> is the fastest, safest way to add a custom network. Just connect your wallet, search for the network you want to add, and click <strong>Add to Taho</strong>.",
         "addBtn": "Add chains with Chainlist"
       },
       "customRPC": {
@@ -663,7 +663,7 @@
     }
   },
   "addNewChain": {
-    "subtitle": "Wants to add a main network to Taho",
+    "subtitle": "Wants to add a custom network to Taho",
     "name": "Name",
     "chainId": "Chain ID",
     "currency": "Currency",
@@ -671,7 +671,7 @@
     "explorer": "BlockExplorer",
     "submit": "Add network",
     "cancel": "Reject",
-    "warnAlreadyExistsHeader": "Network already added to Taho wallet.",
+    "warnAlreadyExistsHeader": "Network already added to Taho.",
     "warnAlreadyExistsBody": "You can switch to it from Network dropdown"
   },
   "swap": {

--- a/ui/components/Shared/SharedNetworkIcon.tsx
+++ b/ui/components/Shared/SharedNetworkIcon.tsx
@@ -81,6 +81,7 @@ export default function SharedNetworkIcon(props: {
           justify-content: center;
           user-select: none;
           color: var(--white);
+          border-radius: ${size < 24 ? 2 : 3}px;
         }
         .icon_network {
           background: url("${sources[currentSource]}");

--- a/ui/pages/Settings/SettingsAddCustomAsset.tsx
+++ b/ui/pages/Settings/SettingsAddCustomAsset.tsx
@@ -275,7 +275,6 @@ export default function SettingsAddCustomAsset(): ReactElement {
                         textDecoration: "underline",
                         "--link-color": "var(--green-95)",
                         "--hover-color": "var(--green-40)",
-                        marginLeft: "-4px",
                       }}
                       type="button"
                       url={HELPDESK_CUSTOM_TOKENS_LINK}


### PR DESCRIPTION
Closes #3317, #3318, #3319, #3320, #3324 

Also adds rounded corners to network fallback icons


## To Test
- [x] Check messages displayed in the UI match the copy updates
- [x] Check fallback icons for custom networks

Latest build: [extension-builds-3328](https://github.com/tahowallet/extension/suites/12515171347/artifacts/667837920) (as of Thu, 27 Apr 2023 04:55:52 GMT).