### PR TITLE
Add (beta) label to custom network menu options

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -494,7 +494,7 @@
     "addCustomAsset": "Add custom assets",
     "analytics": "Analytics",
     "needHelp": "Need Help?",
-    "customNetworks": "Custom networks",
+    "customNetworks": "Custom networks (beta)",
     "showBanners": "Show achievement banners",
     "versionLabel": "Version {{version}}",
     "unknownVersionOrCommit": "<unknown>",
@@ -558,7 +558,7 @@
       "footer.hint": "How to add a custom asset"
     },
     "customNetworksSettings": {
-      "title": "Custom networks",
+      "title": "Custom networks (beta)",
       "ariaLabel": "Open custom networks page",
       "subtitleAdded": "Manage chains",
       "subtitleAddMore": "Add more chains",
@@ -728,7 +728,7 @@
     "protocolList": {
       "testnetsSectionTitle": "Testnets",
       "customNetworksSectionTitle": "Custom networks",
-      "networkSettingsBtn": "Add network"
+      "networkSettingsBtn": "Add network (beta)"
     },
     "connectedDappInfo": {
       "modalClose": "Background close",


### PR DESCRIPTION
<img width="379" alt="image" src="https://user-images.githubusercontent.com/94649004/235003931-c1f2f429-f0ea-4f66-98ff-42df5cec3a25.png">

<img width="377" alt="image" src="https://user-images.githubusercontent.com/94649004/235003948-8a6ed999-68c2-48c6-a335-3768d27ac3ff.png">

<img width="378" alt="image" src="https://user-images.githubusercontent.com/94649004/235004006-36b44287-a8f9-49ac-aad0-84f97522537f.png">


Latest build: [extension-builds-3335](https://github.com/tahowallet/extension/suites/12538186689/artifacts/669589536) (as of Thu, 27 Apr 2023 22:27:38 GMT).