### PR TITLE
Fix style regression issue for transaction warning

### DIFF
--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -260,3 +260,7 @@ export const CHAIN_ID_TO_OPENSEA_CHAIN = {
   [AVALANCHE.chainID]: "avalanche",
   [BINANCE_SMART_CHAIN.chainID]: "bsc",
 }
+
+export const NETWORKS_WITH_FEE_SETTINGS = new Set(
+  [ETHEREUM, POLYGON, ARBITRUM_ONE, AVALANCHE].map((network) => network.chainID)
+)

--- a/ui/components/SignTransaction/SignTransactionDetailPanel.tsx
+++ b/ui/components/SignTransaction/SignTransactionDetailPanel.tsx
@@ -14,8 +14,10 @@ import { useTranslation } from "react-i18next"
 import {
   BINANCE_SMART_CHAIN,
   EIP_1559_COMPLIANT_CHAIN_IDS,
+  isBuiltInNetwork,
 } from "@tallyho/tally-background/constants"
 import classNames from "classnames"
+import { selectCurrentNetwork } from "@tallyho/tally-background/redux-slices/selectors"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import FeeSettingsButton from "../NetworkFees/FeeSettingsButton"
 import NetworkSettingsChooser from "../NetworkFees/NetworkSettingsChooser"
@@ -47,8 +49,12 @@ export default function SignTransactionDetailPanel({
   const estimatedFeesPerGas = useBackgroundSelector(selectEstimatedFeesPerGas)
 
   const reduxTransactionData = useBackgroundSelector(selectTransactionData)
+
+  const selectedNetwork = useBackgroundSelector(selectCurrentNetwork)
   // If a transaction request is passed directly, prefer it over Redux.
   const transactionDetails = transactionRequest ?? reduxTransactionData
+
+  const currentNetwork = transactionDetails?.network || selectedNetwork
 
   const dispatch = useBackgroundDispatch()
 
@@ -139,6 +145,8 @@ export default function SignTransactionDetailPanel({
       <span
         className={classNames("detail_item warning", {
           visible: hasInsufficientFundsWarning,
+          hidden:
+            !isBuiltInNetwork(currentNetwork) && !hasInsufficientFundsWarning,
         })}
       >
         <SignTransactionDetailWarning
@@ -163,19 +171,22 @@ export default function SignTransactionDetailPanel({
             display: flex;
             margin-top: 21px;
             flex-direction: column;
-            height: 108px;
+            max-height: 108px;
           }
           .detail_item_right {
             color: var(--green-20);
             font-size: 16px;
           }
           .warning {
-            width: 384px;
-            transform: translateX(-100%);
+            width: 100%;
+            transform: translateX(calc(-100% - 24px));
             transition: transform ease-out 0.3s;
           }
           .warning.visible {
             transform: translateX(0);
+          }
+          .warning.hidden {
+            height: 0;
           }
         `}
       </style>

--- a/ui/components/SignTransaction/SignTransactionDetailPanel.tsx
+++ b/ui/components/SignTransaction/SignTransactionDetailPanel.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from "react-i18next"
 import {
   BINANCE_SMART_CHAIN,
   EIP_1559_COMPLIANT_CHAIN_IDS,
-  isBuiltInNetwork,
+  NETWORKS_WITH_FEE_SETTINGS,
 } from "@tallyho/tally-background/constants"
 import classNames from "classnames"
 import { selectCurrentNetwork } from "@tallyho/tally-background/redux-slices/selectors"
@@ -146,7 +146,9 @@ export default function SignTransactionDetailPanel({
         className={classNames("detail_item warning", {
           visible: hasInsufficientFundsWarning,
           hidden:
-            !isBuiltInNetwork(currentNetwork) && !hasInsufficientFundsWarning,
+            // Networks that have fee settings should have extra space for warning
+            !NETWORKS_WITH_FEE_SETTINGS.has(currentNetwork.chainID) &&
+            !hasInsufficientFundsWarning,
         })}
       >
         <SignTransactionDetailWarning


### PR DESCRIPTION
Closes https://github.com/tahowallet/extension/issues/3326

Please check this [PR](https://github.com/tahowallet/extension/pull/3088). When the network has the ability to change fees, we should leave extra space for a possible warning that will appear. Otherwise, there should be no extra space. 

For internal swaps, we have an additional tab - "Raw data". When we make an external swap there is a problem with additional space for example for the Optimism network. In this case, we should leave extra space for a possible warning. It is not the best solution but it is a quick fix. 

## UI
Before
<img width="200" alt="Screenshot 2023-04-28 at 11 13 49" src="https://user-images.githubusercontent.com/23117945/235107466-92501370-439f-43ac-baf6-655512dbfd0d.png">

After
<img width="250" alt="Screenshot 2023-04-28 at 11 05 10" src="https://user-images.githubusercontent.com/23117945/235107291-5450c918-9d60-42bc-be86-8cd774d53504.png">

<img width="250" alt="Screenshot 2023-04-28 at 11 07 32" src="https://user-images.githubusercontent.com/23117945/235107296-f88e3ab7-afea-4281-9e6c-867f5ad4b507.png">

<img width="250" alt="Screenshot 2023-04-28 at 13 57 49" src="https://user-images.githubusercontent.com/23117945/235141629-a02074ff-42ba-488e-b04e-f4bc1064048d.png">

https://user-images.githubusercontent.com/23117945/235107275-8b4f5fa2-bfc6-4635-95aa-e85349eae4a3.mov

**Extreme case**

https://user-images.githubusercontent.com/23117945/235142515-606be4de-0c6d-442f-b79c-5448ab8872d2.mov


## To Test
- [x] check styles on the internal swap page - when the network has a fee setting (it should have extra space)
- [x]  check styles on the internal swap page - when the network does not have a fee setting (it should not have extra space)
- [x] check styles on the external swap page for custom networks (it should not have extra space) 
- [x] check styles on the external swap page for the Optimism network (it should have extra space)

Latest build: [extension-builds-3337](https://github.com/tahowallet/extension/suites/12547180032/artifacts/670314053) (as of Fri, 28 Apr 2023 09:18:40 GMT).