### PR TITLE
Add zksync era specific multicall contract address

### DIFF
--- a/background/lib/erc20.ts
+++ b/background/lib/erc20.ts
@@ -13,6 +13,7 @@ import { HexString } from "../types"
 import { AddressOnNetwork } from "../accounts"
 import {
   AggregateContractResponse,
+  CHAIN_SPECIFIC_MULTICALL_CONTRACT_ADDRESSES,
   MULTICALL_ABI,
   MULTICALL_CONTRACT_ADDRESS,
 } from "./multicall"
@@ -192,8 +193,12 @@ export const getTokenBalances = async (
   tokenAddresses: HexString[],
   provider: Provider
 ): Promise<SmartContractAmount[]> => {
+  const multicallAddress =
+    CHAIN_SPECIFIC_MULTICALL_CONTRACT_ADDRESSES[network.chainID] ||
+    MULTICALL_CONTRACT_ADDRESS
+
   const contract = new ethers.Contract(
-    MULTICALL_CONTRACT_ADDRESS,
+    multicallAddress,
     MULTICALL_ABI,
     provider
   )

--- a/background/lib/multicall.ts
+++ b/background/lib/multicall.ts
@@ -10,10 +10,12 @@ export interface AggregateContractResponse {
   }>
 }
 
-// @TODO Handle chain-specific cases - but this contract should
-// be good enough for all popular chains in the meantime
 export const MULTICALL_CONTRACT_ADDRESS =
   "0xca11bde05977b3631167028862be2a173976ca11"
+
+export const CHAIN_SPECIFIC_MULTICALL_CONTRACT_ADDRESSES = {
+  "324": "0x47898B2C52C957663aE9AB46922dCec150a2272c", // zksync era
+} as { [chainId: string]: string }
 
 export const MULTICALL_ABI = [
   // https://github.com/mds1/multicall


### PR DESCRIPTION
Contract scan link: https://explorer.zksync.io/address/0x47898B2C52C957663aE9AB46922dCec150a2272c#contract

### To Test
- [ ] Add zkSync Era to the wallet.
- [ ] Attempt to add an ERC-20 token (e.g. [Liquity].(https://explorer.zksync.io/address/0x503234F203fC7Eb888EEC8513210612a43Cf6115))
- [ ] Adding the token should not fail.