### PR TITLE
Custom Networks - Add balances lookup fallback for networks without multicall support

### DIFF
--- a/background/lib/erc20.ts
+++ b/background/lib/erc20.ts
@@ -75,7 +75,7 @@ export async function getBalance(
   provider: BaseProvider,
   tokenAddress: string,
   account: string
-): Promise<BigInt> {
+): Promise<bigint> {
   const token = new ethers.Contract(tokenAddress, ERC20_ABI, provider)
 
   return BigInt((await token.balanceOf(account)).toString())

--- a/background/lib/multicall.ts
+++ b/background/lib/multicall.ts
@@ -10,12 +10,69 @@ export interface AggregateContractResponse {
   }>
 }
 
+const NETWORKS_SUPPORTING_MULTICALL_BY_CHAIN_ID = [
+  "1",
+  "3",
+  "4",
+  "5",
+  "10",
+  "42",
+  "137",
+  "69",
+  "100",
+  "420",
+  "42161",
+  "421611",
+  "421613",
+  "80001",
+  "11155111",
+  "43114",
+  "43113",
+  "4002",
+  "250",
+  "56",
+  "97",
+  "1284",
+  "1285",
+  "1287",
+  "1666600000",
+  "25",
+  "122",
+  "19",
+  "16",
+  "288",
+  "1313161554",
+  "592",
+  "66",
+  "128",
+  "1088",
+  "30",
+  "31",
+  "9001",
+  "9000",
+  "108",
+  "18",
+  "26863",
+  "42220",
+  "71402",
+  "71401",
+  "8217",
+  "2001",
+  "321",
+  "111",
+  "59140",
+]
+
 export const MULTICALL_CONTRACT_ADDRESS =
   "0xca11bde05977b3631167028862be2a173976ca11"
 
 export const CHAIN_SPECIFIC_MULTICALL_CONTRACT_ADDRESSES = {
   "324": "0x47898B2C52C957663aE9AB46922dCec150a2272c", // zksync era
 } as { [chainId: string]: string }
+
+export const networkSupportsMultiCall = (chainID: string): boolean =>
+  NETWORKS_SUPPORTING_MULTICALL_BY_CHAIN_ID.includes(chainID) ||
+  chainID in CHAIN_SPECIFIC_MULTICALL_CONTRACT_ADDRESSES
 
 export const MULTICALL_ABI = [
   // https://github.com/mds1/multicall

--- a/background/lib/multicall.ts
+++ b/background/lib/multicall.ts
@@ -10,69 +10,12 @@ export interface AggregateContractResponse {
   }>
 }
 
-const NETWORKS_SUPPORTING_MULTICALL_BY_CHAIN_ID = [
-  "1",
-  "3",
-  "4",
-  "5",
-  "10",
-  "42",
-  "137",
-  "69",
-  "100",
-  "420",
-  "42161",
-  "421611",
-  "421613",
-  "80001",
-  "11155111",
-  "43114",
-  "43113",
-  "4002",
-  "250",
-  "56",
-  "97",
-  "1284",
-  "1285",
-  "1287",
-  "1666600000",
-  "25",
-  "122",
-  "19",
-  "16",
-  "288",
-  "1313161554",
-  "592",
-  "66",
-  "128",
-  "1088",
-  "30",
-  "31",
-  "9001",
-  "9000",
-  "108",
-  "18",
-  "26863",
-  "42220",
-  "71402",
-  "71401",
-  "8217",
-  "2001",
-  "321",
-  "111",
-  "59140",
-]
-
 export const MULTICALL_CONTRACT_ADDRESS =
   "0xca11bde05977b3631167028862be2a173976ca11"
 
 export const CHAIN_SPECIFIC_MULTICALL_CONTRACT_ADDRESSES = {
   "324": "0x47898B2C52C957663aE9AB46922dCec150a2272c", // zksync era
 } as { [chainId: string]: string }
-
-export const networkSupportsMultiCall = (chainID: string): boolean =>
-  NETWORKS_SUPPORTING_MULTICALL_BY_CHAIN_ID.includes(chainID) ||
-  chainID in CHAIN_SPECIFIC_MULTICALL_CONTRACT_ADDRESSES
 
 export const MULTICALL_ABI = [
   // https://github.com/mds1/multicall

--- a/background/services/chain/asset-data-helper.ts
+++ b/background/services/chain/asset-data-helper.ts
@@ -37,34 +37,30 @@ export default class AssetDataHelper {
   constructor(private providerTracker: ProviderManager) {}
 
   async getTokenBalance(
-    addressOnNetwork: AddressOnNetwork,
-    smartContractAddress: HexString
+    { address, network }: AddressOnNetwork,
+    contractAddress: HexString
   ): Promise<SmartContractAmount> {
-    const provider = this.providerTracker.providerForNetwork(
-      addressOnNetwork.network
-    )
+    const provider = this.providerTracker.providerForNetwork(network)
 
     if (!provider) {
-      throw logger.buildError(
-        "Could not find a provider for network",
-        addressOnNetwork.network
-      )
+      throw logger.buildError("Could not find a provider for network", network)
     }
 
-    const balances = await getTokenBalances(
-      addressOnNetwork,
-      [smartContractAddress],
-      provider
+    const balance = await getBalance(provider, contractAddress, address).catch(
+      () => null
     )
 
-    if (balances.length < 1) {
+    if (balance === null) {
       throw logger.buildError(
-        "Unable to retrieve balances for contract",
-        smartContractAddress
+        "Unable to retrieve balance for contract",
+        contractAddress
       )
     }
 
-    return balances[0]
+    return {
+      smartContract: { contractAddress, homeNetwork: network },
+      amount: balance,
+    }
   }
 
   async getTokenBalances(


### PR DESCRIPTION
Closes #3336

Loads token balances through multiple requests on networks where the multicall contract might not be available

## To Test
- [ ] Comment out [this line](https://github.com/tallycash/extension/blob/35391a5891ee21ba41984d3106663c826518cb11/background/lib/multicall.ts#L70)
- [ ] Import this address as read only `0xf0ee42aa7a347a2d1e9dbdf5cfc42b66843ab33d`
- [ ] Import this token `0x3355df6D4c9C3035724Fd0e3914dE96A5a83aaf4` on zkSync era
- [ ] Importing the token should work and there should be no errors logged in the background page

Latest build: [extension-builds-3348](https://github.com/tahowallet/extension/suites/12696304699/artifacts/681316461) (as of Fri, 05 May 2023 09:40:23 GMT).