### PR TITLE
Round corners on custom network icons

### DIFF
--- a/ui/components/Shared/SharedNetworkIcon.tsx
+++ b/ui/components/Shared/SharedNetworkIcon.tsx
@@ -81,7 +81,7 @@ export default function SharedNetworkIcon(props: {
           justify-content: center;
           user-select: none;
           color: var(--white);
-          border-radius: ${size < 24 ? 2 : 3}px;
+          border-radius: 2px;
         }
         .icon_network {
           background: url("${sources[currentSource]}");


### PR DESCRIPTION
Closes https://github.com/tahowallet/extension/issues/3321

It looks like the dynamic sizing wasn't working at all so we would get a border radius of 0px every time.

Addressed per https://github.com/tahowallet/extension/issues/3321#issuecomment-1527118305

<img width="272" alt="image" src="https://user-images.githubusercontent.com/94649004/235557581-97e4d84a-4c60-4203-8c32-37c818f3200f.png">


Latest build: [extension-builds-3352](https://github.com/tahowallet/extension/suites/12606759478/artifacts/674557353) (as of Tue, 02 May 2023 01:07:23 GMT).