### PR TITLE
Catch Enter keypress on Unlock screen

### DIFF
--- a/ui/components/InternalSigner/InternalSignerUnlock.tsx
+++ b/ui/components/InternalSigner/InternalSignerUnlock.tsx
@@ -83,7 +83,11 @@ export default function InternalSignerUnlock({
       </div>
       <h1 className="serif_header">{t("title")}</h1>
       <div className="simple_text subtitle">{t("subtitle")}</div>
-      <form onSubmit={dispatchUnlockWallet}>
+      <form
+        role="presentation"
+        onSubmit={dispatchUnlockWallet}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
         <div className="signing_wrap">
           <div className="input_wrap">
             <PasswordInput


### PR DESCRIPTION
### What
To prevent Enter keypress to mess with other components listening for that key let's catch it on the Unlock screen so user can type password and press Enter to confirm.

### Testing
Confirm you can unlock by pressing Enter on:

- [x] full screen unlock screen - tabbed onboarding
- [x] popup full screen - for example while adding or removing accounts
- [x] slideup - export mnemonic
- [x] slideup - export private key

![image](https://user-images.githubusercontent.com/20949277/235644575-6460bdef-ac02-40b2-9eb2-a0ef5795961e.png)


Latest build: [extension-builds-3355](https://github.com/tahowallet/extension/suites/12615522781/artifacts/675227855) (as of Tue, 02 May 2023 10:41:45 GMT).