### PR TITLE
Fix the issue for QA checklist

### DIFF
--- a/.github/workflows/test-list/release-test-list.md
+++ b/.github/workflows/test-list/release-test-list.md
@@ -26,7 +26,7 @@ This release checklist should be performed before release is published.
    - [ ] check assets
    - [ ] check balance
    - [ ] check NFTs
-   - [ ] check abilities
+   - [ ] check abilities (abilities should not be displayed)
    - [ ] check activities
    - [ ] check overview page
 2. Add read-only account with UNS

--- a/.github/workflows/test-list/release-test-list.md
+++ b/.github/workflows/test-list/release-test-list.md
@@ -33,14 +33,14 @@ This release checklist should be performed before release is published.
    - [ ] check assets
    - [ ] check balance
    - [ ] check NFTs
-   - [ ] check abilities
+   - [ ] check abilities (abilities should not be displayed)
    - [ ] check activities
    - [ ] check overview page
 3. Add read-only account with 0x address
    - [ ] check assets
    - [ ] check balance
    - [ ] check NFTs
-   - [ ] check abilities
+   - [ ] check abilities (abilities should not be displayed)
    - [ ] check activities
    - [ ] check overview page
 4. Import account with a seed phrase


### PR DESCRIPTION
Abilities should not be displayed for read-only accounts.

**_Originally posted in https://github.com/tahowallet/extension/pull/3304#discussion_r1184669786_**

Latest build: [extension-builds-3364](https://github.com/tahowallet/extension/suites/12695934333/artifacts/681289464) (as of Fri, 05 May 2023 09:21:57 GMT).