### PR TITLE
Remove private key signers if they are replaced by accounts from HD wallet

### DIFF
--- a/background/redux-slices/abilities.ts
+++ b/background/redux-slices/abilities.ts
@@ -16,18 +16,18 @@ const isLedgerAccount = (
     .includes(address)
 
 const isImportOrInternalAccount = (
-  internalSigners: InternalSignerState,
+  internalSigner: InternalSignerState,
   address: NormalizedEVMAddress
 ): boolean =>
-  internalSigners.keyrings
+  internalSigner.keyrings
     .flatMap(({ addresses }) => addresses)
     .includes(address)
 
 const isPrivateKeyAccount = (
-  internalSigners: InternalSignerState,
+  internalSigner: InternalSignerState,
   address: NormalizedEVMAddress
 ): boolean =>
-  internalSigners.privateKeys
+  internalSigner.privateKeys
     .flatMap(({ addresses }) => addresses)
     .includes(address)
 
@@ -188,14 +188,14 @@ export const initAbilities = createBackgroundAsyncThunk(
     address: NormalizedEVMAddress,
     { dispatch, getState, extra: { main } }
   ) => {
-    const { ledger, internalSigners, abilities } = getState() as {
+    const { ledger, internalSigner, abilities } = getState() as {
       ledger: LedgerState
-      internalSigners: InternalSignerState
+      internalSigner: InternalSignerState
       abilities: AbilitiesState
     }
     if (
-      isImportOrInternalAccount(internalSigners, address) ||
-      isPrivateKeyAccount(internalSigners, address) ||
+      isImportOrInternalAccount(internalSigner, address) ||
+      isPrivateKeyAccount(internalSigner, address) ||
       isLedgerAccount(ledger, address)
     ) {
       await main.pollForAbilities(address)

--- a/background/services/internal-signer/index.ts
+++ b/background/services/internal-signer/index.ts
@@ -654,6 +654,8 @@ export default class InternalSignerService extends BaseService<Events> {
       )
     }
     this.#keyrings = filteredKeyrings
+    delete this.#signerMetadata[keyringId]
+
     return filteredKeyrings
   }
 
@@ -669,6 +671,8 @@ export default class InternalSignerService extends BaseService<Events> {
     }
 
     this.#privateKeys = filteredPrivateKeys
+    delete this.#signerMetadata[normalizeEVMAddress(address)]
+
     return filteredPrivateKeys
   }
 

--- a/background/services/internal-signer/index.ts
+++ b/background/services/internal-signer/index.ts
@@ -609,18 +609,21 @@ export default class InternalSignerService extends BaseService<Events> {
 
   /**
    * Remove signer from the service's memory.
+   * If it was imported with a private key then it will be completely removed from the service.
+   * If address belongs to the keyring then we will hide it without removing from underlying keyring.
+   * If that address is the last one from a given keyring then we will remove whole keyring.
    *
-   * @param address account to be hidden from UI
+   * @param address account to be removed from UI
    */
-  async hideAccount(address: HexString): Promise<void> {
+  async removeAccount(address: HexString): Promise<void> {
     this.#hiddenAccounts[address] = true
 
     const keyringSigner = this.#findKeyring(address)
     const privateKeySigner = this.#findPrivateKey(address)
 
-    if (!keyringSigner && !privateKeySigner) return
+    if (keyringSigner === null && privateKeySigner === null) return
 
-    if (keyringSigner) {
+    if (keyringSigner !== null) {
       const keyringAddresses = await keyringSigner.getAddresses()
 
       if (
@@ -635,7 +638,7 @@ export default class InternalSignerService extends BaseService<Events> {
       }
     }
 
-    if (privateKeySigner) {
+    if (privateKeySigner !== null) {
       this.#removePrivateKey(address)
     }
 

--- a/background/services/internal-signer/tests/index.unit.test.ts
+++ b/background/services/internal-signer/tests/index.unit.test.ts
@@ -116,20 +116,20 @@ describe("InternalSignerService", () => {
         keyringID: keyring.id ?? "",
       })
 
-      await internalSignerService.hideAccount(address)
+      await internalSignerService.removeAccount(address)
 
       const [updatedKeyring] = internalSignerService.getKeyrings()
 
       expect(updatedKeyring.addresses.length).toBe(1)
     })
     it("should be able to remove HD wallet by hiding all addresses", async () => {
-      await internalSignerService.hideAccount(HD_WALLET_MOCK.addresses[0])
+      await internalSignerService.removeAccount(HD_WALLET_MOCK.addresses[0])
       const keyrings = internalSignerService.getKeyrings()
 
       expect(keyrings.length).toBe(0)
     })
     it("should be able to remove HD wallet and add it again", async () => {
-      await internalSignerService.hideAccount(HD_WALLET_MOCK.addresses[0])
+      await internalSignerService.removeAccount(HD_WALLET_MOCK.addresses[0])
       await internalSignerService.importSigner({
         type: SignerSourceTypes.keyring,
         mnemonic: HD_WALLET_MOCK.mnemonic,
@@ -192,7 +192,7 @@ describe("InternalSignerService", () => {
       ).toBe("import")
     })
     it("should be able to remove pk wallet and add it again", async () => {
-      await internalSignerService.hideAccount(PK_WALLET_MOCK.address)
+      await internalSignerService.removeAccount(PK_WALLET_MOCK.address)
       expect(internalSignerService.getPrivateKeys().length).toBe(0)
 
       await internalSignerService.importSigner({

--- a/background/services/signing/index.ts
+++ b/background/services/signing/index.ts
@@ -166,7 +166,7 @@ export default class SigningService extends BaseService<Events> {
       switch (signerType) {
         case "privateKey":
         case "keyring":
-          await this.internalSignerService.hideAccount(address)
+          await this.internalSignerService.removeAccount(address)
           break
         case "ledger":
           await this.ledgerService.removeAddress(address)


### PR DESCRIPTION
Improvement mentioned in the [RFB 4: One-Off Keyring Design](https://github.com/tahowallet/extension/pull/3372/commits/6c71c8de122ab2e59f71e77c5d246921fccbcd90#diff-ed55cc77a7760815ad539b38803831098099e4912702cee612fa3565656a39bfR163-R165)
### What
To avoid storing duplicated key material let's remove duplicated accounts, HD wallet accounts should have higher priority than accounts imported with single private key.

### Testing

This was already working as intended from a user perspective but we were leaving "orphaned" duplicated accounts in the service

- [x] add account with private key - this should be account from mnemonic you know
- [x] add HD wallet using mnemonic - account should be removed from private keys section and added to the HD wallet. This should be observed in the wallet's interface and in the redux and service.

Latest build: [extension-builds-3377](https://github.com/tahowallet/extension/suites/12854108486/artifacts/692919980) (as of Fri, 12 May 2023 11:21:11 GMT).