### PR TITLE
Failing to Prepare: Add a SigningService hook for pre-notifying signers of a request

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -1195,17 +1195,8 @@ export default class Main extends BaseService<never> {
     this.internalEthereumProviderService.emitter.on(
       "transactionSignatureRequest",
       async ({ payload, resolver, rejecter }) => {
-        /**
-         * There is a case in which the user changes the settings on the ledger after connection.
-         * For example, it sets disabled blind signing. Before the transaction signature request
-         * ledger should be connected again to refresh the state. Without reconnection,
-         * the user doesn't receive an error message on how to fix it.
-         */
-        const isArbitraryDataSigningEnabled =
-          await this.ledgerService.isArbitraryDataSigningEnabled()
-        if (!isArbitraryDataSigningEnabled) {
-          this.connectLedger()
-        }
+        await this.signingService.prepareForSigningRequest()
+
         this.store.dispatch(
           clearTransactionState(TransactionConstructionStatus.Pending)
         )
@@ -1260,6 +1251,11 @@ export default class Main extends BaseService<never> {
         resolver: (result: string | PromiseLike<string>) => void
         rejecter: () => void
       }) => {
+        // Don't await, as the below enrichment is expected to take longer than
+        // signer prep. If that assumption breaks, we should probably await the
+        // two in parallel.
+        this.signingService.prepareForSigningRequest()
+
         const enrichedsignTypedDataRequest =
           await this.enrichmentService.enrichSignTypedDataRequest(payload)
         this.store.dispatch(typedDataRequest(enrichedsignTypedDataRequest))
@@ -1313,6 +1309,8 @@ export default class Main extends BaseService<never> {
         resolver: (result: string | PromiseLike<string>) => void
         rejecter: () => void
       }) => {
+        await this.signingService.prepareForSigningRequest()
+
         this.chainService.pollBlockPricesForNetwork(
           payload.account.network.chainID
         )

--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -580,13 +580,4 @@ export default class LedgerService extends BaseService<Events> {
 
     return signatureHex
   }
-
-  async isArbitraryDataSigningEnabled(): Promise<boolean> {
-    if (this.transport) {
-      const eth = new Eth(this.transport)
-      const appConfig = await eth.getAppConfiguration()
-      return appConfig.arbitraryDataEnabled !== 0
-    }
-    return false
-  }
 }

--- a/background/services/signing/index.ts
+++ b/background/services/signing/index.ts
@@ -170,6 +170,23 @@ export default class SigningService extends BaseService<Events> {
     await this.chainService.removeAccountToTrack(address)
   }
 
+  /**
+   * Requests that signers prepare for a signing request. For hardware wallets
+   * in particular, this can include refreshing connection information so that
+   * the status is up to date. For remote wallets, e.g. WalletConnect, it can
+   * include connection setup.
+   *
+   * Currently this method does not take information about the request, but if
+   * the required setup is expensive enough, the `from` address can be passed
+   * in so that signers are only set up when the request applies to them.
+   */
+  async prepareForSigningRequest(): Promise<void> {
+    // Refresh connected Ledger info indiscriminately. No real harm vs doing it
+    // only under certain circumstances, might even be more performant than
+    // testing whether the Ledger can sign for the requested `from` address.
+    await this.ledgerService.refreshConnectedLedger()
+  }
+
   async signTransaction(
     transactionRequest: TransactionRequest,
     accountSigner: AccountSigner


### PR DESCRIPTION
> “By failing to prepare, you are preparing to fail.”
>
> ― Benjamin Franklin

Some signers can require various types of setup when a new signing request is about to come in. Two quick examples are hardware wallets, which may need to explicitly refresh the connection state to make sure that the wallet is still connected and ready, or remote signers like WalletConnect (currently not supported), which might need to establish a remote connection to be able to make a request.

For the case where a Ledger did not have arbitrary data signing enabled specifically, 8dc160b landed a fix where a full connection refresh would be kicked off, fixing a specific bug. However, this led to an issue where arbitrary data signing information would be checked in certain cases when a Ledger was disconnected, throwing an error early in the signing process and preventing advancing to the signing stage even for non-Ledger signers.

This commit reworks that fix, instead providing a new method on the SigningService, which is responsible for coordinating between signers. This method, `prepareForSigningRequest`, is called immediately prior to passing a signing request (data, typed data, or transaction signing) to the UI, giving the signers an opportunity to do any setup they might need.

The method can be used in blocking fashion in cases where the UI will be presented quickly and the signer should already be prepared when the UI is presented; this is used for transaction signing and data signing. For typed data signing, the data is enriched before presenting the UI, and this will generally take much longer than the current implementation of signer preparation, so the call to `prepareForSigningRequest` is left un-awaited.

Currently, the signing service's implementation simply always asks the Ledger service to refresh its connection information in preparation for the request. Future refinement could pass the signing address and check whether the Ledger service is responsible for that address before refreshing connection information, but the current implementation seems to have pretty low overhead.

Fixes #3031.

## Testing

- [x] Repeat the test at https://github.com/tahowallet/extension/pull/2796#issue-1500202808 to ensure we have not introduced a regression for that fix.
- [x] After the above, disconnect the Ledger and try to swap one more time. The signing screen should come up, reflecting the disconnected state of the Ledger. Without this branch, the signing screen should be locked in a loading state.

Latest build: [extension-builds-3380](https://github.com/tahowallet/extension/suites/12845908941/artifacts/692276466) (as of Fri, 12 May 2023 03:12:50 GMT).