### PR TITLE
Ledger-en-dary: Categorize accounts by signer id instead of just keyring id

### DIFF
--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -45,6 +45,7 @@ import {
   ReadOnlyAccountSigner,
   SignerType,
 } from "../../services/signing"
+import { assertUnreachable } from "../../lib/utils/type-guards"
 
 // TODO What actual precision do we want here? Probably more than 2
 // TODO decimals? Maybe it's configurable?
@@ -285,15 +286,30 @@ export const selectCurrentAccountBalances = createSelector(
 export type AccountTotal = AddressOnNetwork & {
   shortenedAddress: string
   accountType: AccountType
-  // FIXME This is solely used for categorization.
-  // FIXME Add `categoryFor(accountSigner): string` utility function to
-  // FIXME generalize beyond keyrings.
-  keyringId: string | null
+  signerId: string | null
   path: string | null
   accountSigner: AccountSigner
   name?: string
   avatarURL?: string
   localizedTotalMainCurrencyAmount?: string
+}
+
+/**
+ * Given an account signer, resolves a unique id for that signer. Returns null
+ * for read-only accounts. This allows for grouping accounts together by the
+ * signer that can provide signatures for those accounts.
+ */
+function signerIdFor(accountSigner: AccountSigner): string | null {
+  switch (accountSigner.type) {
+    case "keyring":
+      return accountSigner.keyringID
+    case "ledger":
+      return accountSigner.deviceID
+    case "read-only":
+      return null
+    default:
+      return assertUnreachable(accountSigner)
+  }
 }
 
 export type CategorizedAccountTotals = { [key in AccountType]?: AccountTotal[] }
@@ -374,7 +390,7 @@ function getNetworkAccountTotalsByCategory(
       const shortenedAddress = truncateAddress(address)
 
       const accountSigner = accountSignersByAddress[address]
-      const keyringId = keyringsByAddresses[address]?.id
+      const signerId = signerIdFor(accountSigner)
       const path = keyringsByAddresses[address]?.path
 
       const accountType = getAccountType(
@@ -389,7 +405,7 @@ function getNetworkAccountTotalsByCategory(
           network,
           shortenedAddress,
           accountType,
-          keyringId,
+          signerId,
           path,
           accountSigner,
         }
@@ -400,7 +416,7 @@ function getNetworkAccountTotalsByCategory(
         network,
         shortenedAddress,
         accountType,
-        keyringId,
+        signerId,
         path,
         accountSigner,
         name: accountData.ens.name ?? accountData.defaultName,

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -299,136 +299,135 @@ export default function AccountsNotificationPanelAccounts({
 
   return (
     <div className="switcher_wrap">
-      {accountTypes
-        .filter((type) => (accountTotals[type]?.length ?? 0) > 0)
-        .map((accountType) => {
-          // Known-non-null due to above filter.
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const accountTotalsByType = accountTotals[accountType]!.reduce(
-            (acc, accountTypeTotal) => {
-              if (accountTypeTotal.keyringId) {
-                acc[accountTypeTotal.keyringId] ??= []
-                // Known-non-null due to above ??=
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                acc[accountTypeTotal.keyringId].push(accountTypeTotal)
-              } else {
-                acc.readOnly ??= []
-                acc.readOnly.push(accountTypeTotal)
-              }
-              return acc
-            },
-            {} as { [keyringId: string]: AccountTotal[] }
-          )
-          return (
-            <>
-              {!(
-                accountType === AccountType.Imported &&
-                (accountTotals[AccountType.Internal]?.length ?? 0)
-              ) && (
-                <div className="category_wrap simple_text">
-                  <p className="category_title">
-                    {walletTypeDetails[accountType].category}
-                  </p>
-                  {isEnabled(FeatureFlags.SUPPORT_KEYRING_LOCKING) &&
-                    (accountType === AccountType.Imported ||
-                      accountType === AccountType.Internal) && (
-                      <SigningButton
-                        onCurrentAddressChange={onCurrentAddressChange}
-                      />
-                    )}
-                </div>
-              )}
-              {Object.values(accountTotalsByType).map(
-                (accountTotalsByKeyringId, idx) => {
-                  return (
-                    <section key={accountType}>
-                      <WalletTypeHeader
-                        accountType={accountType}
-                        walletNumber={idx + 1}
-                        path={accountTotalsByKeyringId[0].path}
-                        accountSigner={
-                          accountTotalsByKeyringId[0].accountSigner
-                        }
-                        onClickAddAddress={
-                          accountType === "imported" ||
-                          accountType === "internal"
-                            ? () => {
-                                if (accountTotalsByKeyringId[0].keyringId) {
-                                  dispatch(
-                                    deriveAddress(
-                                      accountTotalsByKeyringId[0].keyringId
-                                    )
+      {accountTypes.map((accountType) => {
+        const accountTypeTotals = accountTotals[accountType]
+
+        // If there are no account totals for the given type, skip the section.
+        if (accountTypeTotals === undefined || accountTypeTotals.length <= 0) {
+          return <></>
+        }
+
+        const accountTotalsByType = accountTypeTotals.reduce(
+          (acc, accountTypeTotal) => {
+            if (accountTypeTotal.signerId) {
+              acc[accountTypeTotal.signerId] ??= []
+              acc[accountTypeTotal.signerId].push(accountTypeTotal)
+            } else {
+              acc.readOnly ??= []
+              acc.readOnly.push(accountTypeTotal)
+            }
+            return acc
+          },
+          {} as { [signerId: string]: AccountTotal[] }
+        )
+
+        return (
+          <>
+            {!(
+              accountType === AccountType.Imported &&
+              (accountTotals[AccountType.Internal]?.length ?? 0)
+            ) && (
+              <div className="category_wrap simple_text">
+                <p className="category_title">
+                  {walletTypeDetails[accountType].category}
+                </p>
+                {isEnabled(FeatureFlags.SUPPORT_KEYRING_LOCKING) &&
+                  (accountType === AccountType.Imported ||
+                    accountType === AccountType.Internal) && (
+                    <SigningButton
+                      onCurrentAddressChange={onCurrentAddressChange}
+                    />
+                  )}
+              </div>
+            )}
+            {Object.values(accountTotalsByType).map(
+              (accountTotalsBySignerId, idx) => {
+                return (
+                  <section key={accountType}>
+                    <WalletTypeHeader
+                      accountType={accountType}
+                      walletNumber={idx + 1}
+                      path={accountTotalsBySignerId[0].path}
+                      accountSigner={accountTotalsBySignerId[0].accountSigner}
+                      onClickAddAddress={
+                        accountType === "imported" || accountType === "internal"
+                          ? () => {
+                              if (accountTotalsBySignerId[0].signerId) {
+                                dispatch(
+                                  deriveAddress(
+                                    accountTotalsBySignerId[0].signerId
                                   )
-                                }
+                                )
                               }
-                            : undefined
-                        }
-                      />
-                      <ul>
-                        {accountTotalsByKeyringId.map((accountTotal) => {
-                          const normalizedAddress = normalizeEVMAddress(
-                            accountTotal.address
-                          )
+                            }
+                          : undefined
+                      }
+                    />
+                    <ul>
+                      {accountTotalsBySignerId.map((accountTotal) => {
+                        const normalizedAddress = normalizeEVMAddress(
+                          accountTotal.address
+                        )
 
-                          const isSelected = sameEVMAddress(
-                            normalizedAddress,
-                            selectedAccountAddress
-                          )
+                        const isSelected = sameEVMAddress(
+                          normalizedAddress,
+                          selectedAccountAddress
+                        )
 
-                          return (
-                            <li
-                              key={normalizedAddress}
-                              // We use these event handlers in leiu of :hover so that we can prevent child hovering
-                              // from affecting the hover state of this li.
-                              onMouseOver={(e) => {
-                                e.currentTarget.style.backgroundColor =
-                                  "var(--hunter-green)"
+                        return (
+                          <li
+                            key={normalizedAddress}
+                            // We use these event handlers in leiu of :hover so that we can prevent child hovering
+                            // from affecting the hover state of this li.
+                            onMouseOver={(e) => {
+                              e.currentTarget.style.backgroundColor =
+                                "var(--hunter-green)"
+                            }}
+                            onFocus={(e) => {
+                              e.currentTarget.style.backgroundColor =
+                                "var(--hunter-green)"
+                            }}
+                            onMouseOut={(e) => {
+                              e.currentTarget.style.backgroundColor = ""
+                            }}
+                            onBlur={(e) => {
+                              e.currentTarget.style.backgroundColor = ""
+                            }}
+                          >
+                            <div
+                              role="button"
+                              tabIndex={0}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                  updateCurrentAccount(normalizedAddress)
+                                }
                               }}
-                              onFocus={(e) => {
-                                e.currentTarget.style.backgroundColor =
-                                  "var(--hunter-green)"
-                              }}
-                              onMouseOut={(e) => {
-                                e.currentTarget.style.backgroundColor = ""
-                              }}
-                              onBlur={(e) => {
-                                e.currentTarget.style.backgroundColor = ""
+                              onClick={() => {
+                                dispatch(resetClaimFlow())
+                                updateCurrentAccount(normalizedAddress)
                               }}
                             >
-                              <div
-                                role="button"
-                                tabIndex={0}
-                                onKeyDown={(e) => {
-                                  if (e.key === "Enter") {
-                                    updateCurrentAccount(normalizedAddress)
-                                  }
-                                }}
-                                onClick={() => {
-                                  dispatch(resetClaimFlow())
-                                  updateCurrentAccount(normalizedAddress)
-                                }}
+                              <SharedAccountItemSummary
+                                key={normalizedAddress}
+                                accountTotal={accountTotal}
+                                isSelected={isSelected}
                               >
-                                <SharedAccountItemSummary
-                                  key={normalizedAddress}
+                                <AccountItemOptionsMenu
                                   accountTotal={accountTotal}
-                                  isSelected={isSelected}
-                                >
-                                  <AccountItemOptionsMenu
-                                    accountTotal={accountTotal}
-                                  />
-                                </SharedAccountItemSummary>
-                              </div>
-                            </li>
-                          )
-                        })}
-                      </ul>
-                    </section>
-                  )
-                }
-              )}
-            </>
-          )
-        })}
+                                />
+                              </SharedAccountItemSummary>
+                            </div>
+                          </li>
+                        )
+                      })}
+                    </ul>
+                  </section>
+                )
+              }
+            )}
+          </>
+        )
+      })}
       <footer>
         <SharedButton
           type="tertiary"


### PR DESCRIPTION
Previously, the only type of id being taken into account to differentiate between different signers was the keyring id. This meant that two accounts from two different Ledgers appeared under the same entry in the account list, "Ledger 1". Additionally, it meant if you renamed the Ledger category, it was for all Ledgers, not just for one.

The underlying change to fix this is fairly minor: `keyringId` is now generalized to `signerId`, which is derived separately for each account signer type. The derivation is set up such that adding a signer type will require specifying how to differentiate between signers of that type. Any signers that prefer not to differentiate can return `null`, or another value.

NOTE: this change will probably interact with #3089 !

## Testing

The easiest way to test is to add two Ledgers to an existing account. Without this branch, you should see something similar to the below:

<img width="384" alt="image" src="https://github.com/tahowallet/extension/assets/8245/07abb9bc-b438-4573-8254-2aa6fbaca540">

With this branch, you should see this:

<img width="382" alt="image" src="https://github.com/tahowallet/extension/assets/8245/993a5d11-79fa-4a5b-9a57-d0ab0168ab82">

Also confirm:
- [x] Both Ledgers are editable separately.
- [x] Editing an entry before this branch remains applicable after switching to this branch, but with that renamed entry associated only with the first Ledger.

Latest build: [extension-builds-3381](https://github.com/tahowallet/extension/suites/12845936179/artifacts/692278164) (as of Fri, 12 May 2023 03:14:58 GMT).