### PR TITLE
Change `tokenToEthRate` threshold for fetching prices

### DIFF
--- a/background/redux-slices/utils/0x-swap-utils.ts
+++ b/background/redux-slices/utils/0x-swap-utils.ts
@@ -107,7 +107,7 @@ export async function getAssetAmount(
 }
 
 /**
- * If the tokenToEthRate of a is less than 1
+ * If the tokenToEthRate of a is less than 0.1
  * we will probably not get information about the price of the asset.
  * The goal is to reduce the number of price requests sent to CoinGecko.
  */
@@ -119,7 +119,7 @@ export async function checkCurrencyAmount(
   network: EVMNetwork
 ): Promise<string | undefined> {
   const currencyAmount =
-    tokenToEthRate >= 1
+    tokenToEthRate >= 0.1
       ? (
           await getAssetAmount(
             assets,


### PR DESCRIPTION
Resolves https://github.com/tahowallet/extension/issues/3341

### What

It is possible to get prices for assets with a low token to ETH rate, so let's change the threshold to 0.1 to get more accurate price info.

Note: this shouldn't cause much more traffic to Coingecko especially when we will merge the price oracle PR

### Testing

- [ ] setup pair mentioned in the issue (MATIC-FTM on Polygon) - there should be a price displayed for Fantom