### PR TITLE
Add header  in transaction details view

### DIFF
--- a/ui/components/Shared/SharedActivityIcon.tsx
+++ b/ui/components/Shared/SharedActivityIcon.tsx
@@ -1,8 +1,15 @@
 import React, { ReactElement } from "react"
 import classNames from "classnames"
 
+export type ActivityIconType =
+  | "receive"
+  | "send"
+  | "approve"
+  | "swap"
+  | "contract_interaction"
+
 type SharedActivityIconProps = {
-  type: "receive" | "send" | "approve" | "swap" | "contract_interaction"
+  type: ActivityIconType
   size: number
 }
 

--- a/ui/components/Shared/SharedActivityIcon.tsx
+++ b/ui/components/Shared/SharedActivityIcon.tsx
@@ -1,0 +1,48 @@
+import React, { ReactElement } from "react"
+import classNames from "classnames"
+
+type SharedActivityIconProps = {
+  type: "receive" | "send" | "approve" | "swap" | "contract_interaction"
+  size: number
+}
+
+export default function SharedActivityIcon({
+  type,
+  size,
+}: SharedActivityIconProps): ReactElement {
+  return (
+    <>
+      <div className={classNames("activity_icon", type)} />
+      <style jsx>{`
+        .activity_icon {
+          background: url("./images/activity_contract_interaction@2x.png");
+          background-size: cover;
+          width: ${size}px;
+          height: ${size}px;
+          margin-right: 4px;
+          margin-left: 9px;
+        }
+        .receive {
+          background: url("./images/activity_receive@2x.png");
+          background-size: cover;
+        }
+        .send {
+          background: url("./images/activity_send@2x.png");
+          background-size: cover;
+        }
+        .approve {
+          background: url("./images/activity_approve@2x.png");
+          background-size: cover;
+        }
+        .swap {
+          background: url("./images/activity_swap@2x.png");
+          background-size: cover;
+        }
+        .contract_interaction {
+          background: url("./images/activity_contract_interaction@2x.png");
+          background-size: cover;
+        }
+      `}</style>
+    </>
+  )
+}

--- a/ui/components/Shared/SharedActivityIcon.tsx
+++ b/ui/components/Shared/SharedActivityIcon.tsx
@@ -21,7 +21,7 @@ export default function SharedActivityIcon({
           width: ${size}px;
           height: ${size}px;
           margin-right: 4px;
-          margin-left: 9px;
+          margin-left: 4px;
         }
         .asset-transfer-receive {
           background: url("./images/activity_receive@2x.png");

--- a/ui/components/Shared/SharedActivityIcon.tsx
+++ b/ui/components/Shared/SharedActivityIcon.tsx
@@ -1,12 +1,6 @@
 import React, { ReactElement } from "react"
 import classNames from "classnames"
-
-export type ActivityIconType =
-  | "receive"
-  | "send"
-  | "approve"
-  | "swap"
-  | "contract_interaction"
+import { ActivityIconType } from "../../hooks/activity-hooks"
 
 type SharedActivityIconProps = {
   type: ActivityIconType
@@ -29,23 +23,23 @@ export default function SharedActivityIcon({
           margin-right: 4px;
           margin-left: 9px;
         }
-        .receive {
+        .asset-transfer-receive {
           background: url("./images/activity_receive@2x.png");
           background-size: cover;
         }
-        .send {
+        .asset-transfer-send {
           background: url("./images/activity_send@2x.png");
           background-size: cover;
         }
-        .approve {
+        .asset-approval {
           background: url("./images/activity_approve@2x.png");
           background-size: cover;
         }
-        .swap {
+        .asset-swap {
           background: url("./images/activity_swap@2x.png");
           background-size: cover;
         }
-        .contract_interaction {
+        .contract-interaction {
           background: url("./images/activity_contract_interaction@2x.png");
           background-size: cover;
         }

--- a/ui/components/Wallet/WalletActivityDetails.tsx
+++ b/ui/components/Wallet/WalletActivityDetails.tsx
@@ -216,7 +216,7 @@ export default function WalletActivityDetails(
           }
           .header_title {
             margin-left: 4px;
-            margin-right: 14px;
+            margin-right: 8px;
             font-family: "Segment";
             font-style: normal;
             font-weight: 600;

--- a/ui/components/Wallet/WalletActivityDetails.tsx
+++ b/ui/components/Wallet/WalletActivityDetails.tsx
@@ -113,7 +113,7 @@ function DestinationCard(props: DestinationCardProps): ReactElement {
 
 interface WalletActivityDetailsProps {
   activityItem: Activity
-  address: string
+  activityInitiatorAddress: string
 }
 // Include this "or" type to handle existing placeholder data
 // on the single asset page. TODO: Remove once single asset page
@@ -122,7 +122,7 @@ interface WalletActivityDetailsProps {
 export default function WalletActivityDetails(
   props: WalletActivityDetailsProps
 ): ReactElement {
-  const { activityItem, address } = props
+  const { activityItem, activityInitiatorAddress } = props
   const dispatch = useBackgroundDispatch()
   const [details, setDetails] = useState<ActivityDetail[]>([])
   const network = useBackgroundSelector(selectCurrentNetwork)
@@ -148,7 +148,10 @@ export default function WalletActivityDetails(
     fetchDetails()
   }, [activityItem.hash, dispatch])
 
-  const activityViewDetails = useActivityViewDetails(activityItem, address)
+  const activityViewDetails = useActivityViewDetails(
+    activityItem,
+    activityInitiatorAddress
+  )
 
   return (
     <div className="wrap standard_width center_horizontal">

--- a/ui/components/Wallet/WalletActivityDetails.tsx
+++ b/ui/components/Wallet/WalletActivityDetails.tsx
@@ -11,7 +11,7 @@ import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import { scanWebsite } from "../../utils/constants"
 import SharedSkeletonLoader from "../Shared/SharedSkeletonLoader"
 import SharedAssetIcon from "../Shared/SharedAssetIcon"
-import ActivityIcon from "../Shared/SharedActivityIcon"
+import SharedActivityIcon from "../Shared/SharedActivityIcon"
 import SharedIcon from "../Shared/SharedIcon"
 import useActivityViewDetails from "../../hooks/activity-hooks"
 
@@ -155,13 +155,14 @@ export default function WalletActivityDetails(
   return (
     <div className="wrap standard_width center_horizontal">
       <div className="header">
-        <ActivityIcon type={activityViewDetails.iconClass} size={16} />
+        <SharedActivityIcon type={activityViewDetails.icon} size={16} />
         <span className="header_title">{activityViewDetails.label}</span>
         {scanWebsiteUrl && (
           <SharedIcon
             icon="icons/s/new-tab.svg"
             width={16}
             color="var(--green-40)"
+            hoverColor="var(--trophy-gold)"
             onClick={openExplorer}
           />
         )}

--- a/ui/components/Wallet/WalletActivityDetails.tsx
+++ b/ui/components/Wallet/WalletActivityDetails.tsx
@@ -5,12 +5,15 @@ import {
   Activity,
   fetchSelectedActivityDetails,
 } from "@tallyho/tally-background/redux-slices/activities"
-import SharedButton from "../Shared/SharedButton"
+import { DEFAULT_NETWORKS_BY_CHAIN_ID } from "@tallyho/tally-background/constants"
 import SharedAddress from "../Shared/SharedAddress"
 import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import { scanWebsite } from "../../utils/constants"
 import SharedSkeletonLoader from "../Shared/SharedSkeletonLoader"
 import SharedAssetIcon from "../Shared/SharedAssetIcon"
+import ActivityIcon from "../Shared/SharedActivityIcon"
+import SharedIcon from "../Shared/SharedIcon"
+import useActivityViewDetails from "../../hooks/activity-hooks"
 
 function DetailRowItem(props: ActivityDetail): ReactElement {
   const { assetIconUrl, label, value } = props
@@ -110,6 +113,7 @@ function DestinationCard(props: DestinationCardProps): ReactElement {
 
 interface WalletActivityDetailsProps {
   activityItem: Activity
+  address: string
 }
 // Include this "or" type to handle existing placeholder data
 // on the single asset page. TODO: Remove once single asset page
@@ -118,18 +122,18 @@ interface WalletActivityDetailsProps {
 export default function WalletActivityDetails(
   props: WalletActivityDetailsProps
 ): ReactElement {
-  const { activityItem } = props
+  const { activityItem, address } = props
   const dispatch = useBackgroundDispatch()
   const [details, setDetails] = useState<ActivityDetail[]>([])
   const network = useBackgroundSelector(selectCurrentNetwork)
 
-  const scanWebsiteInfo = scanWebsite[network.chainID]
+  const scanWebsiteUrl = DEFAULT_NETWORKS_BY_CHAIN_ID.has(network.chainID)
+    ? scanWebsite[network.chainID].url
+    : network.blockExplorerURL
 
   const openExplorer = useCallback(() => {
-    window
-      .open(`${scanWebsiteInfo.url}/tx/${activityItem.hash}`, "_blank")
-      ?.focus()
-  }, [activityItem?.hash, scanWebsiteInfo])
+    window.open(`${scanWebsiteUrl}/tx/${activityItem.hash}`, "_blank")?.focus()
+  }, [activityItem?.hash, scanWebsiteUrl])
 
   useEffect(() => {
     const fetchDetails = async () => {
@@ -144,22 +148,22 @@ export default function WalletActivityDetails(
     fetchDetails()
   }, [activityItem.hash, dispatch])
 
+  const activityViewDetails = useActivityViewDetails(activityItem, address)
+
   if (!activityItem) return <></>
 
   return (
     <div className="wrap standard_width center_horizontal">
       <div className="header">
-        {scanWebsiteInfo && (
-          <div className="header_button">
-            <SharedButton
-              type="tertiary"
-              size="medium"
-              iconMedium="new-tab"
-              onClick={openExplorer}
-            >
-              {scanWebsiteInfo?.title}
-            </SharedButton>
-          </div>
+        <ActivityIcon type={activityViewDetails.iconClass} size={16} />
+        <span className="header_title">{activityViewDetails.label}</span>
+        {scanWebsiteUrl && (
+          <SharedIcon
+            icon="icons/s/new-tab.svg"
+            width={16}
+            color="var(--green-40)"
+            onClick={openExplorer}
+          />
         )}
       </div>
       <div className="destination_cards">
@@ -205,13 +209,18 @@ export default function WalletActivityDetails(
           }
           .header {
             display: flex;
-            align-items: top;
-            justify-content: space-between;
-            width: 304px;
-            margin-bottom: 10px;
+            align-items: center;
+            margin: 18px 0;
           }
-          .header_button {
-            margin-top: 10px;
+          .header_title {
+            margin-left: 4px;
+            margin-right: 14px;
+            font-family: "Segment";
+            font-style: normal;
+            font-weight: 600;
+            font-size: 18px;
+            line-height: 24px;
+            color: var(--white);
           }
           .icon_transfer {
             background: url("./images/transfer@2x.png") center no-repeat;

--- a/ui/components/Wallet/WalletActivityDetails.tsx
+++ b/ui/components/Wallet/WalletActivityDetails.tsx
@@ -150,8 +150,6 @@ export default function WalletActivityDetails(
 
   const activityViewDetails = useActivityViewDetails(activityItem, address)
 
-  if (!activityItem) return <></>
-
   return (
     <div className="wrap standard_width center_horizontal">
       <div className="header">

--- a/ui/components/Wallet/WalletActivityList.tsx
+++ b/ui/components/Wallet/WalletActivityList.tsx
@@ -91,7 +91,10 @@ export default function WalletActivityList({
       {!instantlyHideActivityDetails && (
         <SharedSlideUpMenu isOpen={!!showingActivityDetail} close={handleClose}>
           {showingActivityDetail ? (
-            <WalletActivityDetails activityItem={showingActivityDetail} />
+            <WalletActivityDetails
+              activityItem={showingActivityDetail}
+              address={currentAccount}
+            />
           ) : (
             <></>
           )}

--- a/ui/components/Wallet/WalletActivityList.tsx
+++ b/ui/components/Wallet/WalletActivityList.tsx
@@ -43,13 +43,17 @@ export default function WalletActivityList({
     dispatch(setShowingActivityDetail(null))
   }, [dispatch])
 
-  const currentAccount = useBackgroundSelector(selectCurrentAccount).address
+  const activityInitiatorAddress =
+    useBackgroundSelector(selectCurrentAccount).address
 
   const openExplorer = useCallback(() => {
     window
-      .open(`${scanWebsiteInfo.url}/address/${currentAccount}`, "_blank")
+      .open(
+        `${scanWebsiteInfo.url}/address/${activityInitiatorAddress}`,
+        "_blank"
+      )
       ?.focus()
-  }, [scanWebsiteInfo, currentAccount])
+  }, [scanWebsiteInfo, activityInitiatorAddress])
 
   const handleOpen = useCallback(
     (activityItem: Activity) => {
@@ -93,7 +97,7 @@ export default function WalletActivityList({
           {showingActivityDetail ? (
             <WalletActivityDetails
               activityItem={showingActivityDetail}
-              address={currentAccount}
+              activityInitiatorAddress={activityInitiatorAddress}
             />
           ) : (
             <></>
@@ -111,7 +115,7 @@ export default function WalletActivityList({
                 }}
                 key={activityItem?.hash}
                 activity={activityItem}
-                asAccount={currentAccount}
+                activityInitiatorAddress={activityInitiatorAddress}
               />
             )
           }

--- a/ui/components/Wallet/WalletActivityListItem.tsx
+++ b/ui/components/Wallet/WalletActivityListItem.tsx
@@ -13,12 +13,15 @@ import useActivityViewDetails from "../../hooks/activity-hooks"
 interface Props {
   onClick: () => void
   activity: Activity
-  asAccount: string
+  activityInitiatorAddress: string
 }
 
-function isSendActivity(activity: Activity, account: string): boolean {
+function isSendActivity(
+  activity: Activity,
+  activityInitiatorAddress: string
+): boolean {
   return activity.type === "asset-transfer"
-    ? sameEVMAddress(activity.sender?.address, account)
+    ? sameEVMAddress(activity.sender?.address, activityInitiatorAddress)
     : true
 }
 
@@ -26,7 +29,7 @@ export default function WalletActivityListItem(props: Props): ReactElement {
   const { t } = useTranslation("translation", {
     keyPrefix: "wallet.activities",
   })
-  const { onClick, activity, asAccount } = props
+  const { onClick, activity, activityInitiatorAddress } = props
   const outcomeRef = useRef<HTMLDivElement>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
   const [outcomeWidth, setOutcomeWidth] = useState(0)
@@ -44,7 +47,10 @@ export default function WalletActivityListItem(props: Props): ReactElement {
     }
   }, [bottomRef])
 
-  const activityViewDetails = useActivityViewDetails(activity, asAccount)
+  const activityViewDetails = useActivityViewDetails(
+    activity,
+    activityInitiatorAddress
+  )
 
   return (
     <li>
@@ -100,7 +106,7 @@ export default function WalletActivityListItem(props: Props): ReactElement {
             </div>
           </div>
           <div ref={outcomeRef} className="right">
-            {isSendActivity(activity, asAccount) ? (
+            {isSendActivity(activity, activityInitiatorAddress) ? (
               <div
                 className="outcome"
                 title={activityViewDetails.recipient.address}

--- a/ui/components/Wallet/WalletActivityListItem.tsx
+++ b/ui/components/Wallet/WalletActivityListItem.tsx
@@ -51,10 +51,7 @@ export default function WalletActivityListItem(props: Props): ReactElement {
       <button type="button" className="standard_width" onClick={onClick}>
         <div className="top">
           <div className="left">
-            <SharedActivityIcon
-              type={activityViewDetails.iconClass}
-              size={14}
-            />
+            <SharedActivityIcon type={activityViewDetails.icon} size={14} />
             {activityViewDetails.label}
             {"status" in activity &&
             activity.blockHash !== null &&

--- a/ui/hooks/activity-hooks.ts
+++ b/ui/hooks/activity-hooks.ts
@@ -5,9 +5,17 @@ import {
 } from "@tallyho/tally-background/redux-slices/activities"
 import { sameEVMAddress } from "@tallyho/tally-background/lib/utils"
 import { i18n } from "../_locales/i18n"
+import { ActivityIconType } from "../components/Shared/SharedActivityIcon"
+
+function isReceiveActivity(activity: Activity, account: string): boolean {
+  return (
+    activity.type === "asset-transfer" &&
+    sameEVMAddress(activity.recipient?.address, account)
+  )
+}
 
 type ActivityViewDetails = {
-  iconClass: "receive" | "send" | "approve" | "swap" | "contract_interaction"
+  icon: ActivityIconType
   label: string
   recipient: {
     address?: HexString
@@ -16,13 +24,6 @@ type ActivityViewDetails = {
   assetLogoURL?: string
   assetSymbol: string
   assetValue: string
-}
-
-function isReceiveActivity(activity: Activity, account: string): boolean {
-  return (
-    activity.type === "asset-transfer" &&
-    sameEVMAddress(activity.recipient?.address, account)
-  )
 }
 
 export default function useActivityViewDetails(
@@ -36,13 +37,13 @@ export default function useActivityViewDetails(
         label: isReceiveActivity(activity, address)
           ? i18n.t("wallet.activities.tokenReceived")
           : i18n.t("wallet.activities.tokenSent"),
-        iconClass: isReceiveActivity(activity, address) ? "receive" : "send",
+        icon: isReceiveActivity(activity, address) ? "receive" : "send",
       }
       break
     case "asset-approval":
       details = {
         label: i18n.t("wallet.activities.tokenApproved"),
-        iconClass: "approve",
+        icon: "approve",
         assetValue:
           activity.value === INFINITE_VALUE
             ? i18n.t("wallet.activities.infiniteApproval")
@@ -51,7 +52,7 @@ export default function useActivityViewDetails(
       break
     case "asset-swap":
       details = {
-        iconClass: "swap",
+        icon: "swap",
         label: i18n.t("wallet.activities.tokenSwapped"),
       }
       break
@@ -59,7 +60,7 @@ export default function useActivityViewDetails(
     case "contract-interaction":
     default:
       details = {
-        iconClass: "contract_interaction",
+        icon: "contract_interaction",
         label: i18n.t("wallet.activities.contractInteraction"),
       }
   }

--- a/ui/hooks/activity-hooks.ts
+++ b/ui/hooks/activity-hooks.ts
@@ -1,0 +1,73 @@
+import { HexString } from "@tallyho/tally-background/types"
+import {
+  Activity,
+  INFINITE_VALUE,
+} from "@tallyho/tally-background/redux-slices/activities"
+import { sameEVMAddress } from "@tallyho/tally-background/lib/utils"
+import { i18n } from "../_locales/i18n"
+
+type ActivityViewDetails = {
+  iconClass: "receive" | "send" | "approve" | "swap" | "contract_interaction"
+  label: string
+  recipient: {
+    address?: HexString
+    name?: string
+  }
+  assetLogoURL?: string
+  assetSymbol: string
+  assetValue: string
+}
+
+function isReceiveActivity(activity: Activity, account: string): boolean {
+  return (
+    activity.type === "asset-transfer" &&
+    sameEVMAddress(activity.recipient?.address, account)
+  )
+}
+
+export default function useActivityViewDetails(
+  activity: Activity,
+  address: string
+): ActivityViewDetails {
+  let details
+  switch (activity.type) {
+    case "asset-transfer":
+      details = {
+        label: isReceiveActivity(activity, address)
+          ? i18n.t("wallet.activities.tokenReceived")
+          : i18n.t("wallet.activities.tokenSent"),
+        iconClass: isReceiveActivity(activity, address) ? "receive" : "send",
+      }
+      break
+    case "asset-approval":
+      details = {
+        label: i18n.t("wallet.activities.tokenApproved"),
+        iconClass: "approve",
+        assetValue:
+          activity.value === INFINITE_VALUE
+            ? i18n.t("wallet.activities.infiniteApproval")
+            : activity.value,
+      }
+      break
+    case "asset-swap":
+      details = {
+        iconClass: "swap",
+        label: i18n.t("wallet.activities.tokenSwapped"),
+      }
+      break
+    case "contract-deployment":
+    case "contract-interaction":
+    default:
+      details = {
+        iconClass: "contract_interaction",
+        label: i18n.t("wallet.activities.contractInteraction"),
+      }
+  }
+  return {
+    recipient: activity.recipient,
+    assetLogoURL: activity.assetLogoUrl,
+    assetSymbol: activity.assetSymbol,
+    assetValue: activity.value,
+    ...details,
+  } as ActivityViewDetails
+}

--- a/ui/hooks/activity-hooks.ts
+++ b/ui/hooks/activity-hooks.ts
@@ -43,10 +43,16 @@ export default function useActivityViewDetails(
   const { t } = useTranslation("translation", {
     keyPrefix: "wallet.activities",
   })
-  let details
+  const baseDetails = {
+    recipient: activity.recipient,
+    assetLogoURL: activity.assetLogoUrl,
+    assetSymbol: activity.assetSymbol,
+    assetValue: activity.value,
+  }
   switch (activity.type) {
     case "asset-transfer":
-      details = {
+      return {
+        ...baseDetails,
         label: isReceiveActivity(activity, activityInitiatorAddress)
           ? t("tokenReceived")
           : t("tokenSent"),
@@ -54,9 +60,9 @@ export default function useActivityViewDetails(
           ? "asset-transfer-receive"
           : "asset-transfer-send",
       }
-      break
     case "asset-approval":
-      details = {
+      return {
+        ...baseDetails,
         label: t("tokenApproved"),
         icon: "asset-approval",
         assetValue:
@@ -64,26 +70,19 @@ export default function useActivityViewDetails(
             ? t("infiniteApproval")
             : activity.value,
       }
-      break
     case "asset-swap":
-      details = {
+      return {
+        ...baseDetails,
         icon: "asset-swap",
         label: t("tokenSwapped"),
       }
-      break
     case "contract-deployment":
     case "contract-interaction":
     default:
-      details = {
+      return {
+        ...baseDetails,
         icon: "contract-interaction",
         label: t("contractInteraction"),
       }
   }
-  return {
-    recipient: activity.recipient,
-    assetLogoURL: activity.assetLogoUrl,
-    assetSymbol: activity.assetSymbol,
-    assetValue: activity.value,
-    ...details,
-  } as ActivityViewDetails
 }

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -123,7 +123,9 @@ export default function Wallet(): ReactElement {
           />
           <div
             className={classNames("panel standard_width", {
-              no_padding: panelNumber === 1,
+              no_padding:
+                panelNumber === 1 &&
+                NETWORKS_SUPPORTING_NFTS.has(selectedNetwork.chainID),
             })}
           >
             {panelNumber === 0 && (


### PR DESCRIPTION
Closes #1167 

This PR adds a header to the transaction details view and solves the problem of missing header for the custom network. Changes:
-  Separate component for the activity icon
- Special hook to return activity details view
- Minor improvements

In addition, the problem with missing padding when the network does not have NFTs has been fixed, check the screenshots below.

### UI

**Before**
<img width="250" alt="Screenshot 2023-05-17 at 10 12 35" src="https://github.com/tahowallet/extension/assets/23117945/d73274dd-7afd-468e-8ca7-8e838043979b">

<img width="250" alt="Screenshot 2023-05-17 at 10 40 32" src="https://github.com/tahowallet/extension/assets/23117945/a8f03bb1-93bc-4158-8df4-eea643bf2676">

<img width="250" alt="Screenshot 2023-05-17 at 10 42 32" src="https://github.com/tahowallet/extension/assets/23117945/c59904c3-fcb3-4440-b2f2-00136f2395ac">

**After**
<img width="250" alt="Screenshot 2023-05-17 at 10 18 34" src="https://github.com/tahowallet/extension/assets/23117945/9f77f522-f3d6-45bc-a4fc-3893fbf05019">

<img width="250" alt="Screenshot 2023-05-17 at 13 52 32" src="https://github.com/tahowallet/extension/assets/23117945/68dbffd7-51d5-4c36-8112-adc5ddef4c34">

<img width="250" alt="Screenshot 2023-05-17 at 10 10 39" src="https://github.com/tahowallet/extension/assets/23117945/e5850599-ffb3-44be-a48c-5663cb11ba1b">

### To Test
- [x] Check top padding for the activity list when a network does not have NFTs.
- [x] Check the header for custom network. The link should be working properly.
- [x] check the header for default network. The link should be working properly.

Latest build: [extension-builds-3387](https://github.com/tahowallet/extension/suites/12979887290/artifacts/702340713) (as of Thu, 18 May 2023 07:07:45 GMT).