### PR TITLE
Cache new asset price points

### DIFF
--- a/background/redux-slices/0x-swap.ts
+++ b/background/redux-slices/0x-swap.ts
@@ -362,14 +362,16 @@ export const fetchSwapPrice = createBackgroundAsyncThunk(
           quoteRequest.assets.buyAsset,
           assets,
           quote.buyAmount,
-          quoteRequest.network
+          quoteRequest.network,
+          dispatch
         ),
         sellCurrencyAmount: await checkCurrencyAmount(
           Number(quote.sellTokenToEthRate),
           quoteRequest.assets.sellAsset,
           assets,
           quote.sellAmount,
-          quoteRequest.network
+          quoteRequest.network,
+          dispatch
         ),
       }
 


### PR DESCRIPTION
Resolves https://github.com/tahowallet/extension/issues/3406

It's working but very ugly approach right now 🤢 will think about something better 

### What
If we are using a function that will trigger fetching new prices for assets then these prices should be cached.
Let's try dispatching `newPricePoint` on demand with these new prices.

Latest build: [extension-builds-3408](https://github.com/tahowallet/extension/suites/13148307583/artifacts/714837068) (as of Thu, 25 May 2023 14:28:21 GMT).