### PR TITLE
Don't await Ledger connection to not block transaction screen

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -1251,10 +1251,7 @@ export default class Main extends BaseService<never> {
         resolver: (result: string | PromiseLike<string>) => void
         rejecter: () => void
       }) => {
-        // Don't await, as the below enrichment is expected to take longer than
-        // signer prep. If that assumption breaks, we should probably await the
-        // two in parallel.
-        this.signingService.prepareForSigningRequest()
+        await this.signingService.prepareForSigningRequest()
 
         const enrichedsignTypedDataRequest =
           await this.enrichmentService.enrichSignTypedDataRequest(payload)

--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -306,7 +306,9 @@ export default class LedgerService extends BaseService<Events> {
     }
 
     if (usbDeviceArray.length === 1) {
-      await this.onConnection(usbDeviceArray[0].productId)
+      // Don't await connection because Ledger may not be connected until user
+      // manually unlocks the device
+      this.onConnection(usbDeviceArray[0].productId)
     }
 
     return this.#currentLedgerId


### PR DESCRIPTION
Resolves https://github.com/tahowallet/extension/issues/3419

### What
Hotfix for broken Ledger signing screen when Ledger is asleep 💤 

- if Ledger isn't awake it will block `onConnection`'s Promise and it will result in a blank screen as this is blocking creating transaction
- added back the `await` on `signingService.prepareForSigningRequest()` to keep it consistent

### Testing

- [x] test signing transactions when Ledger is awake
- [x] wait for Ledger to show the screensaver and try to sign the transaction (or signature) - you should see the disconnected ledger transaction screen without problems and you should be able to sign tx when you'll unlock the device
- [x] test signing txs and messages with regular accounts

Latest build: [extension-builds-3420](https://github.com/tahowallet/extension/suites/13242863815/artifacts/721755928) (as of Tue, 30 May 2023 13:41:10 GMT).