### PR TITLE
Fix the issue of adding a custom token

### DIFF
--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -590,19 +590,21 @@ export default class IndexingService extends BaseService<Events> {
     asset: SmartContractFungibleAsset,
     addressNetwork: AddressOnNetwork
   ): Promise<void> {
-    // eslint-disable-next-line no-param-reassign
-    asset.metadata = {
-      ...(asset.metadata ?? {}),
-      // Manually imported tokens are verified
-      verified: true,
+    const customAsset = {
+      ...asset,
+      metadata: {
+        ...(asset.metadata ?? {}),
+        // Manually imported tokens are verified
+        verified: true,
+      },
     }
 
     await this.addTokenToTrackByContract(
       asset.homeNetwork,
       asset.contractAddress,
-      asset.metadata
+      customAsset.metadata
     )
-    await this.retrieveTokenBalances(addressNetwork, [asset])
+    await this.retrieveTokenBalances(addressNetwork, [customAsset])
   }
 
   /**

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -590,13 +590,17 @@ export default class IndexingService extends BaseService<Events> {
     asset: SmartContractFungibleAsset,
     addressNetwork: AddressOnNetwork
   ): Promise<void> {
-    const { metadata = {} } = asset
-    // Manually imported tokens are verified
-    metadata.verified = true
+    // eslint-disable-next-line no-param-reassign
+    asset.metadata = {
+      ...(asset.metadata ?? {}),
+      // Manually imported tokens are verified
+      verified: true,
+    }
 
     await this.addTokenToTrackByContract(
       asset.homeNetwork,
-      asset.contractAddress
+      asset.contractAddress,
+      asset.metadata
     )
     await this.retrieveTokenBalances(addressNetwork, [asset])
   }
@@ -618,7 +622,7 @@ export default class IndexingService extends BaseService<Events> {
   async addTokenToTrackByContract(
     network: EVMNetwork,
     contractAddress: string,
-    metadata: { discoveryTxHash?: HexString } = {}
+    metadata: { discoveryTxHash?: HexString; verified?: boolean } = {}
   ): Promise<SmartContractFungibleAsset | undefined> {
     const normalizedAddress = normalizeEVMAddress(contractAddress)
 


### PR DESCRIPTION
## What
[Changes](https://github.com/tahowallet/extension/blob/main/background/services/indexing/index.ts#L589:#L602) for verified/unverified tokens have resulted in an error about importing custom tokens. The metadata has not been set correctly. This caused imported tokens to be added to the db as unverified assets. By default, these assets should be verified.

## UI

Before
<img width="250" alt="Screenshot 2023-05-30 at 15 00 58" src="https://github.com/tahowallet/extension/assets/23117945/1ee0d55b-ab96-4515-8974-a8cb0faf94ca">

After
https://github.com/tahowallet/extension/assets/23117945/5a1f4b77-ef66-4d80-8547-88d54fce1b8d

## To Test
Use `testertesting.eth` account for the Fantom network. 

- [x] Try to import the custom token - `0x841fad6eae12c286d1fd18d1d525dffa75c7effe`. The token should appear as a verified asset.

Latest build: [extension-builds-3423](https://github.com/tahowallet/extension/suites/13262265640/artifacts/723282407) (as of Wed, 31 May 2023 06:58:35 GMT).