### PR TITLE
Add zkSync custom network to NFTs supported networks

### DIFF
--- a/background/constants/base-assets.ts
+++ b/background/constants/base-assets.ts
@@ -94,6 +94,11 @@ const BNB: NetworkBaseAsset = {
   },
 }
 
+const ZK_SYNC_ETH: NetworkBaseAsset = {
+  ...ETH,
+  chainID: "324",
+}
+
 export const BASE_ASSETS_BY_CUSTOM_NAME = {
   ETH,
   MATIC,
@@ -104,6 +109,7 @@ export const BASE_ASSETS_BY_CUSTOM_NAME = {
   ARBITRUM_NOVA_ETH,
   OPTIMISTIC_ETH,
   GOERLI_ETH,
+  ZK_SYNC_ETH,
 }
 
 export const BASE_ASSETS = Object.values(BASE_ASSETS_BY_CUSTOM_NAME)

--- a/background/constants/currencies.ts
+++ b/background/constants/currencies.ts
@@ -59,6 +59,11 @@ export const GOERLI_ETH: NetworkBaseAsset & Required<CoinGeckoAsset> = {
   ...ETH_DATA,
 }
 
+export const ZK_SYNC_ETH: NetworkBaseAsset & Required<CoinGeckoAsset> = {
+  ...BASE_ASSETS_BY_CUSTOM_NAME.ZK_SYNC_ETH,
+  ...ETH_DATA,
+}
+
 export const MATIC: NetworkBaseAsset & Required<CoinGeckoAsset> = {
   ...BASE_ASSETS_BY_CUSTOM_NAME.MATIC,
   coinType: coinTypesByAssetSymbol.MATIC,

--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -10,6 +10,7 @@ import {
   MATIC,
   OPTIMISTIC_ETH,
   RBTC,
+  ZK_SYNC_ETH,
 } from "./currencies"
 
 export const ETHEREUM: EVMNetwork = {
@@ -85,6 +86,13 @@ export const GOERLI: EVMNetwork = {
   coingeckoPlatformID: "ethereum",
 }
 
+export const ZK_SYNC: EVMNetwork = {
+  name: "zkSync Era",
+  baseAsset: ZK_SYNC_ETH,
+  chainID: "324",
+  family: "EVM",
+}
+
 export const DEFAULT_NETWORKS = [
   ETHEREUM,
   POLYGON,
@@ -136,6 +144,7 @@ export const NETWORK_BY_CHAIN_ID = {
   [BINANCE_SMART_CHAIN.chainID]: BINANCE_SMART_CHAIN,
   [GOERLI.chainID]: GOERLI,
   [FORK.chainID]: FORK,
+  [ZK_SYNC.chainID]: ZK_SYNC,
 }
 
 export const TEST_NETWORK_BY_CHAIN_ID = new Set(

--- a/background/lib/simple-hash_update.ts
+++ b/background/lib/simple-hash_update.ts
@@ -10,7 +10,13 @@ import { HexString } from "../types"
 import logger from "./logger"
 import { sameEVMAddress } from "./utils"
 
-type SupportedChain = "polygon" | "arbitrum" | "optimism" | "ethereum" | "bsc"
+type SupportedChain =
+  | "polygon"
+  | "arbitrum"
+  | "optimism"
+  | "ethereum"
+  | "bsc"
+  | "zksync-era"
 
 type SimpleHashNFTModel = {
   nft_id: string
@@ -101,6 +107,7 @@ const CHAIN_ID_TO_NAME = {
   42161: "arbitrum",
   43114: "avalanche",
   56: "bsc",
+  324: "zksync-era",
 }
 
 const SIMPLE_HASH_CHAIN_TO_ID = {
@@ -110,6 +117,7 @@ const SIMPLE_HASH_CHAIN_TO_ID = {
   arbitrum: 42161,
   avalanche: 43114,
   bsc: 56,
+  "zksync-era": 324,
 }
 
 function isGalxeAchievement(url: string | null | undefined) {

--- a/background/nfts.ts
+++ b/background/nfts.ts
@@ -5,6 +5,7 @@ import {
   ARBITRUM_ONE,
   AVALANCHE,
   BINANCE_SMART_CHAIN,
+  ZK_SYNC,
 } from "./constants"
 import { EVMNetwork } from "./networks"
 // Networks that are not added to this struct will
@@ -18,6 +19,7 @@ export const CHAIN_ID_TO_NFT_METADATA_PROVIDER: {
   [ARBITRUM_ONE.chainID]: ["simplehash"],
   [AVALANCHE.chainID]: ["simplehash"],
   [BINANCE_SMART_CHAIN.chainID]: ["simplehash"],
+  [ZK_SYNC.chainID]: ["simplehash"],
 }
 
 export const NFT_PROVIDER_TO_CHAIN = {
@@ -29,6 +31,7 @@ export const NFT_PROVIDER_TO_CHAIN = {
     ARBITRUM_ONE.chainID,
     AVALANCHE.chainID,
     BINANCE_SMART_CHAIN.chainID,
+    ZK_SYNC.chainID,
   ],
 }
 

--- a/ui/components/NFTS_update/ExploreMarketLink.tsx
+++ b/ui/components/NFTS_update/ExploreMarketLink.tsx
@@ -105,7 +105,11 @@ export function getRelevantMarketsList(nft: NFTCached): MarketDetails[] {
   if (nft.chainID === ETHEREUM.chainID)
     return [MARKET_LINK.rarible, MARKET_LINK.looksrare, MARKET_LINK.opensea]
 
-  return [MARKET_LINK.opensea]
+  if (CHAIN_ID_TO_OPENSEA_CHAIN[nft.chainID]) {
+    return [MARKET_LINK.opensea]
+  }
+
+  return []
 }
 
 export const HARDCODED_MARKETS = [

--- a/ui/components/NFTS_update/NFTPreview.tsx
+++ b/ui/components/NFTS_update/NFTPreview.tsx
@@ -178,19 +178,21 @@ export default function NFTPreview(props: NFTWithCollection): ReactElement {
           )}
         </div>
 
-        <div className="preview_section">
-          <div className="preview_section_header"> {t("preview.viewOn")}</div>
-          <div className="preview_section_row preview_markets">
-            {marketsList.map(({ url, title, icon, getNFTLink }) => (
-              <ExploreMarketLink
-                type="icon"
-                key={url}
-                url={getNFTLink(nft)}
-                {...{ title, icon }}
-              />
-            ))}
+        {!!marketsList.length && (
+          <div className="preview_section">
+            <div className="preview_section_header"> {t("preview.viewOn")}</div>
+            <div className="preview_section_row preview_markets">
+              {marketsList.map(({ url, title, icon, getNFTLink }) => (
+                <ExploreMarketLink
+                  type="icon"
+                  key={url}
+                  url={getNFTLink(nft)}
+                  {...{ title, icon }}
+                />
+              ))}
+            </div>
           </div>
-        </div>
+        )}
 
         <div className="preview_section">
           <div className="preview_section_header">

--- a/ui/components/Shared/SharedButtonUp.tsx
+++ b/ui/components/Shared/SharedButtonUp.tsx
@@ -71,7 +71,7 @@ export default function SharedButtonUp<T extends HTMLElement>(props: {
           mask-image: url("./images/chevron_down.svg");
           mask-size: 14px 8px;
           mask-repeat: no-repeat;
-          width: 18px;
+          width: 14px;
           height: 8px;
           background-color: var(--hunter-green);
           transform: rotate(180deg);

--- a/ui/components/Shared/SharedNetworkIcon.tsx
+++ b/ui/components/Shared/SharedNetworkIcon.tsx
@@ -45,7 +45,9 @@ export default function SharedNetworkIcon(props: {
 
   return (
     <div className="icon_network_wrapper">
-      {hasBackground && <div className="icon_network_background" />}
+      {hasBackground && hasIconAvailable && (
+        <div className="icon_network_background" />
+      )}
       {hasIconAvailable ? (
         <div className="icon_network" />
       ) : (


### PR DESCRIPTION
### What

- support NFTs on zkSync
- fix button up icon
- fix custom network icon on NFT thumbnails

### Testing

- [x] check if you can browse NFTs on zkSync
- [x] check if NFTs previews are displayed correctly
- [x] check if badges on zkSync are linked to Galxe on the NFT preview page

![image](https://github.com/tahowallet/extension/assets/20949277/874e8914-2f7d-4c9b-a0b0-8f84f7737078)

Latest build: [extension-builds-3425](https://github.com/tahowallet/extension/suites/13291296855/artifacts/725535967) (as of Thu, 01 Jun 2023 06:22:34 GMT).