### PR TITLE
Fix duplicate base assets being stored in redux asset cache

### DIFF
--- a/background/redux-slices/assets.ts
+++ b/background/redux-slices/assets.ts
@@ -13,11 +13,7 @@ import {
 import { AddressOnNetwork } from "../accounts"
 import { findClosestAssetIndex } from "../lib/asset-similarity"
 import { createBackgroundAsyncThunk } from "./utils"
-import {
-  isBuiltInNetworkBaseAsset,
-  isSameAsset,
-  sameBuiltInNetworkBaseAsset,
-} from "./utils/asset-utils"
+import { isBuiltInNetworkBaseAsset, isSameAsset } from "./utils/asset-utils"
 import { getProvider } from "./utils/contract-utils"
 import { EVMNetwork, sameNetwork } from "../networks"
 import { ERC20_INTERFACE } from "../lib/erc20"
@@ -27,7 +23,6 @@ import { convertFixedPoint } from "../lib/fixed-point"
 import { removeAssetReferences, updateAssetReferences } from "./accounts"
 import { NormalizedEVMAddress } from "../types"
 import type { RootState } from "."
-import { sameEVMAddress } from "../lib/utils"
 
 export type AssetWithRecentPrices<T extends AnyAsset = AnyAsset> = T & {
   recentPrices: {
@@ -72,18 +67,7 @@ const assetsSlice = createSlice({
           const duplicateIndexes = mappedAssets[newAsset.symbol].reduce<
             number[]
           >((acc, existingAsset, id) => {
-            if (
-              ("homeNetwork" in newAsset &&
-                "homeNetwork" in existingAsset &&
-                sameNetwork(existingAsset.homeNetwork, newAsset.homeNetwork) &&
-                "contractAddress" in newAsset &&
-                "contractAddress" in existingAsset &&
-                sameEVMAddress(
-                  existingAsset.contractAddress,
-                  newAsset.contractAddress
-                )) ||
-              sameBuiltInNetworkBaseAsset(newAsset, existingAsset)
-            ) {
+            if (isSameAsset(newAsset, existingAsset)) {
               acc.push(id)
             }
             return acc

--- a/background/redux-slices/migrations/index.ts
+++ b/background/redux-slices/migrations/index.ts
@@ -25,12 +25,13 @@ import to25 from "./to-25"
 import to26 from "./to-26"
 import to27 from "./to-27"
 import to28 from "./to-28"
+import to29 from "./to-29"
 
 /**
  * The version of persisted Redux state the extension is expecting. Any previous
  * state without this version, or with a lower version, ought to be migrated.
  */
-export const REDUX_STATE_VERSION = 28
+export const REDUX_STATE_VERSION = 29
 
 /**
  * Common type for all migration functions.
@@ -68,6 +69,7 @@ const allMigrations: { [targetVersion: string]: Migration } = {
   26: to26,
   27: to27,
   28: to28,
+  29: to29,
 }
 
 /**

--- a/background/redux-slices/migrations/to-29.ts
+++ b/background/redux-slices/migrations/to-29.ts
@@ -1,0 +1,14 @@
+// This migration ensures the assets collection is cleared of duplicated
+// base assets
+
+export default (
+  prevState: Record<string, unknown>
+): Record<string, unknown> => {
+  const { assets, ...newState } = prevState
+
+  // Clear assets collection; these should be immediately repopulated by the
+  // IndexingService in startService.
+  newState.assets = []
+
+  return newState
+}

--- a/background/redux-slices/migrations/to-29.ts
+++ b/background/redux-slices/migrations/to-29.ts
@@ -1,5 +1,5 @@
 // This migration ensures the assets collection is cleared of duplicated
-// base assets
+// base assets https://github.com/tahowallet/extension/issues/3445
 
 export default (
   prevState: Record<string, unknown>

--- a/background/redux-slices/utils/asset-utils.ts
+++ b/background/redux-slices/utils/asset-utils.ts
@@ -399,7 +399,7 @@ export function isSameAsset(asset1: AnyAsset, asset2: AnyAsset): boolean {
   }
 
   if (isNetworkBaseAsset(asset1) && isNetworkBaseAsset(asset2)) {
-    return asset1.chainID === asset2.chainID
+    return sameNetworkBaseAsset(asset1, asset2)
   }
 
   return asset1.symbol === asset2.symbol

--- a/background/redux-slices/utils/asset-utils.ts
+++ b/background/redux-slices/utils/asset-utils.ts
@@ -17,8 +17,8 @@ import {
   POLYGON,
 } from "../../constants"
 import { fromFixedPointNumber } from "../../lib/fixed-point"
-import { normalizeEVMAddress } from "../../lib/utils"
-import { AnyNetwork, NetworkBaseAsset } from "../../networks"
+import { sameEVMAddress } from "../../lib/utils"
+import { AnyNetwork, NetworkBaseAsset, sameNetwork } from "../../networks"
 import { hardcodedMainCurrencySign } from "./constants"
 
 /**
@@ -386,8 +386,8 @@ export function isSameAsset(asset1: AnyAsset, asset2: AnyAsset): boolean {
     isSmartContractFungibleAsset(asset2)
   ) {
     return (
-      normalizeEVMAddress(asset1.contractAddress) ===
-      normalizeEVMAddress(asset2.contractAddress)
+      sameNetwork(asset1.homeNetwork, asset2.homeNetwork) &&
+      sameEVMAddress(asset1.contractAddress, asset2.contractAddress)
     )
   }
 
@@ -396,6 +396,10 @@ export function isSameAsset(asset1: AnyAsset, asset2: AnyAsset): boolean {
     isSmartContractFungibleAsset(asset2)
   ) {
     return false
+  }
+
+  if (isNetworkBaseAsset(asset1) && isNetworkBaseAsset(asset2)) {
+    return asset1.chainID === asset2.chainID
   }
 
   return asset1.symbol === asset2.symbol

--- a/background/redux-slices/utils/asset-utils.ts
+++ b/background/redux-slices/utils/asset-utils.ts
@@ -376,7 +376,7 @@ export function isUnverifiedAssetByUser(asset: AnyAsset | undefined): boolean {
 }
 
 // FIXME Unify once asset similarity code is unified.
-export function isSameAsset(asset1: AnyAsset, asset2: AnyAsset): boolean {
+export function isSameAsset(asset1?: AnyAsset, asset2?: AnyAsset): boolean {
   if (typeof asset1 === "undefined" || typeof asset2 === "undefined") {
     return false
   }

--- a/background/redux-slices/utils/tests/asset-utils.unit.test.ts
+++ b/background/redux-slices/utils/tests/asset-utils.unit.test.ts
@@ -1,5 +1,7 @@
-import { ETH } from "../../../constants"
-import { isUnverifiedAssetByUser } from "../asset-utils"
+import { createSmartContractAsset } from "../../../tests/factories"
+import { ETH, OPTIMISTIC_ETH } from "../../../constants"
+import { isSameAsset, isUnverifiedAssetByUser } from "../asset-utils"
+import { NetworkBaseAsset } from "../../../networks"
 
 describe("Asset utils", () => {
   describe("isUnverifiedAssetByUser", () => {
@@ -16,6 +18,7 @@ describe("Asset utils", () => {
       }
       expect(isUnverifiedAssetByUser(asset)).toBeTruthy()
     })
+
     test("should return false if is a verified asset", () => {
       const asset = {
         name: "Test",
@@ -35,11 +38,60 @@ describe("Asset utils", () => {
       }
       expect(isUnverifiedAssetByUser(asset)).toBeFalsy()
     })
+
     test("should return false if is a base asset", () => {
       expect(isUnverifiedAssetByUser(ETH)).toBeFalsy()
     })
+
     test("should return false if an asset is undefined", () => {
       expect(isUnverifiedAssetByUser(undefined)).toBeFalsy()
+    })
+  })
+
+  describe("isSameAsset", () => {
+    const smartContractAsset = createSmartContractAsset({ symbol: "ABC" })
+
+    test("should check smart contract assets have same network and contractAddress", () => {
+      expect(isSameAsset(smartContractAsset, smartContractAsset)).toBe(true)
+
+      expect(
+        isSameAsset(smartContractAsset, {
+          ...smartContractAsset,
+          homeNetwork: { ...smartContractAsset.homeNetwork, chainID: "222" },
+        })
+      ).toBe(false)
+
+      expect(
+        isSameAsset(smartContractAsset, {
+          ...smartContractAsset,
+          contractAddress: "0x",
+        })
+      ).toBe(false)
+    })
+
+    test("should handle undefined values", () => {
+      expect(isSameAsset(smartContractAsset, undefined)).toBe(false)
+      expect(isSameAsset(undefined, smartContractAsset)).toBe(false)
+      expect(isSameAsset(undefined, undefined)).toBe(false)
+    })
+
+    test("should check base network assets have same chainID and symbol", () => {
+      const baseAsset: NetworkBaseAsset = {
+        decimals: 18,
+        symbol: "METIS",
+        name: "METIS Network",
+        chainID: "1088",
+      }
+
+      expect(isSameAsset(smartContractAsset, ETH)).toBe(false)
+      expect(isSameAsset(ETH, undefined)).toBe(false)
+      expect(isSameAsset(OPTIMISTIC_ETH, ETH)).toBe(false)
+      expect(isSameAsset(ETH, ETH)).toBe(true)
+      expect(isSameAsset(ETH, ETH)).toBe(true)
+      expect(isSameAsset(baseAsset, ETH)).toBe(false)
+      expect(isSameAsset(baseAsset, { ...baseAsset, chainID: "999" })).toBe(
+        false
+      )
     })
   })
 })


### PR DESCRIPTION
Closes #3445 

Fixes an issue when caching assets in the redux state that did not correctly handle already existing network base assets.

## To Test
- [x] Do a fresh install on `main`
- [x] Add a custom network, after a few minutes check the assets slice in the redux state, the last entries should be duplicates of the custom network's base asset.
- [x] Switch to this branch and reload the extension, after a few minutes check the assets slice, there should not be any duplicates.

Latest build: [extension-builds-3431](https://github.com/tahowallet/extension/suites/13384491623/artifacts/732526029) (as of Mon, 05 Jun 2023 17:25:44 GMT).