### PR TITLE
Fix UI crash when gas fee data is unavailable

### DIFF
--- a/ui/components/NetworkFees/FeeSettingsText.tsx
+++ b/ui/components/NetworkFees/FeeSettingsText.tsx
@@ -137,7 +137,7 @@ export default function FeeSettingsText({
   networkSettings = customNetworkSetting ?? networkSettings
   const baseFeePerGas =
     useBackgroundSelector((state) => {
-      return state.networks.blockInfo[currentNetwork.chainID].baseFeePerGas
+      return state.networks.blockInfo[currentNetwork.chainID]?.baseFeePerGas
     }) ??
     networkSettings.values?.baseFeePerGas ??
     0n


### PR DESCRIPTION
Prevents a crash when trying to send funds after adding a network under slow network conditions or certain RPCs

## To Test
- [ ] Add a custom network, e.g. hardhat, the first RPC on this network should be unavailable
- [ ] Attempt to send some funds, UI should not crash

Latest build: [extension-builds-3434](https://github.com/tahowallet/extension/suites/13375997039/artifacts/731891139) (as of Mon, 05 Jun 2023 12:10:42 GMT).