### PR TITLE
Cable Connection: Implement standard flow for dApp connect popup

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -595,6 +595,7 @@
     "showPasswordHint": "Show Password",
     "hidePasswordHint": "Hide Password",
     "close": "Close",
+    "modalClose": "Background close",
     "accountItemSummary": {
       "connectedStatus": "Connected"
     },
@@ -736,7 +737,6 @@
       "networkSettingsBtn": "Add network (beta)"
     },
     "connectedDappInfo": {
-      "modalClose": "Background close",
       "dAppTitle": "Account connected to",
       "dappConnections": "Dapp connections",
       "guideline": {

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -840,6 +840,13 @@
       "descFirstPart": "We disabled Taho as default wallet for you. You can always enable it back from Settings",
       "descSecondPart": "at any time.",
       "toggleTitle": "Use Taho as default wallet"
+    },
+    "defaultConnectionPopover": {
+      "title": "Connecting with Taho",
+      "activeWallet": "Your active wallet is Taho.",
+      "activeWalletMeaning": "This means that you'll be connecting to websites with Taho even when selecting MetaMask.",
+      "metaMaskHeading": "Want to switch to MetaMask?",
+      "toggleLabel": "Use the toggle at the top to connect with MetaMask or another wallet."
     }
   },
   "abilities": {

--- a/ui/components/DAppConnection/DAppConnectionDefaultToggle.tsx
+++ b/ui/components/DAppConnection/DAppConnectionDefaultToggle.tsx
@@ -9,15 +9,40 @@ import { useBackgroundDispatch, useBackgroundSelector } from "../../hooks"
 import SharedIcon from "../Shared/SharedIcon"
 import SharedToggleButton from "../Shared/SharedToggleButton"
 
-export default function DAppConnectionDefaultToggle(): ReactElement {
+type Props = {
+  /**
+   * Renders as a button instead of a toggle. In this mode, always set the
+   * specified value (true means always setting Taho as default, false means
+   * always setting Taho as non-default), even if that value is already set.
+   */
+  alwaysForceSelection?: "taho" | "other"
+}
+
+export default function DAppConnectionDefaultToggle({
+  alwaysForceSelection,
+}: Props): ReactElement {
   const { t } = useTranslation("translation", { keyPrefix: "topMenu" })
 
   const dispatch = useBackgroundDispatch()
 
   const isDefaultWallet = useBackgroundSelector(selectDefaultWallet)
-  const toggleDefaultWallet = (defaultWalletValue: boolean) => {
-    dispatch(setNewDefaultWalletValue(defaultWalletValue))
+  const setDefaultWallet = (defaultWalletValue: boolean) => {
+    // If renderAsButtonForValue is set, interactions will always set
+    // that value for defaultWallet.
+    const finalValue =
+      alwaysForceSelection === undefined
+        ? defaultWalletValue
+        : alwaysForceSelection === "taho"
+
+    dispatch(setNewDefaultWalletValue(finalValue))
   }
+
+  // If renderAsButtonForValue is set, we will always display that value for
+  // defaultWallet.
+  const defaultIsSelected =
+    alwaysForceSelection === undefined
+      ? isDefaultWallet
+      : alwaysForceSelection === "taho"
 
   // TODO Read this from background information.
   const hasDetectedOtherWallets = true
@@ -26,27 +51,27 @@ export default function DAppConnectionDefaultToggle(): ReactElement {
     <>
       {hasDetectedOtherWallets && (
         <p className="default_wallet">
-          {t("connectToWebsiteUsing")}
+          {alwaysForceSelection === undefined ? t("connectToWebsiteUsing") : ""}
           <SharedIcon
             width={20}
             icon="taho-connect-icon.svg"
             ariaLabel={t("setTahoAsDefault")}
-            color={isDefaultWallet ? "var(--success)" : "var(--green-20)"}
-            onClick={() => toggleDefaultWallet(true)}
+            color={defaultIsSelected ? "var(--success)" : "var(--green-20)"}
+            onClick={() => setDefaultWallet(true)}
           />
           <SharedToggleButton
-            onChange={(toggleValue) => toggleDefaultWallet(toggleValue)}
+            onChange={(toggleValue) => setDefaultWallet(toggleValue)}
             onColor="var(--success)"
             offColor="var(--white)"
-            value={isDefaultWallet}
+            value={defaultIsSelected}
             leftToRight={false}
           />
           <SharedIcon
             width={24}
             icon="other-wallet-connect-icon.svg"
             ariaLabel={t("setOtherAsDefault")}
-            color={isDefaultWallet ? "var(--green-20)" : "var(--white)"}
-            onClick={() => toggleDefaultWallet(false)}
+            color={defaultIsSelected ? "var(--green-20)" : "var(--white)"}
+            onClick={() => setDefaultWallet(false)}
           />
         </p>
       )}

--- a/ui/components/DAppConnection/DAppConnectionDefaultToggle.tsx
+++ b/ui/components/DAppConnection/DAppConnectionDefaultToggle.tsx
@@ -27,8 +27,8 @@ export default function DAppConnectionDefaultToggle({
 
   const isDefaultWallet = useBackgroundSelector(selectDefaultWallet)
   const setDefaultWallet = (defaultWalletValue: boolean) => {
-    // If renderAsButtonForValue is set, interactions will always set
-    // that value for defaultWallet.
+    // If alwaysForceSelection is set, interactions will always set that value
+    // for defaultWallet.
     const finalValue =
       alwaysForceSelection === undefined
         ? defaultWalletValue

--- a/ui/components/DAppConnection/DAppConnectionInfoBar.tsx
+++ b/ui/components/DAppConnection/DAppConnectionInfoBar.tsx
@@ -1,0 +1,238 @@
+import classNames from "classnames"
+import React, { ReactElement, useCallback, useState } from "react"
+import { useTranslation } from "react-i18next"
+import SharedIcon from "../Shared/SharedIcon"
+import DAppConnectionDefaultToggle from "./DAppConnectionDefaultToggle"
+
+type PopoverProps = {
+  close: () => void
+}
+
+function DefaultConnectionPopover({ close }: PopoverProps): ReactElement {
+  const { t: tShared } = useTranslation("translation", { keyPrefix: "shared" })
+  const { t } = useTranslation("translation", {
+    keyPrefix: "dAppConnect.defaultConnectionPopover",
+  })
+
+  const [isClosing, setIsClosing] = useState(false)
+
+  const animateThenClose = useCallback(() => {
+    setIsClosing(true)
+    setTimeout(close, 300)
+  }, [close])
+
+  return (
+    <div
+      className={classNames("bg", {
+        fadeIn: !isClosing,
+        fade_out: isClosing,
+      })}
+    >
+      <section>
+        <SharedIcon
+          icon="close.svg"
+          width={12}
+          aria-label={tShared("close")}
+          onClick={animateThenClose}
+          color="var(--green-20)"
+          hoverColor="var(--white)"
+          customStyles={`
+            position: absolute;
+            top: 16px;
+            right: 16px;
+          `}
+        />
+
+        <h3>{t("title")}</h3>
+
+        <p>{t("activeWallet")}</p>
+        <p>{t("activeWalletMeaning")}</p>
+
+        <h4>{t("metaMaskHeading")}</h4>
+
+        <div className="default-toggle">
+          {t("toggleLabel")}
+          <DAppConnectionDefaultToggle alwaysForceSelection="taho" />
+        </div>
+      </section>
+      <button
+        aria-label={tShared("modalClose")}
+        type="button"
+        className="void_space"
+        onClick={animateThenClose}
+      />
+      <style jsx>{`
+        .bg {
+          position: fixed;
+          top: 48px;
+          left: 0px;
+          width: 100%;
+          height: 100%;
+
+          background-color: color-mix(
+            in srgb,
+            var(--green-120),
+            transparent 30%
+          );
+
+          z-index: 4;
+        }
+
+        section {
+          position: absolute;
+          top: 16px;
+          z-index: 4;
+
+          display: flex;
+          flex-direction: column;
+
+          margin: 0 6px 0 16px;
+          padding: 10px 16px 20px 20px;
+
+          color: var(--green-20);
+
+          background-color: var(--green-120);
+          border: 1px solid var(--green-80);
+          border-radius: 16px;
+          box-shadow: 0 10px 12px rgba(0, 20, 19, 0.34),
+            0 14px 16px rgba(0, 20, 19, 0.24), 0 24px 24px rgba(0, 20, 19, 0.14);
+        }
+
+        section:before,
+        section:after {
+          content: "";
+          position: absolute;
+          top: -10px;
+          left: 28px;
+        }
+
+        section:before {
+          transform: rotate(45deg);
+
+          width: 17px;
+          height: 17px;
+
+          border: 1px var(--green-80);
+          border-style: solid none none solid;
+          border-top-left-radius: 6px;
+
+          background-color: var(--green-120);
+        }
+
+        section:after {
+          top: -7px;
+          left: 30px;
+
+          width: 0;
+          height: 0;
+
+          border: 7px transparent;
+          border-style: none solid solid;
+          border-bottom-color: var(--success);
+          border-top-left-radius: 3px;
+        }
+
+        h3 {
+          font-size: 1.375rem;
+          color: var(--success);
+
+          margin: 0 0 12px;
+        }
+
+        p {
+          font-weight: 500;
+
+          margin: 0 0 4px;
+        }
+
+        h4 {
+          color: var(--white);
+
+          margin: 21px 0 14px;
+        }
+
+        div.default-toggle {
+          display: flex;
+
+          flex-direction: row;
+          align-items: center;
+        }
+
+        .void_space {
+          height: 100%;
+          width: 100%;
+          position: fixed;
+          top: 0;
+          left: 0;
+          z-index: -1;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+/**
+ * Component to show the toggle for using Taho as the default vs non-default
+ * wallet when the user tries to connect a dApp. This toggle can be used to
+ * switch to a different wallet right in the connection flow.
+ */
+export default function DAppConnectionInfoBar(): ReactElement {
+  const [
+    isShowingDefaultConnectionTooltip,
+    setIsShowingDefaultConnectionTooltip,
+  ] = useState(false)
+
+  const toggleIsShowingDefaultConnectionTooltip = useCallback(() => {
+    setIsShowingDefaultConnectionTooltip(!isShowingDefaultConnectionTooltip)
+  }, [isShowingDefaultConnectionTooltip, setIsShowingDefaultConnectionTooltip])
+
+  return (
+    <section
+      className={classNames({ highlighted: isShowingDefaultConnectionTooltip })}
+    >
+      <SharedIcon
+        onClick={() => toggleIsShowingDefaultConnectionTooltip()}
+        icon="icons/m/info.svg"
+        width={16}
+        hoverColor="var(--success)"
+        color={
+          isShowingDefaultConnectionTooltip
+            ? "var(--success)"
+            : "var(--green-20)"
+        }
+      />
+      {isShowingDefaultConnectionTooltip ? (
+        <DefaultConnectionPopover
+          close={() => setIsShowingDefaultConnectionTooltip(false)}
+        />
+      ) : (
+        <></>
+      )}
+
+      <DAppConnectionDefaultToggle />
+
+      <style jsx>{`
+        section {
+          background-color: var(--green-120);
+          padding: 10px 16px 10px 4px;
+
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+          justify-content: center;
+
+          gap: 8px;
+
+          // These exist so that they can be switched to the success
+          // color below.
+          border-top: 1px solid var(--green-120);
+          border-bottom: 1px solid var(--hunter-green);
+        }
+
+        section.highlighted {
+          border-color: var(--success);
+        }
+      `}</style>
+    </section>
+  )
+}

--- a/ui/components/DAppConnection/DAppConnectionInfoBar.tsx
+++ b/ui/components/DAppConnection/DAppConnectionInfoBar.tsx
@@ -181,9 +181,9 @@ export default function DAppConnectionInfoBar(): ReactElement {
     setIsShowingDefaultConnectionTooltip,
   ] = useState(false)
 
-  const toggleIsShowingDefaultConnectionTooltip = useCallback(() => {
+  const toggleIsShowingDefaultConnectionTooltip = () => {
     setIsShowingDefaultConnectionTooltip(!isShowingDefaultConnectionTooltip)
-  }, [isShowingDefaultConnectionTooltip, setIsShowingDefaultConnectionTooltip])
+  }
 
   return (
     <section

--- a/ui/components/DAppConnection/DAppConnectionInfoBar.tsx
+++ b/ui/components/DAppConnection/DAppConnectionInfoBar.tsx
@@ -81,7 +81,6 @@ function DefaultConnectionPopover({ close }: PopoverProps): ReactElement {
         section {
           position: absolute;
           top: 16px;
-          z-index: 4;
 
           display: flex;
           flex-direction: column;

--- a/ui/components/DAppConnection/DAppConnectionInfoBar.tsx
+++ b/ui/components/DAppConnection/DAppConnectionInfoBar.tsx
@@ -132,7 +132,7 @@ function DefaultConnectionPopover({ close }: PopoverProps): ReactElement {
         }
 
         h3 {
-          font-size: 1.375rem;
+          font-size: 22px;
           color: var(--success);
 
           margin: 0 0 12px;

--- a/ui/components/TopMenu/TopMenuConnectedDAppInfo.tsx
+++ b/ui/components/TopMenu/TopMenuConnectedDAppInfo.tsx
@@ -256,7 +256,7 @@ export default function TopMenuConnectedDAppInfo(props: {
         <ConnectionDAppGuideline isConnected={isConnected} />
       </div>
       <button
-        aria-label={t("modalClose")}
+        aria-label={tShared("modalClose")}
         type="button"
         className="void_space"
         onClick={animateThenClose}

--- a/ui/pages/DAppConnect/DAppConnectPage.tsx
+++ b/ui/pages/DAppConnect/DAppConnectPage.tsx
@@ -11,6 +11,7 @@ import SharedButton from "../../components/Shared/SharedButton"
 import SharedAccountItemSummary from "../../components/Shared/SharedAccountItemSummary"
 import RequestingDAppBlock from "./RequestingDApp"
 import SwitchWallet from "./SwitchWallet"
+import DAppConnectionInfoBar from "../../components/DAppConnection/DAppConnectionInfoBar"
 
 type DAppConnectPageProps = {
   permission: PermissionRequest
@@ -32,6 +33,9 @@ export default function DAppConnectPage({
 
   return (
     <>
+      {isEnabled(FeatureFlags.ENABLE_UPDATED_DAPP_CONNECTIONS) && (
+        <DAppConnectionInfoBar />
+      )}
       <section className="standard_width">
         <h1 className="serif_header">{t("connectToDapp")}</h1>
         <div className="connection_destination">


### PR DESCRIPTION
The dApp Connect popup now shows the top bar for switching
between Taho being default and not, and includes an explanatory
popover triggered by clicking on an `i` icon.

This PR does not yet implement the “first time” flow, where the
default wallet explanation appears without user interaction;
that is in #3464. It also does not implement automatically closing
the dApp connection popup and bringing up the next wallet if
default connection is turned off; that is in #3462.

## Testing

- [x] Try to connect to a dApp while Taho is marked as default.
      The Taho dApp connection flow should come up.
  - [x] There should be a top bar on the connection modal that
        matches the one in the wallet popup.
  - [x] When clicking the default toggle on/off, opening the wallet
        popup should show the same default state.
  - [x] Toggling default to off (or not Taho) and then closing the
        dApp Connection modal, then reloading the dApp and attempting
        to connect, should trigger the other wallet's dApp Connection
        flow.

Additionally, without updated dApp Connections enabled:

- [x] Try to connect to a dApp while Taho is marked as default.
      The Taho dApp connection flow should come up.
  - [x] There should NOT be a top bar on the connection modal that
        matches the one in the wallet popup.

## Testing Environment

```
ENABLE_UPDATED_DAPP_CONNECTIONS=true
```

Latest build: [extension-builds-3451](https://github.com/tahowallet/extension/suites/13578654320/artifacts/747855360) (as of Tue, 13 Jun 2023 18:45:28 GMT).