### PR TITLE
Fix issue for assets list for swapping/sending 

### DIFF
--- a/background/redux-slices/selectors/0xSwapSelectors.ts
+++ b/background/redux-slices/selectors/0xSwapSelectors.ts
@@ -2,7 +2,10 @@ import { createSelector } from "@reduxjs/toolkit"
 import { selectCurrentNetwork } from "./uiSelectors"
 import { SwappableAsset, isSmartContractFungibleAsset } from "../../assets"
 import { sameNetwork } from "../../networks"
-import { isBuiltInNetworkBaseAsset } from "../utils/asset-utils"
+import {
+  canBeUsedForTransaction,
+  isBuiltInNetworkBaseAsset,
+} from "../utils/asset-utils"
 import { RootState } from ".."
 import { SingleAssetState } from "../assets"
 
@@ -26,6 +29,9 @@ export const selectSwapBuyAssets = createSelector(
       ): asset is SwappableAsset & {
         recentPrices: SingleAssetState["recentPrices"]
       } => {
+        if (!canBeUsedForTransaction(asset)) {
+          return false
+        }
         if (isSmartContractFungibleAsset(asset)) {
           if (sameNetwork(asset.homeNetwork, currentNetwork)) {
             return true

--- a/background/redux-slices/utils/asset-utils.ts
+++ b/background/redux-slices/utils/asset-utils.ts
@@ -16,6 +16,7 @@ import {
   OPTIMISM,
   POLYGON,
 } from "../../constants"
+import { FeatureFlags, isEnabled } from "../../features"
 import { fromFixedPointNumber } from "../../lib/fixed-point"
 import { sameEVMAddress } from "../../lib/utils"
 import { AnyNetwork, NetworkBaseAsset, sameNetwork } from "../../networks"
@@ -373,6 +374,17 @@ export function isUnverifiedAssetByUser(asset: AnyAsset | undefined): boolean {
   }
 
   return false
+}
+
+/**
+ * Assets that are untrusted and have not been verified by the user
+ * should not be swapped or sent.
+ */
+export function canBeUsedForTransaction(asset: AnyAsset): boolean {
+  if (!isEnabled(FeatureFlags.SUPPORT_UNVERIFIED_ASSET)) {
+    return true
+  }
+  return isUntrustedAsset(asset) ? !isUnverifiedAssetByUser(asset) : true
 }
 
 // FIXME Unify once asset similarity code is unified.

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -27,7 +27,10 @@ import {
   transferAsset,
 } from "@tallyho/tally-background/redux-slices/assets"
 import { CompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
-import { enrichAssetAmountWithMainCurrencyValues } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
+import {
+  canBeUsedForTransaction,
+  enrichAssetAmountWithMainCurrencyValues,
+} from "@tallyho/tally-background/redux-slices/utils/asset-utils"
 import { useHistory, useLocation } from "react-router-dom"
 import classNames from "classnames"
 import { ReadOnlyAccountSigner } from "@tallyho/tally-background/services/signing"
@@ -103,10 +106,13 @@ export default function Send(): ReactElement {
   })
 
   const fungibleAssetAmounts =
-    // Only look at fungible assets.
+    // Only look at fungible assets that have a balance greater than zero.
+    // To be able to send an asset needs to be trusted or verified by the user.
     balanceData?.allAssetAmounts?.filter(
       (assetAmount): assetAmount is CompleteAssetAmount<FungibleAsset> =>
-        isFungibleAssetAmount(assetAmount)
+        isFungibleAssetAmount(assetAmount) &&
+        assetAmount.decimalAmount > 0 &&
+        canBeUsedForTransaction(assetAmount.asset)
     )
   const assetPricePoint = useBackgroundSelector((state) =>
     selectAssetPricePoint(state.assets, selectedAsset, mainCurrencySymbol)

--- a/ui/utils/swap.ts
+++ b/ui/utils/swap.ts
@@ -17,7 +17,10 @@ import {
 import { debounce, DebouncedFunc } from "lodash"
 import { useState, useRef, useCallback } from "react"
 import { CompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
-import { isSameAsset } from "@tallyho/tally-background/redux-slices/utils/asset-utils"
+import {
+  canBeUsedForTransaction,
+  isSameAsset,
+} from "@tallyho/tally-background/redux-slices/utils/asset-utils"
 import { useBackgroundDispatch, useBackgroundSelector } from "../hooks"
 import { useValueRef, useIsMounted, useSetState } from "../hooks/react-hooks"
 
@@ -265,8 +268,10 @@ export function getOwnedSellAssetAmounts(
   return (
     assetAmounts?.filter(
       (assetAmount): assetAmount is CompleteAssetAmount<SwappableAsset> =>
-        isSmartContractFungibleAsset(assetAmount.asset) ||
-        assetAmount.asset.symbol === currentNetwork.baseAsset.symbol
+        (isSmartContractFungibleAsset(assetAmount.asset) ||
+          assetAmount.asset.symbol === currentNetwork.baseAsset.symbol) &&
+        assetAmount.decimalAmount > 0 &&
+        canBeUsedForTransaction(assetAmount.asset)
     ) ?? []
   )
 }


### PR DESCRIPTION
Closes https://github.com/tahowallet/extension/issues/3438

## What
The user should not be able to send and swap unverified assets. In addition, assets with 0 balance should not appear in the list of assets.

## UI

Before

https://github.com/tahowallet/extension/assets/23117945/44eb61d8-9783-4c55-8a43-b7850cfe457c

After

https://github.com/tahowallet/extension/assets/23117945/c549328e-d03e-4d7f-a488-46c3add42df5

## Testing
- [x] Check the list of assets that can be sent. There should not be unverified assets and assets with a balance of 0.
- [x] Check the list of assets that can be swap. There should not be unverified assets and assets with a balance of 0.
- [x] Verify the asset and see if it appears in the lists above.


## Testing Env

```
SUPPORT_UNVERIFIED_ASSET=true
```

Latest build: [extension-builds-3452](https://github.com/tahowallet/extension/suites/13430489328/artifacts/736164593) (as of Wed, 07 Jun 2023 09:22:45 GMT).