### PR TITLE
Open the transaction details in new tab when activity is not available

### DIFF
--- a/ui/components/Wallet/UnverifiedAsset/AssetWarning.tsx
+++ b/ui/components/Wallet/UnverifiedAsset/AssetWarning.tsx
@@ -70,11 +70,6 @@ export default function AssetWarning(props: AssetWarningProps): ReactElement {
     history.push("/")
   }
 
-  const copyTxHash = (txHash: string) => {
-    navigator.clipboard.writeText(txHash)
-    dispatch(setSnackbarMessage(sharedT("copyTextSnackbar")))
-  }
-
   const currentAccountActivities = useBackgroundSelector(
     selectCurrentAccountActivities
   )
@@ -147,18 +142,32 @@ export default function AssetWarning(props: AssetWarningProps): ReactElement {
                     <button
                       type="button"
                       className={classNames("address_button", {
-                        no_click: !blockExplorerUrl,
+                        no_click: activityItem ? false : !blockExplorerUrl,
                       })}
                       onClick={() => {
                         if (activityItem) {
                           openActivityDetails(activityItem)
                         } else {
-                          copyTxHash(discoveryTxHash)
+                          window
+                            .open(
+                              `${blockExplorerUrl}/tx/${discoveryTxHash}`,
+                              "_blank"
+                            )
+                            ?.focus()
                         }
                       }}
                       title={discoveryTxHash}
                     >
                       {truncateAddress(discoveryTxHash)}
+                      {!activityItem && blockExplorerUrl && (
+                        <SharedIcon
+                          width={16}
+                          icon="icons/s/new-tab.svg"
+                          color="var(--green-5)"
+                          hoverColor="var(--trophy-gold)"
+                          transitionHoverTime="0.2s"
+                        />
+                      )}
                     </button>
                   </div>
                 </div>


### PR DESCRIPTION
## What
The user should be able to view activity details from the token verification level. If the activity is not yet available the preview should not be available but the user should be able to open transaction details in a new tab.

## UI

https://github.com/tahowallet/extension/assets/23117945/40435aee-1f49-42d0-8ed5-cb2ea88c5c85


## Testing
- [ ]  Check that the activity details preview is not available when the activity is not yet loaded. After clicking, a new tab should open with the details of the transaction. 
- [ ]  Check activity preview is working correctly (Token `BANANA` for `testertesting.eth`)

## Testing Env

```
SUPPORT_UNVERIFIED_ASSET=true
```