### PR TITLE
Repeater Connection: Forward requests to new default when default is switched off during dApp connection flow

### DIFF
--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -400,7 +400,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
     const { address } = await this.preferenceService.getSelectedAccount()
 
     // TODO make this multi-network friendly
-    await this.db.deletePermission(
+    const deleted = await this.db.deletePermission(
       permission.origin,
       address,
       permission.chainID
@@ -411,7 +411,9 @@ export default class ProviderBridgeService extends BaseService<Events> {
       delete this.#pendingPermissionsRequests[permission.origin]
     }
 
-    this.notifyContentScriptsAboutAddressChange()
+    if (deleted > 0) {
+      this.notifyContentScriptsAboutAddressChange()
+    }
   }
 
   async revokePermissionsForAddress(revokeAddress: string): Promise<void> {

--- a/env.d.ts
+++ b/env.d.ts
@@ -55,6 +55,7 @@ interface Window {
       shouldSetTally: boolean,
       shouldReload?: boolean
     ) => void
+    routeToNewDefault: (request: unknown) => Promise<unknown>
     getProviderInfo: (
       provider: WalletProvider
     ) => WalletProvider["providerInfo"]

--- a/src/window-provider.ts
+++ b/src/window-provider.ts
@@ -116,6 +116,10 @@ Object.defineProperty(window, "ethereum", {
       return cachedWindowEthereumProxy
     }
 
+    if (window.walletRouter.currentProvider === undefined) {
+      return undefined
+    }
+
     cachedWindowEthereumProxy = new Proxy(window.walletRouter.currentProvider, {
       get(target, prop, receiver) {
         if (

--- a/src/window-provider.ts
+++ b/src/window-provider.ts
@@ -142,7 +142,17 @@ Object.defineProperty(window, "ethereum", {
           return window.walletRouter[prop]
         }
 
-        return Reflect.get(target, prop, receiver)
+        return Reflect.get(
+          // Always proxy to the current provider, even if it has changed. This
+          // allows changes in the current provider, particularly when the user
+          // changes their default wallet, to take effect immediately. Combined
+          // with walletRouter.routeToNewDefault, this allows Taho to effect a
+          // change in provider without a page reload or even a second attempt
+          // at connecting.
+          window.walletRouter?.currentProvider ?? target,
+          prop,
+          receiver
+        )
       },
     })
     cachedCurrentProvider = window.walletRouter.currentProvider

--- a/src/window-provider.ts
+++ b/src/window-provider.ts
@@ -1,4 +1,5 @@
 import {
+  RequestArgument,
   WindowListener,
   WindowRequestEvent,
 } from "@tallyho/provider-bridge-shared"
@@ -64,6 +65,9 @@ if (!window.walletRouter) {
             window.location.reload()
           }, 1000)
         }
+      },
+      routeToNewDefault(request: Required<RequestArgument>): Promise<unknown> {
+        return this.currentProvider.request(request)
       },
       getProviderInfo(provider: WalletProvider) {
         return (

--- a/ui/pages/DAppConnect/DAppConnectPage.tsx
+++ b/ui/pages/DAppConnect/DAppConnectPage.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react"
+import React, { ReactElement, useEffect } from "react"
 import { AccountTotal } from "@tallyho/tally-background/redux-slices/selectors"
 import { PermissionRequest } from "@tallyho/provider-bridge-shared"
 import { useTranslation } from "react-i18next"
@@ -7,10 +7,12 @@ import {
   isDisabled,
   isEnabled,
 } from "@tallyho/tally-background/features"
+import { selectDefaultWallet } from "@tallyho/tally-background/redux-slices/ui"
 import SharedButton from "../../components/Shared/SharedButton"
 import SharedAccountItemSummary from "../../components/Shared/SharedAccountItemSummary"
 import RequestingDAppBlock from "./RequestingDApp"
 import SwitchWallet from "./SwitchWallet"
+import { useBackgroundSelector } from "../../hooks"
 
 type DAppConnectPageProps = {
   permission: PermissionRequest
@@ -29,6 +31,19 @@ export default function DAppConnectPage({
 }: DAppConnectPageProps): ReactElement {
   const { t } = useTranslation("translation", { keyPrefix: "dappConnection" })
   const { title, origin, faviconUrl, accountAddress } = permission
+
+  const isDefaultWallet = useBackgroundSelector(selectDefaultWallet)
+
+  useEffect(() => {
+    if (
+      isEnabled(FeatureFlags.ENABLE_UPDATED_DAPP_CONNECTIONS) &&
+      !isDefaultWallet
+    ) {
+      // When default wallet is toggled off, wait for the toggle animation to
+      // complete and close the window out.
+      setTimeout(() => window.close(), 300)
+    }
+  }, [isDefaultWallet])
 
   return (
     <>

--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -150,6 +150,7 @@ export default class TallyWindowProvider extends EventEmitter {
         )
         const currentHost = window.location.host
         if (
+          process.env.ENABLE_UPDATED_DAPP_CONNECTIONS === "true" ||
           impersonateMetamaskWhitelist.some((host) =>
             currentHost.includes(host)
           )

--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -184,16 +184,14 @@ export default class TallyWindowProvider extends EventEmitter {
             // Make sure to re-route the requests in the order they were
             // received.
             .sort(([id], [id2]) => Number(BigInt(id2) - BigInt(id)))
-            .forEach(([id, { sendData, reject, resolve }]) => {
+            .forEach(([, { sendData, reject, resolve }]) => {
               window.walletRouter
                 ?.routeToNewDefault(sendData.request)
                 // On success or error, call the original reject/resolve
                 // functions to notify the requestor of the new wallet's
                 // response.
-                .then((...a) => resolve(...a))
-                .catch((...b) => reject(...b))
-
-              this.requestResolvers.delete(id)
+                .then(resolve)
+                .catch(reject)
             })
         }
 


### PR DESCRIPTION
Adds the ability to pass through to the next provider as soon
as the user toggles default wallet off.

Can be reviewed and merged separately from #3451.

Ex:

https://github.com/tahowallet/extension/assets/8245/9fcb3c77-8242-4461-831b-7988243be4ed

## Testing

- [ ] Make sure Taho is set as default and connect to a dApp, waiting for the dApp Connection popup to appear.
- [ ] Switch the default wallet toggle to off in the top bar of the dApp Connection popup.
  - [ ] The dApp Connection popup should disappear, and the next wallet should pop up its connection flow immediately.

Note that you can get into a state where you've previously requested a MetaMask connection, but did not complete the flow (e.g. by not unlocking MetaMask). In this case MetaMask will auto-decline the connection request from the dApp, so the above flow will appear not to work. Make sure MetaMask is in an unlocked idle state before testing the flow above.

## Testing Env

```
ENABLE_UPDATED_DAPP_CONNECTIONS=true
```

Latest build: [extension-builds-3462](https://github.com/tahowallet/extension/suites/13633228421/artifacts/752242181) (as of Thu, 15 Jun 2023 15:12:02 GMT).