### PR TITLE
Fix broken E2E test removing wallet

### DIFF
--- a/e2e-tests/accounts.spec.ts
+++ b/e2e-tests/accounts.spec.ts
@@ -4,7 +4,7 @@ test("Remove wallet", async ({ page, walletPageHelper }) => {
   await walletPageHelper.onboarding.addNewWallet()
   await walletPageHelper.goToStartPage()
 
-  await page.locator(".profile_button").nth(1).click()
+  await page.locator(".profile_button").click()
   await page.locator(".icon_settings").click()
   await page.locator("text=Remove address").click()
   await page.locator("text=Yes, I want to remove it").click()


### PR DESCRIPTION
After changes made in https://github.com/tahowallet/extension/pull/3447 the E2E tests started to fail on `await page.locator(".profile_button").nth(1).click()` in `e2e-tests/accounts.spec.ts` file. The element could not be found. It looks that previously some DOM elements were duplicated and we had two elements with class name `profile_button`. Now we have only one, so we can remove the `.nth(1)` locator from the step.