### PR TITLE
Case Dismissed: Forcibly show DAppConnectionInfoBar popover on first dApp connection

### DIFF
--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -22,7 +22,7 @@ const getSignerRecordId = (signer: AccountSignerWithId): SignerRecordId => {
 
 // The idea is to use this interface to describe the data structure stored in indexedDb
 // In the future this might also have a runtime type check capability, but it's good enough for now.
-export interface Preferences {
+export type Preferences = {
   id?: number
   savedAt: number
   tokenLists: { autoUpdate: boolean; urls: string[] }
@@ -36,6 +36,30 @@ export interface Preferences {
   }
 }
 
+/**
+ * Items that the user will see and then will not reappear once they've been
+ * manually dismissed. Manual dismissal can include closing a popover, or
+ * selecting "Don't show again" on a popup before closing it.
+ */
+export type ManuallyDismissableItem = "analytics-enabled-banner"
+/**
+ * Items that the user will see once and will not be auto-displayed again. Can
+ * be used for tours, or for popups that can be retriggered but will not
+ * auto-display more than once.
+ */
+export type SingleShotItem = "default-connection-popover"
+
+/**
+ * Items that the user will view one time and either manually dismiss or that
+ * will remain auto-collapsed after first view.
+ */
+export type DismissableItem = ManuallyDismissableItem | SingleShotItem
+
+type DismissableItemEntry = {
+  id: DismissableItem
+  shown: boolean
+}
+
 export class PreferenceDatabase extends Dexie {
   private preferences!: Dexie.Table<Preferences, number>
 
@@ -44,19 +68,18 @@ export class PreferenceDatabase extends Dexie {
     string
   >
 
+  private shownDismissableItems!: Dexie.Table<DismissableItemEntry, string>
+
   constructor() {
     super("tally/preferences")
 
-    // DELETE ME: No need to keep this, but because this service was using a different method
-    // I thought it's easier to follow the history if it's here at least until we discuss this approach
+    // TODO Would be good to move all of these migrations to their own file or
+    // TODO files.
     this.version(1).stores({
       preferences: "++id,savedAt",
       migrations: "++id,appliedAt",
     })
 
-    // DELETE ME: This is not necessary either, but because there was a different approach
-    // implementing the migration I kept it here for now just to make sure
-    // the db is in working condition.
     this.version(2)
       .stores({
         preferences: "++id,savedAt,currency,tokenLists,defaultWallet",
@@ -76,9 +99,6 @@ export class PreferenceDatabase extends Dexie {
           })
       })
 
-    // TBD @Antonio: Implemented database versioning and population according to the Dexie docs
-    // https://dexie.org/docs/Tutorial/Design#database-versioning
-    // I fully expect that I might need to revert all of this, but as per my current knowledge this seems to be a good idea
     this.version(3).stores({
       migrations: null, // If we use dexie built in migrations then we don't need to keep track of them manually
       preferences: "++id", // removed all the unused indexes
@@ -203,6 +223,7 @@ export class PreferenceDatabase extends Dexie {
           })
       })
 
+    // Update Taho token list reference.
     this.version(9)
       .stores({
         preferences: "++id",
@@ -319,6 +340,12 @@ export class PreferenceDatabase extends Dexie {
         })
     })
 
+    this.version(17).stores({
+      preferences: "++id",
+      signersSettings: "&id",
+      shownDismissableItems: "&id,shown",
+    })
+
     // This is the old version for populate
     // https://dexie.org/docs/Dexie/Dexie.on.populate-(old-version)
     // The this does not behave according the new docs, but works
@@ -379,6 +406,20 @@ export class PreferenceDatabase extends Dexie {
   ): Promise<AccountSignerSettings[]> {
     await this.signersSettings.delete(getSignerRecordId(signer))
     return this.signersSettings.toArray()
+  }
+
+  async markDismissableItemAsShown(item: DismissableItem): Promise<void> {
+    await this.shownDismissableItems.put({ id: item, shown: true })
+  }
+
+  async getShownDismissableItems(): Promise<DismissableItem[]> {
+    return (await this.shownDismissableItems.toArray()).map(({ id }) => id)
+  }
+
+  async wasDismissableItemAlreadyShown(
+    item: DismissableItem
+  ): Promise<boolean> {
+    return (await this.shownDismissableItems.get(item))?.shown ?? false
   }
 }
 

--- a/background/services/preferences/index.ts
+++ b/background/services/preferences/index.ts
@@ -7,7 +7,7 @@ import {
   Preferences,
   TokenListPreferences,
 } from "./types"
-import { getOrCreateDB, PreferenceDatabase } from "./db"
+import { DismissableItem, getOrCreateDB, PreferenceDatabase } from "./db"
 import BaseService from "../base"
 import { normalizeEVMAddress } from "../../lib/utils"
 import { ETHEREUM, OPTIMISM, ARBITRUM_ONE } from "../../constants"
@@ -15,6 +15,8 @@ import { EVMNetwork, sameNetwork } from "../../networks"
 import { HexString } from "../../types"
 import { AccountSignerSettings } from "../../ui"
 import { AccountSignerWithId } from "../../signing"
+
+export { ManuallyDismissableItem, SingleShotItem, DismissableItem } from "./db"
 
 type AddressBookEntry = {
   network: EVMNetwork
@@ -96,9 +98,11 @@ interface Events extends ServiceLifecycleEvents {
   preferencesChanges: Preferences
   initializeDefaultWallet: boolean
   initializeSelectedAccount: AddressOnNetwork
+  initializeShownDismissableItems: DismissableItem[]
   updateAnalyticsPreferences: AnalyticsPreferences
   addressBookEntryModified: AddressBookEntry
   updatedSignerSettings: AccountSignerSettings[]
+  dismissableItemMarkedAsShown: DismissableItem
 }
 
 /*
@@ -137,6 +141,10 @@ export default class PreferenceService extends BaseService<Events> {
       "updateAnalyticsPreferences",
       await this.getAnalyticsPreferences()
     )
+    this.emitter.emit(
+      "initializeShownDismissableItems",
+      await this.getShownDismissableItems()
+    )
   }
 
   protected override async internalStopService(): Promise<void> {
@@ -145,8 +153,8 @@ export default class PreferenceService extends BaseService<Events> {
     await super.internalStopService()
   }
 
-  // TODO Implement the following 6 methods as something stored in the database and user-manageable.
-  // TODO Track account names in the UI in the address book.
+  // TODO Implement the following 6 methods as something stored in the database
+  // TODO and user-manageable.
 
   addOrEditNameInAddressBook(newEntry: AddressBookEntry): void {
     const correspondingEntryIndex = this.addressBook.findIndex((entry) =>
@@ -203,6 +211,8 @@ export default class PreferenceService extends BaseService<Events> {
     )
   }
 
+  // FIXME This should not be publicly accessible, but triggered by observing
+  // FIXME an event on the signer service.
   async deleteAccountSignerSettings(
     signer: AccountSignerWithId
   ): Promise<void> {
@@ -222,6 +232,16 @@ export default class PreferenceService extends BaseService<Events> {
     this.emitter.emit("updatedSignerSettings", await updatedSignerSettings)
   }
 
+  async markDismissableItemAsShown(item: DismissableItem): Promise<void> {
+    await this.db.markDismissableItemAsShown(item)
+
+    this.emitter.emit("dismissableItemMarkedAsShown", item)
+  }
+
+  async getShownDismissableItems(): Promise<DismissableItem[]> {
+    return this.db.getShownDismissableItems()
+  }
+
   async getAnalyticsPreferences(): Promise<Preferences["analytics"]> {
     return (await this.db.getPreferences())?.analytics
   }
@@ -232,8 +252,6 @@ export default class PreferenceService extends BaseService<Events> {
     await this.db.upsertAnalyticsPreferences(analyticsPreferences)
     const { analytics } = await this.db.getPreferences()
 
-    // This step is not strictly needed, because the settings can only
-    // be changed from the UI
     this.emitter.emit("updateAnalyticsPreferences", analytics)
   }
 

--- a/ui/components/DAppConnection/DAppConnectionDefaultToggle.tsx
+++ b/ui/components/DAppConnection/DAppConnectionDefaultToggle.tsx
@@ -53,25 +53,24 @@ export default function DAppConnectionDefaultToggle({
         <p className="default_wallet">
           {alwaysForceSelection === undefined ? t("connectToWebsiteUsing") : ""}
           <SharedIcon
-            width={20}
-            icon="taho-connect-icon.svg"
-            ariaLabel={t("setTahoAsDefault")}
-            color={defaultIsSelected ? "var(--success)" : "var(--green-20)"}
-            onClick={() => setDefaultWallet(true)}
+            width={24}
+            icon="other-wallet-connect-icon.svg"
+            ariaLabel={t("setOtherAsDefault")}
+            color={defaultIsSelected ? "var(--green-20)" : "var(--white)"}
+            onClick={() => setDefaultWallet(false)}
           />
           <SharedToggleButton
             onChange={(toggleValue) => setDefaultWallet(toggleValue)}
             onColor="var(--success)"
             offColor="var(--white)"
             value={defaultIsSelected}
-            leftToRight={false}
           />
           <SharedIcon
-            width={24}
-            icon="other-wallet-connect-icon.svg"
-            ariaLabel={t("setOtherAsDefault")}
-            color={defaultIsSelected ? "var(--green-20)" : "var(--white)"}
-            onClick={() => setDefaultWallet(false)}
+            width={20}
+            icon="taho-connect-icon.svg"
+            ariaLabel={t("setTahoAsDefault")}
+            color={defaultIsSelected ? "var(--success)" : "var(--green-20)"}
+            onClick={() => setDefaultWallet(true)}
           />
         </p>
       )}

--- a/ui/components/Shared/SharedToggleButton.tsx
+++ b/ui/components/Shared/SharedToggleButton.tsx
@@ -14,12 +14,6 @@ type SharedToggleButtonProps = {
    */
   offColor?: string
   value?: boolean | undefined
-  /**
-   * True if the toggle is off when on the left and on when on the right, false
-   * if the direction is opposite (on when on the left and off when on the
-   * right). True by default.
-   */
-  leftToRight: boolean
 }
 
 export default function SharedToggleButton({
@@ -27,7 +21,6 @@ export default function SharedToggleButton({
   onColor,
   offColor,
   value,
-  leftToRight,
 }: SharedToggleButtonProps): ReactElement {
   const [isActive, setIsActive] = useState(value || false)
 
@@ -59,8 +52,6 @@ export default function SharedToggleButton({
             padding: 4px;
             cursor: pointer;
             display: flex;
-
-            ${leftToRight ? "" : "transform: rotate(180deg);"}
           }
           .bulb {
             width: 16px;
@@ -81,6 +72,4 @@ export default function SharedToggleButton({
   )
 }
 
-SharedToggleButton.defaultProps = {
-  leftToRight: true,
-}
+SharedToggleButton.defaultProps = {}


### PR DESCRIPTION
Draft until #3451 lands.

Adds a `DismissableItem` concept and related functionality to the
`PreferencesService` and to the UI slice, providing a common pattern
for things that should be shown to the user exactly once, e.g. new
feature banners and related functions.

This PR will complete the work on updated dApp connections.

Latest build: [extension-builds-3464](https://github.com/tahowallet/extension/suites/13641442570/artifacts/752912241) (as of Thu, 15 Jun 2023 20:55:13 GMT).