### PR TITLE
Slide On Over: Drop an unnecessary z-index on CorePage

### DIFF
--- a/ui/components/Core/CorePage.tsx
+++ b/ui/components/Core/CorePage.tsx
@@ -36,7 +36,6 @@ export default function CorePage(props: Props): ReactElement {
             margin: 0 auto;
             align-items: center;
             background-color: var(--hunter-green);
-            z-index: 10;
             height: 100%;
           }
           .top_menu_wrap {


### PR DESCRIPTION
In addition to being unnecessary, this z-index was preventing SharedSlideUps from properly overlaying on top of the tab bar by creating a new stacking context. Whoops!

Latest build: [extension-builds-3476](https://github.com/tahowallet/extension/suites/13586815056/artifacts/748529675) (as of Wed, 14 Jun 2023 02:56:08 GMT).