### PR TITLE
Exclude `article` and `result` types for abilities

### DIFF
--- a/background/abilities.ts
+++ b/background/abilities.ts
@@ -31,8 +31,11 @@ export const ABILITY_TYPES_ENABLED = [
 export const ABILITY_TYPES = [
   ...ABILITY_TYPES_ENABLED,
   "event",
-  "article",
-  "result",
+  // Abilities type `article` and `result` will be fetched from the new endpoint.
+  // Let's exclude this type for a moment.
+  // TODO Fetch abilities from the correct endpoint.
+  // "article",
+  // "result",
   "misc",
 ] as const
 

--- a/background/services/abilities/index.ts
+++ b/background/services/abilities/index.ts
@@ -106,6 +106,7 @@ export default class AbilitiesService extends BaseService<Events> {
 
   protected override async internalStartService(): Promise<void> {
     await super.internalStartService()
+    await this.fetchAbilities()
   }
 
   // Should only be called with ledger or imported accounts
@@ -190,12 +191,7 @@ export default class AbilitiesService extends BaseService<Events> {
     }
   }
 
-  async refreshAbilities(): Promise<void> {
-    const lastFetchTime = localStorage.getItem(this.ABILITY_TIME_KEY)
-
-    if (lastFetchTime && Number(lastFetchTime) + HOUR > Date.now()) {
-      return
-    }
+  async fetchAbilities(): Promise<void> {
     localStorage.setItem(this.ABILITY_TIME_KEY, Date.now().toString())
     const accountsToTrack = await this.chainService.getAccountsToTrack()
     const addresses = new Set(
@@ -207,6 +203,15 @@ export default class AbilitiesService extends BaseService<Events> {
     for (const address of addresses) {
       this.emitter.emit("initAbilities", address)
     }
+  }
+
+  async refreshAbilities(): Promise<void> {
+    const lastFetchTime = localStorage.getItem(this.ABILITY_TIME_KEY)
+
+    if (lastFetchTime && Number(lastFetchTime) + HOUR > Date.now()) {
+      return
+    }
+    await this.fetchAbilities()
   }
 
   async reportAndRemoveAbility(


### PR DESCRIPTION
## What

Currently, all abilities are fetched from one endpoint. In about two weeks' time, the abilities type the `article` and the `result` should be fetched from another endpoint. Let's exclude these types and then, in the next steps, retrieve them from another endpoint. 

## UI
https://github.com/tahowallet/extension/assets/23117945/9586609d-3719-42c6-889c-1dcff932bf4a

## Testing
- [x] Check that abilities of this type are not fetched from the API. 
- [x] In the filter list, the `article` and `result` types should not be present.

Latest build: [extension-builds-3479](https://github.com/tahowallet/extension/suites/13624732258/artifacts/751620264) (as of Thu, 15 Jun 2023 10:02:31 GMT).