### PR TITLE
Auto-Not-So-Matic: Fix two matic.network URLs to polygon.technology

### DIFF
--- a/background/lib/gas.ts
+++ b/background/lib/gas.ts
@@ -42,7 +42,7 @@ type PolygonGasResponse = {
 const getPolygonGasPrices = async (price: bigint): Promise<BlockPrices> => {
   // @TODO Validate this response using ajv
   const gasEstimates = (await fetchJson(
-    "https://gasstation-mainnet.matic.network/v2"
+    "https://gasstation.polygon.technology/v2"
   )) as PolygonGasResponse
 
   const baseFeePerGas = BigInt(Math.ceil(gasEstimates.estimatedBaseFee * 1e9))

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -48,7 +48,6 @@ import {
   normalizeEVMAddress,
   sameEVMAddress,
 } from "../../lib/utils"
-import { fixPolygonWETHIssue, polygonTokenListURL } from "./token-list-edit"
 
 // Transactions seen within this many blocks of the chain tip will schedule a
 // token refresh sooner than the standard rate.
@@ -911,11 +910,6 @@ export default class IndexingService extends BaseService<Events> {
           try {
             const newListRef = await fetchAndValidateTokenList(url)
 
-            if (url === polygonTokenListURL) {
-              newListRef.tokenList.tokens = fixPolygonWETHIssue(
-                newListRef.tokenList.tokens
-              )
-            }
             await this.db.saveTokenList(url, newListRef.tokenList)
           } catch (err) {
             logger.error(

--- a/background/services/indexing/token-list-edit.ts
+++ b/background/services/indexing/token-list-edit.ts
@@ -34,7 +34,7 @@ export function fixPolygonWETHIssue(tokensParam: TokenInfo[]): TokenInfo[] {
       ...tokens[tokenToRenameIndex],
       name: "Wrapped Ether",
       symbol: "WETH",
-      logoURI: "https://wallet-asset.matic.network/img/tokens/weth.svg",
+      logoURI: "https://assets.polygon.technology/tokenAssets/eth.svg",
     }
   }
 


### PR DESCRIPTION
Looks like matic.network has been fully decommissioned, and for both gas prices and for the PoS WETH asset, we were relying on it. Move to polygon.technology equivalents.

In practice, the asset SVG for PoS WETH won't be used because newer versions of the Polygon token lists don't include the broken WETH asset that we were substituting in. We keep it because it's referenced in a migration and I would rather not try to figure out if it's safe to kill the migration for now.

## Testing

- [x] Switch to Polygon
  - [x] Try to send an asset. You should be able to get to the send transaction screen with a populated gas price.
  - [x] Look up ETH under the swap target while on Polygon and make sure you see ![](https://assets.polygon.technology/tokenAssets/eth.svg) as the icon. The changes in this PR shouldn't really affect this, but might as well check!

Fixes #3482 .

Latest build: [extension-builds-3483](https://github.com/tahowallet/extension/suites/13645026026/artifacts/753192433) (as of Fri, 16 Jun 2023 00:51:51 GMT).