### PR TITLE
Fix throwing SharedToggleItem on item without label

### DIFF
--- a/background/lib/utils/index.ts
+++ b/background/lib/utils/index.ts
@@ -166,7 +166,11 @@ export function getEthereumNetwork(): EVMNetwork {
 }
 
 export function isProbablyEVMAddress(str: string): boolean {
-  if (normalizeHexAddress(str).startsWith("0x") && str.length === 42) {
+  if (
+    typeof str === "string" &&
+    str.length === 42 &&
+    normalizeHexAddress(str).startsWith("0x")
+  ) {
     return true
   }
   return false

--- a/background/lib/utils/index.ts
+++ b/background/lib/utils/index.ts
@@ -166,11 +166,7 @@ export function getEthereumNetwork(): EVMNetwork {
 }
 
 export function isProbablyEVMAddress(str: string): boolean {
-  if (
-    typeof str === "string" &&
-    str.length === 42 &&
-    normalizeHexAddress(str).startsWith("0x")
-  ) {
+  if (str.length === 42 && normalizeHexAddress(str).startsWith("0x")) {
     return true
   }
   return false

--- a/ui/components/Shared/SharedToggleItem.tsx
+++ b/ui/components/Shared/SharedToggleItem.tsx
@@ -8,7 +8,7 @@ import SharedToggleButton from "./SharedToggleButton"
 export const STARS_GREY_URL = "./images/stars_grey.svg"
 
 type SharedToggleItemProps = {
-  label: string
+  label?: string
   thumbnailURL?: string
   checked: boolean
   onChange: (toggleValue: boolean) => void
@@ -25,7 +25,9 @@ export default function SharedToggleItem({
       <div className="text_wrap">
         <div className="thumbnail" role="img" />
         <label className="label ellipsis">
-          {isProbablyEVMAddress(label) ? truncateAddress(label) : label ?? ""}
+          {typeof label === "string" && isProbablyEVMAddress(label)
+            ? truncateAddress(label)
+            : label ?? ""}
         </label>
       </div>
       <SharedToggleButton onChange={onChange} value={checked} />

--- a/ui/components/Shared/SharedToggleItem.tsx
+++ b/ui/components/Shared/SharedToggleItem.tsx
@@ -25,7 +25,7 @@ export default function SharedToggleItem({
       <div className="text_wrap">
         <div className="thumbnail" role="img" />
         <label className="label ellipsis">
-          {isProbablyEVMAddress(label) ? truncateAddress(label) : label}
+          {isProbablyEVMAddress(label) ? truncateAddress(label) : label ?? ""}
         </label>
       </div>
       <SharedToggleButton onChange={onChange} value={checked} />


### PR DESCRIPTION
### What

Solve throwing NFTs filters page when some collection got `undefined` label. Seems like it makes `SharedToggleItem` throw an unexpected error. As we don't know yet how it happened that the collection had an `undefined` label let's make a fix in `isProbablyEVMAddress`

![image](https://github.com/tahowallet/extension/assets/20949277/8197a45a-d7b0-4c83-9399-342be748f51f)

Latest build: [extension-builds-3486](https://github.com/tahowallet/extension/suites/13700610101/artifacts/757499670) (as of Mon, 19 Jun 2023 10:13:43 GMT).