### PR TITLE
Change expected account name in NFTs tests to ENS domain

### DIFF
--- a/e2e-tests/nfts.spec.ts
+++ b/e2e-tests/nfts.spec.ts
@@ -80,7 +80,7 @@ test.describe("NFTs", () => {
       await page
         .getByTestId("nft_account_filters")
         .filter({
-          hasText: /^(Phoenix|Matilda|Sirius|Topa|Atos|Sport|Lola|Foz)$/,
+          hasText: /^e2e\.testertesting\.eth$/,
         })
         .getByRole("checkbox")
         .click()
@@ -107,7 +107,7 @@ test.describe("NFTs", () => {
         .getByTestId("nft_account_filters")
         .getByTestId("toggle_item")
         .filter({
-          hasText: /^(Phoenix|Matilda|Sirius|Topa|Atos|Sport|Lola|Foz)$/,
+          hasText: /^e2e\.testertesting\.eth$/,
         })
         .getByRole("checkbox")
         .click()

--- a/e2e-tests/nfts.spec.ts
+++ b/e2e-tests/nfts.spec.ts
@@ -1,5 +1,6 @@
 import { wait } from "@tallyho/tally-background/lib/utils"
 import { test, expect } from "./utils"
+import { account1Address, account1Name } from "./utils/onboarding"
 
 test.describe("NFTs", () => {
   test("User can view nft collections, poaps and badges", async ({
@@ -36,9 +37,7 @@ test.describe("NFTs", () => {
         }
       })
 
-      await walletPageHelper.onboarding.addReadOnlyAccount(
-        "0x6f1b1f1feb01235e15a7962f16c389c7f8218ed6"
-      )
+      await walletPageHelper.onboarding.addReadOnlyAccount(account1Address)
 
       await walletPageHelper.goToStartPage()
       await walletPageHelper.setViewportSize()
@@ -75,14 +74,12 @@ test.describe("NFTs", () => {
     })
 
     await test.step("Filtering accounts", async () => {
-      const accountName = /^e2e\.testertesting\.eth$/
-
       await page.getByRole("button", { name: "Filter collections" }).click()
 
       await page
         .getByTestId("nft_account_filters")
         .filter({
-          hasText: accountName,
+          hasText: account1Name,
         })
         .getByRole("checkbox")
         .click()
@@ -109,7 +106,7 @@ test.describe("NFTs", () => {
         .getByTestId("nft_account_filters")
         .getByTestId("toggle_item")
         .filter({
-          hasText: accountName,
+          hasText: account1Name,
         })
         .getByRole("checkbox")
         .click()

--- a/e2e-tests/nfts.spec.ts
+++ b/e2e-tests/nfts.spec.ts
@@ -75,12 +75,14 @@ test.describe("NFTs", () => {
     })
 
     await test.step("Filtering accounts", async () => {
+      const accountName = /^e2e\.testertesting\.eth$/
+
       await page.getByRole("button", { name: "Filter collections" }).click()
 
       await page
         .getByTestId("nft_account_filters")
         .filter({
-          hasText: /^e2e\.testertesting\.eth$/,
+          hasText: accountName,
         })
         .getByRole("checkbox")
         .click()
@@ -107,7 +109,7 @@ test.describe("NFTs", () => {
         .getByTestId("nft_account_filters")
         .getByTestId("toggle_item")
         .filter({
-          hasText: /^e2e\.testertesting\.eth$/,
+          hasText: accountName,
         })
         .getByRole("checkbox")
         .click()

--- a/e2e-tests/utils/onboarding.ts
+++ b/e2e-tests/utils/onboarding.ts
@@ -25,6 +25,10 @@ export const getOnboardingPage = async (
 }
 
 const DEFAULT_PASSWORD = "12345678"
+// The account1 is a 3rd address associated with the testertesting.eth account.
+// It owns some NFTs/badges.
+export const account1Address = "0x6f1b1f1feb01235e15a7962f16c389c7f8218ed6"
+export const account1Name = /^e2e\.testertesting\.eth$/
 
 export default class OnboardingHelper {
   constructor(


### PR DESCRIPTION
We have configured a ENS name for the
`0x6f1b1f1feb01235e15a7962f16c389c7f8218ed6` address. We need to update the tests to reflect that.

Latest build: [extension-builds-3494](https://github.com/tahowallet/extension/suites/13792525506/artifacts/764721892) (as of Thu, 22 Jun 2023 14:20:28 GMT).