### PR TITLE
v0.39.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -51,6 +51,7 @@ body:
       label: Version
       description: What version of the extension are you running?
       options:
+        - v0.39.0
         - v0.38.1
         - v0.38.0
         - v0.37.0

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Taho",
-  "version": "0.38.1",
+  "version": "0.39.0",
   "description": "The community owned and operated Web3 wallet.",
   "homepage_url": "https://taho.xyz",
   "author": "https://taho.xyz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tallyho/tally-extension",
   "private": true,
-  "version": "0.38.1",
+  "version": "0.39.0",
   "description": "Taho, the community owned and operated Web3 wallet.",
   "main": "index.js",
   "repository": "git@github.com:thesis/tally-extension.git",


### PR DESCRIPTION
## What's Changed
* Repeater Connection: Forward requests to new default when default is switched off during dApp connection flow by @Shadowfiend in https://github.com/tahowallet/extension/pull/3462
* Auto-Not-So-Matic: Fix two matic.network URLs to polygon.technology by @Shadowfiend in https://github.com/tahowallet/extension/pull/3483
* v0.38.0 by @kkosiorowska in https://github.com/tahowallet/extension/pull/3480
* Case Dismissed: Forcibly show DAppConnectionInfoBar popover on first dApp connection by @Shadowfiend in https://github.com/tahowallet/extension/pull/3464
* Add Hardhat Fork Functionality by @0xDaedalus in https://github.com/tahowallet/extension/pull/3247
* Faded Jeans: Rename fadeIn class to fade_in  by @Shadowfiend in https://github.com/tahowallet/extension/pull/3485
* Fix issue for discovery transaction hash by @kkosiorowska in https://github.com/tahowallet/extension/pull/3458
* Full Sweep: Drop the USE_UPDATED_SIGNING_UI feature flag by @Shadowfiend in https://github.com/tahowallet/extension/pull/3475
* Token Discovery - Remap redux asset balances by @hyphenized in https://github.com/tahowallet/extension/pull/3195
* Make specific warnings for adding custom asset by @kkosiorowska in https://github.com/tahowallet/extension/pull/3478
* Run NFTs e2e tests on a controlled wallet address by @michalinacienciala in https://github.com/tahowallet/extension/pull/3487
* v0.38.1 by @jagodarybacka in https://github.com/tahowallet/extension/pull/3484


**Full Changelog**: https://github.com/tahowallet/extension/compare/v0.38.1...v0.39.0
Latest build: [extension-builds-3496](https://github.com/tahowallet/extension/suites/13792957673/artifacts/764738599) (as of Thu, 22 Jun 2023 14:27:32 GMT).