### PR TITLE
Fix E2E onboarding helper

### DIFF
--- a/e2e-tests/utils/onboarding.ts
+++ b/e2e-tests/utils/onboarding.ts
@@ -3,25 +3,21 @@ import { BrowserContext, test as base, expect, Page } from "@playwright/test"
 export const getOnboardingPage = async (
   context: BrowserContext
 ): Promise<Page> => {
-  await expect(async () => {
+  const getOnboardingOrThrow = () => {
     const pages = context.pages()
+
     const onboarding = pages.find((page) => /onboarding/.test(page.url()))
 
     if (!onboarding) {
       throw new Error("Unable to find onboarding tab")
     }
 
-    expect(onboarding).toHaveURL(/onboarding/)
-  }).toPass()
-
-  const onboarding = context.pages().at(-1)
-
-  if (!onboarding) {
-    // Should never happen
-    throw new Error("Onboarding page closed too early")
+    return onboarding
   }
 
-  return onboarding
+  await expect(async () => getOnboardingOrThrow()).toPass()
+
+  return getOnboardingOrThrow()
 }
 
 const DEFAULT_PASSWORD = "12345678"
@@ -36,30 +32,6 @@ export default class OnboardingHelper {
     // public readonly backgroundPage: Page,
     public readonly context: BrowserContext
   ) {}
-
-  async getOnboardingPage(): Promise<Page> {
-    await expect(async () => {
-      const pages = this.context.pages()
-      const onboarding = pages.find((page) => /onboarding/.test(page.url()))
-
-      if (!onboarding) {
-        throw new Error("Unable to find onboarding tab")
-      }
-
-      expect(onboarding).toHaveURL(/onboarding/)
-    }).toPass()
-
-    const onboarding = this.context
-      .pages()
-      .find((page) => /onboarding/.test(page.url()))
-
-    if (!onboarding) {
-      // Should never happen
-      throw new Error("Onboarding page closed too early")
-    }
-
-    return onboarding
-  }
 
   async addReadOnlyAccount(
     addressOrName: string,


### PR DESCRIPTION
Under certain conditions, running e2e tests would sometimes open up a third, blank tab which caused an onboarding helper to fail setting the page to run the tests correctly or even executing the test run.

There are a few ways to test this fix addresses the issue:
- Run `PWDebug=1 npx playwright test`, after opening the browser the tests should run normally (might need to click play button on the playwright debugger).
- Run `PWDebug=console npx playwright test`, after opening the browser the tests should run normally.
- Run `npx playwright test`, tests should also run normally
- Check CI e2e runs still work

Latest build: [extension-builds-3503](https://github.com/tahowallet/extension/suites/13878762407/artifacts/771453927) (as of Mon, 26 Jun 2023 22:16:46 GMT).