### PR TITLE
Update Taho token list reference

### DIFF
--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -369,6 +369,7 @@ export class PreferenceDatabase extends Dexie {
             "bafybeihufwj43zej34itf66qyguq35k4f6s4ual4uk3iy643wn3xnff2ka"
           )
 
+          // Param reassignment is the recommended way to use `modify` https://dexie.org/docs/Collection/Collection.modify()
           // eslint-disable-next-line no-param-reassign
           storedPreferences.tokenLists = {
             ...storedPreferences.tokenLists,

--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -20,6 +20,24 @@ const getSignerRecordId = (signer: AccountSignerWithId): SignerRecordId => {
   return `${signer.type}/${id}`
 }
 
+/**
+ * Update Taho token list reference.
+ * Returns an updated URLs for the token list.
+ */
+const getNewUrlsForTokenList = (
+  storedPreferences: Preferences,
+  oldPath: string,
+  newPath: string
+): string[] => {
+  // Get rid of old Taho URL
+  const newURLs = storedPreferences.tokenLists.urls.filter(
+    (url) => !url.includes(oldPath)
+  )
+  newURLs.push(`https://ipfs.io/ipfs/${newPath}`)
+
+  return newURLs
+}
+
 // The idea is to use this interface to describe the data structure stored in indexedDb
 // In the future this might also have a runtime type check capability, but it's good enough for now.
 export type Preferences = {
@@ -159,16 +177,12 @@ export class PreferenceDatabase extends Dexie {
           .table("preferences")
           .toCollection()
           .modify((storedPreferences: Preferences) => {
-            // Get rid of old tally URL
-            const newURLs = storedPreferences.tokenLists.urls.filter(
-              (url) =>
-                !url.includes(
-                  "bafybeicovpqvb533alo5scf7vg34z6fjspdytbzsa2es2lz35sw3ksh2la"
-                )
-            )
-
-            newURLs.push(
-              "https://ipfs.io/ipfs/bafybeifeqadgtritd3p2qzf5ntzsgnph77hwt4tme2umiuxv2ez2jspife"
+            const newURLs = getNewUrlsForTokenList(
+              storedPreferences,
+              // Old path
+              "bafybeicovpqvb533alo5scf7vg34z6fjspdytbzsa2es2lz35sw3ksh2la",
+              // New path
+              "bafybeifeqadgtritd3p2qzf5ntzsgnph77hwt4tme2umiuxv2ez2jspife"
             )
 
             // eslint-disable-next-line no-param-reassign
@@ -233,16 +247,12 @@ export class PreferenceDatabase extends Dexie {
           .table("preferences")
           .toCollection()
           .modify((storedPreferences: Preferences) => {
-            // Get rid of old tally URL
-            const newURLs = storedPreferences.tokenLists.urls.filter(
-              (url) =>
-                !url.includes(
-                  "bafybeifeqadgtritd3p2qzf5ntzsgnph77hwt4tme2umiuxv2ez2jspife"
-                )
-            )
-
-            newURLs.push(
-              "https://ipfs.io/ipfs/bafybeigtlpxobme7utbketsaofgxqalgqzowhx24wlwwrtbzolgygmqorm"
+            const newURLs = getNewUrlsForTokenList(
+              storedPreferences,
+              // Old path
+              "bafybeifeqadgtritd3p2qzf5ntzsgnph77hwt4tme2umiuxv2ez2jspife",
+              // New path
+              "bafybeigtlpxobme7utbketsaofgxqalgqzowhx24wlwwrtbzolgygmqorm"
             )
 
             // eslint-disable-next-line no-param-reassign
@@ -344,6 +354,27 @@ export class PreferenceDatabase extends Dexie {
       preferences: "++id",
       signersSettings: "&id",
       shownDismissableItems: "&id,shown",
+    })
+
+    this.version(18).upgrade((tx) => {
+      return tx
+        .table("preferences")
+        .toCollection()
+        .modify((storedPreferences: Preferences) => {
+          const newURLs = getNewUrlsForTokenList(
+            storedPreferences,
+            // Old path
+            "bafybeigtlpxobme7utbketsaofgxqalgqzowhx24wlwwrtbzolgygmqorm",
+            // New path
+            "bafybeihufwj43zej34itf66qyguq35k4f6s4ual4uk3iy643wn3xnff2ka"
+          )
+
+          // eslint-disable-next-line no-param-reassign
+          storedPreferences.tokenLists = {
+            ...storedPreferences.tokenLists,
+            urls: newURLs,
+          }
+        })
     })
 
     // This is the old version for populate

--- a/background/services/preferences/defaults.ts
+++ b/background/services/preferences/defaults.ts
@@ -7,7 +7,7 @@ const defaultPreferences: Preferences = {
     autoUpdate: false,
     urls: [
       storageGatewayURL(
-        "ipfs://bafybeigtlpxobme7utbketsaofgxqalgqzowhx24wlwwrtbzolgygmqorm"
+        "ipfs://bafybeihufwj43zej34itf66qyguq35k4f6s4ual4uk3iy643wn3xnff2ka"
       ).href, // the Taho community-curated list
       "https://gateway.ipfs.io/ipns/tokens.uniswap.org", // the Uniswap default list
       "https://meta.yearn.finance/api/tokens/list", // the Yearn list


### PR DESCRIPTION
Closes https://github.com/tahowallet/extension/issues/3391
Closes https://github.com/tahowallet/extension/issues/3501

## What
The current list of tokens in the application is not updated. We should update it every time new tokens are added.

## UI

Before
<img width="250" alt="Screenshot 2023-06-29 at 11 39 16" src="https://github.com/tahowallet/extension/assets/23117945/0eff0cbf-076d-4303-922d-9c4a2c93e82d">

After
<img width="250" alt="Screenshot 2023-06-29 at 11 39 56" src="https://github.com/tahowallet/extension/assets/23117945/975881cb-f97a-4ffa-bbe6-5d998015e96a">

## Testing
Test address - `0x23Dd978A22f81e29941358Dbb0eAde9F53389Eb2`
- [x] Install the new app from the `main`. 
- [x] Do migration to the PR branch.
- [x] The OETH token should be verified by default because it belongs to the new token list.
- [x] Check if the URL has been updated in db.

Latest build: [extension-builds-3506](https://github.com/tahowallet/extension/suites/13972850715/artifacts/779111374) (as of Fri, 30 Jun 2023 08:19:57 GMT).