### PR TITLE
Fix throwing NFT filters panel

### DIFF
--- a/background/redux-slices/selectors/nftsSelectors.ts
+++ b/background/redux-slices/selectors/nftsSelectors.ts
@@ -3,7 +3,6 @@ import { RootState } from ".."
 import { normalizeEVMAddress } from "../../lib/utils"
 import { Filter } from "../nfts"
 import {
-  AccountData,
   getAdditionalDataForFilter,
   getFilteredCollections,
   getNFTsCount,
@@ -46,7 +45,7 @@ export const selectEnrichedNFTFilters = createSelector(
     const accounts = filters.accounts.reduce<Filter[]>((acc, filter) => {
       const additionalData = getAdditionalDataForFilter(
         filter.id,
-        accountTotals as AccountData[]
+        accountTotals
       )
       if (Object.keys(additionalData).length > 0) {
         return [

--- a/background/redux-slices/utils/nfts-utils.ts
+++ b/background/redux-slices/utils/nfts-utils.ts
@@ -38,7 +38,7 @@ export const getAdditionalDataForFilter = (
   accounts: AccountData[]
 ): { name?: string; thumbnailURL?: string } => {
   const a = accounts.find(({ address }) => address === id)
-  return a ? { name: a.name, thumbnailURL: a.avatarURL } : {}
+  return a ? { name: a.name ?? a.address, thumbnailURL: a.avatarURL } : {}
 }
 
 /* Items are sorted by price in USD. All other elements are added at the end. */

--- a/background/redux-slices/utils/nfts-utils.ts
+++ b/background/redux-slices/utils/nfts-utils.ts
@@ -7,15 +7,10 @@ import {
   NFTCollectionCached,
   SortType,
 } from "../nfts"
+import { AccountTotal } from "../selectors/accountsSelectors"
 import { enrichAssetAmountWithMainCurrencyValues } from "./asset-utils"
 
 const ETH_SYMBOLS = ["ETH", "WETH"]
-
-export type AccountData = {
-  address: string
-  name: string
-  avatarURL: string
-}
 
 type NFTCollectionEnriched = NFTCollectionCached & {
   floorPrice?: {
@@ -35,7 +30,7 @@ const isETHPrice = (collection: NFTCollectionCached): boolean => {
 
 export const getAdditionalDataForFilter = (
   id: string,
-  accounts: AccountData[]
+  accounts: AccountTotal[]
 ): { name?: string; thumbnailURL?: string } => {
   const a = accounts.find(({ address }) => address === id)
   return a ? { name: a.name ?? a.address, thumbnailURL: a.avatarURL } : {}


### PR DESCRIPTION
### What

Follow up for https://github.com/tahowallet/extension/pull/3486

Add fallback from name to address in NFT filters. To avoid NFT filters throwing error when the account is not yet loaded let's add a fallback from name to address to put in the SharedToggle label.

### Testing

- [x] install extension and throttle network so it is super slow 🐌 
- [x] add account and while it is loading quickly go to NFTs and try to click on the filters panel as soon as it is unblocked
- [x] filters panel should not throw

Latest build: [extension-builds-3513](https://github.com/tahowallet/extension/suites/14022443935/artifacts/782867040) (as of Mon, 03 Jul 2023 10:15:53 GMT).