### PR TITLE
Don't run e2e tests when workflow is triggered by push of tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,7 @@ jobs:
               - '.env.defaults'
   e2e-tests:
     needs: [build, detect-if-flag-changed]
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
In commit https://github.com/tahowallet/extension/commit/780d6d4eb817d05300a8458e534a10d1fa12e4ca we've turned off uploading of
build artifact to workflow details in case when the workflow is triggered by a
push of tag. Later in https://github.com/tahowallet/extension/commit/168d945c0e138c250ca4edac27f9071a59fb0d83 we've decided to
change conditions of e2e tests execution to run the tests more frequently. But
we've forgotten that we can't run the tests when workflow is triggered by a tag
push, as there is no build artifact available. Now we're updating the triggers
of e2e tests to take that under consideration.

Latest build: [extension-builds-3514](https://github.com/tahowallet/extension/suites/14023914491/artifacts/782964063) (as of Mon, 03 Jul 2023 11:15:24 GMT).