### PR TITLE
Use gas price from 0x quote to setup swap transaction

### DIFF
--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -347,16 +347,11 @@ export default function Swap(): ReactElement {
       )) as unknown as AsyncThunkFulfillmentType<typeof fetchSwapQuote>
 
       if (finalQuote) {
-        const { gasPrice, ...quoteWithoutGasPrice } = finalQuote
-
         await dispatch(
           executeSwap({
-            ...quoteWithoutGasPrice,
+            ...finalQuote,
             sellAsset,
             buyAsset,
-            gasPrice:
-              quote.swapTransactionSettings.networkSettings.values.maxFeePerGas.toString() ??
-              gasPrice,
           })
         )
       }


### PR DESCRIPTION
Resolves https://github.com/tahowallet/extension/issues/3515

### What
Let's not override gas price that 0x gave us for Optimism transactions, as our existing fee handling for Optimism has been broken by the EIP-1559 functionality added in the last network upgrade.

### Testing

This should be tested on all networks that are supporting swaps. This can potentially result in high gas fees so you can block broadcasting transaction to avoid loosing money for testing (for example throwing error [here](https://github.com/tahowallet/extension/blob/swaps-on-op/background/services/chain/index.ts#L1190) and logging transaction instead) You should check if gas prices are matching market values.

Latest build: [extension-builds-3516](https://github.com/tahowallet/extension/suites/14029858033/artifacts/783404247) (as of Mon, 03 Jul 2023 15:11:30 GMT).