### PR TITLE
Swaps on op hotfix

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -51,6 +51,7 @@ body:
       label: Version
       description: What version of the extension are you running?
       options:
+        - v0.40.0
         - v0.39.0
         - v0.38.1
         - v0.38.0

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Taho",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "The community owned and operated Web3 wallet.",
   "homepage_url": "https://taho.xyz",
   "author": "https://taho.xyz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tallyho/tally-extension",
   "private": true,
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "Taho, the community owned and operated Web3 wallet.",
   "main": "index.js",
   "repository": "git@github.com:thesis/tally-extension.git",

--- a/ui/pages/Swap.tsx
+++ b/ui/pages/Swap.tsx
@@ -347,16 +347,11 @@ export default function Swap(): ReactElement {
       )) as unknown as AsyncThunkFulfillmentType<typeof fetchSwapQuote>
 
       if (finalQuote) {
-        const { gasPrice, ...quoteWithoutGasPrice } = finalQuote
-
         await dispatch(
           executeSwap({
-            ...quoteWithoutGasPrice,
+            ...finalQuote,
             sellAsset,
             buyAsset,
-            gasPrice:
-              quote.swapTransactionSettings.networkSettings.values.maxFeePerGas.toString() ??
-              gasPrice,
           })
         )
       }


### PR DESCRIPTION
Hotfix for #3516 for 0.40.0 -> 0.40.1.

Since 0.39.0 hasn't yet been approved in the Chrome Store, we should plan to upload 0.40.1 after applying this hotfix and skip 0.40.0.

Latest build: [extension-builds-3517](https://github.com/tahowallet/extension/suites/14032144712/artifacts/783569548) (as of Mon, 03 Jul 2023 16:49:33 GMT).