### PR TITLE
Fix invalid workflow file

### DIFF
--- a/.github/workflows/sync-pledge.yml
+++ b/.github/workflows/sync-pledge.yml
@@ -4,14 +4,22 @@ on:
   schedule:
     - cron: "0 0 */3 * *"
   workflow_dispatch:
+  pull_request: {}
 
 jobs:
   cron:
+    runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Read .nvmrc
+        run: echo "NVMRC=$(cat ./.nvmrc)" >> $GITHUB_OUTPUT
+        id: nvm
       - name: Use Node + Yarn
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
           cache: "yarn"
       - run: yarn install --frozen-lockfile
         working-directory: .github/workflows/pledge-signer-sync
@@ -20,5 +28,5 @@ jobs:
         working-directory: .github/workflows/pledge-signer-sync
         env:
           GALXE_ACCESS_TOKEN: ${{ secrets.GALXE_ACCESS_TOKEN }}
-          FIRESTORE_USER: ${{ secrets.FIRESTORE_USER }}
+          FIRESTORE_USER: ${{ vars.FIRESTORE_USER }}
           FIRESTORE_PASSWORD: ${{ secrets.FIRESTORE_PASSWORD }}


### PR DESCRIPTION
New workflow to sync pledge was missing information about CI environment

Latest build: [extension-builds-3519](https://github.com/tahowallet/extension/suites/14038097612/artifacts/783985722) (as of Mon, 03 Jul 2023 23:10:26 GMT).