### PR TITLE
Remove workflow trigger used for testing

### DIFF
--- a/.github/workflows/sync-pledge.yml
+++ b/.github/workflows/sync-pledge.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 0 */3 * *"
   workflow_dispatch:
-  pull_request: {}
 
 jobs:
   cron:


### PR DESCRIPTION
Follow up on #3519, this removes a trigger used for testing and fixing issues with the new workflow

Latest build: [extension-builds-3520](https://github.com/tahowallet/extension/suites/14041155744/artifacts/784212517) (as of Tue, 04 Jul 2023 03:54:47 GMT).