### PR TITLE
Fix migration for cleaning account balances

### DIFF
--- a/background/redux-slices/migrations/to-31.ts
+++ b/background/redux-slices/migrations/to-31.ts
@@ -3,12 +3,14 @@ type PrevState = {
     accountsData: {
       evm: {
         [chainID: string]: {
-          [address: string]: {
-            balances: {
-              [symbol: string]: unknown
-            }
-            [other: string]: unknown
-          }
+          [address: string]:
+            | "loading"
+            | {
+                balances: {
+                  [symbol: string]: unknown
+                }
+                [other: string]: unknown
+              }
         }
       }
     }
@@ -21,12 +23,14 @@ type NewState = {
     accountsData: {
       evm: {
         [chainID: string]: {
-          [address: string]: {
-            balances: {
-              [assetID: string]: unknown
-            }
-            [other: string]: unknown
-          }
+          [address: string]:
+            | "loading"
+            | {
+                balances: {
+                  [assetID: string]: unknown
+                }
+                [other: string]: unknown
+              }
         }
       }
     }
@@ -43,8 +47,12 @@ export default (prevState: Record<string, unknown>): NewState => {
 
   Object.keys(accountsData.evm).forEach((chainID) =>
     Object.keys(accountsData.evm[chainID]).forEach((address) => {
-      // Clear all accounts cached balances
-      accountsData.evm[chainID][address].balances = {}
+      const account = accountsData.evm[chainID][address]
+
+      if (account !== "loading") {
+        // Clear all accounts cached balances
+        account.balances = {}
+      }
     })
   )
 


### PR DESCRIPTION
### What
Migration should be ready to handle accounts that are in a loading state without throwing and breaking the extension.

![image](https://github.com/tahowallet/extension/assets/20949277/eda012f2-9e24-4270-8e80-69a1b2e4f9d3)


Latest build: [extension-builds-3527](https://github.com/tahowallet/extension/suites/14071112936/artifacts/786522923) (as of Wed, 05 Jul 2023 09:15:07 GMT).