### PR TITLE
Refactor assets slice to fix performance problems

### DIFF
--- a/background/redux-slices/selectors/0xSwapSelectors.ts
+++ b/background/redux-slices/selectors/0xSwapSelectors.ts
@@ -23,28 +23,30 @@ export const selectSwapBuyAssets = createSelector(
   (state: RootState) => state.assets,
   selectCurrentNetwork,
   (assets, currentNetwork) => {
-    return assets.filter(
-      (
-        asset
-      ): asset is SwappableAsset & {
-        recentPrices: SingleAssetState["recentPrices"]
-      } => {
-        if (!canBeUsedForTransaction(asset)) {
-          return false
-        }
-        if (isSmartContractFungibleAsset(asset)) {
-          if (sameNetwork(asset.homeNetwork, currentNetwork)) {
+    return Object.values(assets)
+      .flat()
+      .filter(
+        (
+          asset
+        ): asset is SwappableAsset & {
+          recentPrices: SingleAssetState["recentPrices"]
+        } => {
+          if (!canBeUsedForTransaction(asset)) {
+            return false
+          }
+          if (isSmartContractFungibleAsset(asset)) {
+            if (sameNetwork(asset.homeNetwork, currentNetwork)) {
+              return true
+            }
+          }
+          if (
+            // Explicitly add a network's base asset.
+            isBuiltInNetworkBaseAsset(asset, currentNetwork)
+          ) {
             return true
           }
+          return false
         }
-        if (
-          // Explicitly add a network's base asset.
-          isBuiltInNetworkBaseAsset(asset, currentNetwork)
-        ) {
-          return true
-        }
-        return false
-      }
-    )
+      )
   }
 )

--- a/background/redux-slices/selectors/uiSelectors.ts
+++ b/background/redux-slices/selectors/uiSelectors.ts
@@ -55,6 +55,5 @@ export const selectMainCurrency = createSelector(
   (state: RootState) => state.ui,
   (state: RootState) => state.assets,
   (state: RootState) => selectMainCurrencySymbol(state),
-  (_, assets, mainCurrencySymbol) =>
-    assets.find((asset) => asset.symbol === mainCurrencySymbol)
+  (_, assets, mainCurrencySymbol) => assets[mainCurrencySymbol][0]
 )

--- a/background/redux-slices/tests/assets.unit.test.ts
+++ b/background/redux-slices/tests/assets.unit.test.ts
@@ -15,7 +15,10 @@ import reducer, {
   SingleAssetState,
 } from "../assets"
 
-const asset: SmartContractFungibleAsset = createSmartContractAsset()
+const assetSymbol = "TEST"
+const asset: SmartContractFungibleAsset = createSmartContractAsset({
+  symbol: assetSymbol,
+})
 
 const pricePoint: PricePoint = createPricePoint(asset)
 
@@ -26,21 +29,23 @@ const assetWithPricePoint = {
   },
 }
 
-const assetState: AssetsState = [assetWithPricePoint]
+const assetState: AssetsState = {
+  [assetSymbol]: [assetWithPricePoint],
+}
 
 describe("Reducers", () => {
   describe("assetsLoaded", () => {
     test("updates cached asset metadata", () => {
-      const state = reducer([], assetsLoaded([asset]))
+      const state = reducer({}, assetsLoaded([asset]))
 
-      expect(state[0].metadata?.verified).not.toBeDefined()
+      expect(state[asset.symbol][0].metadata?.verified).not.toBeDefined()
 
       const newState = reducer(
         state,
         assetsLoaded([{ ...asset, metadata: { verified: true } }])
       )
 
-      expect(newState[0].metadata?.verified).toBeTruthy()
+      expect(newState[asset.symbol][0].metadata?.verified).toBeTruthy()
     })
   })
 })
@@ -69,7 +74,9 @@ describe("Assets selectors", () => {
         },
       }
 
-      const state = [assetWithPricePoint, similarAssetWithPricePoint]
+      const state = {
+        [assetSymbol]: [assetWithPricePoint, similarAssetWithPricePoint],
+      }
       const result = selectAssetPricePoint(state, similarAsset, "USD")
 
       expect(result).toMatchObject(similarAssetPricePoint)
@@ -84,7 +91,9 @@ describe("Assets selectors", () => {
         recentPrices: {},
       }
 
-      const state = [assetWithPricePoint, assetWithoutPricePoint]
+      const state = {
+        [assetSymbol]: [assetWithPricePoint, assetWithoutPricePoint],
+      }
       const result = selectAssetPricePoint(state, assetWithoutPricePoint, "USD")
 
       expect(result).toMatchObject(pricePoint)
@@ -99,7 +108,9 @@ describe("Assets selectors", () => {
         recentPrices: {},
       }
 
-      const state = [assetWithPricePoint, assetWithoutPricePoint]
+      const state = {
+        [assetSymbol]: [assetWithPricePoint, assetWithoutPricePoint],
+      }
       const result = selectAssetPricePoint(state, assetWithoutPricePoint, "USD")
 
       expect(assetWithPricePoint.decimals).toBe(18)

--- a/background/redux-slices/utils/0x-swap-utils.ts
+++ b/background/redux-slices/utils/0x-swap-utils.ts
@@ -46,12 +46,9 @@ export async function getAssetPricePoint(
   assets: AssetsState,
   network: EVMNetwork
 ): Promise<PricePoint | undefined> {
-  const assetPricesNetworks = assets
+  const assetPricesNetworks = assets[asset.symbol]
     .filter(
-      (assetItem) =>
-        "contractAddress" in assetItem &&
-        assetItem.contractAddress &&
-        assetItem.symbol === asset.symbol
+      (assetItem) => "contractAddress" in assetItem && assetItem.contractAddress
     )
     .map((assetItem) => {
       const { contractAddress } = assetItem as SingleAssetState & {

--- a/background/redux-slices/utils/tests/nfts-utils.unit.test.ts
+++ b/background/redux-slices/utils/tests/nfts-utils.unit.test.ts
@@ -17,26 +17,32 @@ const COLLECTION_MOCK = {
   hasNextPage: false,
 }
 
-const assetsState: AssetsState = [
-  {
-    ...ETH,
-    recentPrices: {
-      USD: createPricePoint(ETH, 2000),
+const assetsState: AssetsState = {
+  ETH: [
+    {
+      ...ETH,
+      recentPrices: {
+        USD: createPricePoint(ETH, 2000),
+      },
     },
-  },
-  {
-    ...AVAX,
-    recentPrices: {
-      USD: createPricePoint(AVAX, 15),
+  ],
+  AVAX: [
+    {
+      ...AVAX,
+      recentPrices: {
+        USD: createPricePoint(AVAX, 15),
+      },
     },
-  },
-  {
-    ...BNB,
-    recentPrices: {
-      USD: createPricePoint(BNB, 50),
+  ],
+  BNB: [
+    {
+      ...BNB,
+      recentPrices: {
+        USD: createPricePoint(BNB, 50),
+      },
     },
-  },
-]
+  ],
+}
 
 describe("NFTs utils", () => {
   describe("getTotalFloorPrice", () => {

--- a/background/tests/earn/assets.mock.ts
+++ b/background/tests/earn/assets.mock.ts
@@ -1,61 +1,65 @@
 import { ETHEREUM } from "../../constants"
 import { AssetsState } from "../../redux-slices/assets"
 
-const assets: AssetsState = [
-  {
-    name: "Wrapped Ether",
-    symbol: "WETH",
-    decimals: 18,
-    homeNetwork: ETHEREUM,
-    contractAddress: "0x0",
-    recentPrices: {
-      USD: {
-        pair: [
-          {
-            contractAddress: "0x0",
-            decimals: 18,
-            homeNetwork: ETHEREUM,
-            name: "Wrapped Ether",
-            symbol: "WETH",
-          },
-          {
-            name: "United States Dollar",
-            symbol: "USD",
-            decimals: 10,
-          },
-        ],
-        amounts: [1000000000000000000n, 31288400000000n],
-        time: 1650540050,
+const assets: AssetsState = {
+  WETH: [
+    {
+      name: "Wrapped Ether",
+      symbol: "WETH",
+      decimals: 18,
+      homeNetwork: ETHEREUM,
+      contractAddress: "0x0",
+      recentPrices: {
+        USD: {
+          pair: [
+            {
+              contractAddress: "0x0",
+              decimals: 18,
+              homeNetwork: ETHEREUM,
+              name: "Wrapped Ether",
+              symbol: "WETH",
+            },
+            {
+              name: "United States Dollar",
+              symbol: "USD",
+              decimals: 10,
+            },
+          ],
+          amounts: [1000000000000000000n, 31288400000000n],
+          time: 1650540050,
+        },
       },
     },
-  },
-  {
-    name: "Uniswap",
-    symbol: "UNI",
-    decimals: 18,
-    homeNetwork: ETHEREUM,
-    contractAddress: "0x0",
-    recentPrices: {
-      USD: {
-        pair: [
-          {
-            name: "Uniswap",
-            symbol: "UNI",
-            decimals: 18,
-            homeNetwork: ETHEREUM,
-            contractAddress: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
-          },
-          {
-            name: "United States Dollar",
-            symbol: "USD",
-            decimals: 10,
-          },
-        ],
-        amounts: [1000000000000000000n, 90000000000n],
-        time: 1650618496,
+  ],
+  UNI: [
+    {
+      name: "Uniswap",
+      symbol: "UNI",
+      decimals: 18,
+      homeNetwork: ETHEREUM,
+      contractAddress: "0x0",
+      recentPrices: {
+        USD: {
+          pair: [
+            {
+              name: "Uniswap",
+              symbol: "UNI",
+              decimals: 18,
+              homeNetwork: ETHEREUM,
+              contractAddress: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+            },
+            {
+              name: "United States Dollar",
+              symbol: "USD",
+              decimals: 10,
+            },
+          ],
+          amounts: [1000000000000000000n, 90000000000n],
+          time: 1650618496,
+        },
       },
     },
-  },
-]
+  ],
+}
 
 export default assets

--- a/background/tests/earn/earn.test.ts
+++ b/background/tests/earn/earn.test.ts
@@ -52,7 +52,7 @@ describe("Earn", () => {
           reserve1: BigNumber.from(100000n),
         }),
       }))
-      const doggoPrice = await getDoggoPrice([], mainCurrencySymbol)
+      const doggoPrice = await getDoggoPrice({}, mainCurrencySymbol)
 
       expect(doggoPrice).toBe(0n)
     })


### PR DESCRIPTION
Resolves https://github.com/tahowallet/extension/issues/3466
### What
As Redux was having serious performance problems when we were using an array to store all assets let's refactor that slice so it is now storing assets as an object that is indexed by assets' symbols. Seems like this is working great with redux and we are able to reduce CPU usage as we were updating assets very often.