### PR TITLE
Don't treat assets in the token list as unverified

### DIFF
--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -701,19 +701,8 @@ export default class IndexingService extends BaseService<Events> {
     )
 
     if (knownAsset) {
-      const newDiscoveryTxHash = metadata?.discoveryTxHash
-      const addressForDiscoveryTxHash = newDiscoveryTxHash
-        ? Object.keys(newDiscoveryTxHash)[0]
-        : undefined
-      const existingDiscoveryTxHash = addressForDiscoveryTxHash
-        ? knownAsset.metadata?.discoveryTxHash?.[addressForDiscoveryTxHash]
-        : undefined
-      // If the discovery tx hash is not specified
-      // or if it already exists in the asset, do not update the asset
-      if (!newDiscoveryTxHash || existingDiscoveryTxHash) {
-        await this.addAssetToTrack(knownAsset)
-        return knownAsset
-      }
+      await this.addAssetToTrack(knownAsset)
+      return knownAsset
     }
 
     let customAsset = await this.db.getCustomAssetByAddressAndNetwork(


### PR DESCRIPTION
## What

During the new application installation, some of the assets in the token list were treated as unverified assets. 

Removal of the `discoveryTxHash` refresh logic. It is no longer needed. The change was to update the `discoveryTxHash` after the data migration, where `discoveryTxHash` was removed for all custom assets. This also resulted in the wrong adding of a `discoveryTxHash` for the asset in the token list. The change solves this issue.

## UI

**Before**


https://github.com/tahowallet/extension/assets/23117945/c8867a3f-0886-4b9a-a606-30eeba3bbd6b

**After**

https://github.com/tahowallet/extension/assets/23117945/3af9111f-22c9-4f61-a9a8-f6d0bbf2632e


## Testing
- [x] Install the app from `mian` branch. Assets in the token list should tread as unverified for a while time. Check the `assetsToTrack` and `customAssets` tables in the db. Find there, the asset which is in the token list. 

Change the branch. Check the `assetsToTrack` and `customAssets` tables in the db. 
 - [x] Assets in the token list should be removed. - `customAssets` table
 - [x] Assets in the token list should have updated metadata, no `discoveryTxHash`. - `assetsToTrack` table

Install a completely new app from the current branch. Check the `assetsToTrack` and `customAssets` tables in the db. 
 - [x] Assets in the token list shouldn't be in the `customAssets` table.
 - [x] Assets in the token list shouldn't have `discoveryTxHash` in  `assetsToTrack` table.


Latest build: [extension-builds-3534](https://github.com/tahowallet/extension/suites/14136247295/artifacts/791600079) (as of Fri, 07 Jul 2023 14:28:48 GMT).