### PR TITLE
Enrichment Improvements

### DIFF
--- a/background/services/enrichment/addresses.ts
+++ b/background/services/enrichment/addresses.ts
@@ -1,25 +1,346 @@
+import { ethers } from "ethers"
+import { debounce } from "lodash"
+import assert from "assert"
 import { AddressOnNetwork } from "../../accounts"
+import {
+  AggregateContractResponse,
+  MULTICALL_ABI,
+  MULTICALL_CONTRACT_ADDRESS,
+} from "../../lib/multicall"
 
 import ChainService from "../chain"
 import NameService from "../name"
 
 import { AddressOnNetworkAnnotation, EnrichedAddressOnNetwork } from "./types"
+import { normalizeEVMAddress } from "../../lib/utils"
+import { ETHEREUM, SECOND } from "../../constants"
+import logger from "../../lib/logger"
+import { sameNetwork } from "../../networks"
+import { NormalizedEVMAddress } from "../../types"
 
+type ResolveFn<T> = (value: T | PromiseLike<T>) => void
+type RejectFn = (reason?: unknown) => void
+
+function getUnresolvedPromise<T>(): [Promise<T>, ResolveFn<T>, RejectFn] {
+  let resolver: undefined | ResolveFn<T>
+  let rejecter: undefined | RejectFn
+
+  const promise = new Promise<T>((resolve, reject) => {
+    resolver = resolve
+    rejecter = reject
+  })
+
+  assert(resolver)
+  assert(rejecter)
+  return [promise, resolver, rejecter]
+}
+
+const abi = [
+  {
+    inputs: [],
+    name: "blockHeight",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "node",
+        type: "bytes32",
+      },
+    ],
+    name: "ensResolve",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "node",
+        type: "bytes32",
+      },
+    ],
+    name: "ensReverseLookup",
+    outputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "target",
+        type: "address",
+      },
+    ],
+    name: "getBalance",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "addr",
+        type: "address",
+      },
+    ],
+    name: "isContract",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "name",
+        type: "uint256",
+      },
+    ],
+    name: "unsResolve",
+    outputs: [
+      {
+        internalType: "string[]",
+        name: "",
+        type: "string[]",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "addr",
+        type: "address",
+      },
+    ],
+    name: "unsReverseLookup",
+    outputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+]
 // TODO look up whether contracts are verified on EtherScan
 // TODO ABIs
 
-export async function resolveAddressAnnotation(
+let batchId = 1
+let lock = Promise.resolve()
+let [batchResultLock, submitBatchResult, rejectBatchResult] =
+  getUnresolvedPromise<
+    Record<NormalizedEVMAddress, AddressOnNetworkAnnotation>
+  >()
+
+let batch: AddressOnNetwork[] = []
+
+export async function batchResolveAddressAnnotation(
+  chainService: ChainService
+): Promise<void> {
+  logger.info("batch:", batchId, batch)
+
+  const runner = async () => {
+    const provider = chainService.providerForNetworkOrThrow(ETHEREUM)
+
+    const contract = new ethers.Contract(
+      "0x36025f7396Fd7AB297cC83a9334a9Fb54532cC5d",
+      abi,
+      provider
+    )
+
+    const multicall = new ethers.Contract(
+      MULTICALL_CONTRACT_ADDRESS,
+      MULTICALL_ABI,
+      provider
+    )
+
+    const addressesToFetchMap: Record<NormalizedEVMAddress, AddressOnNetwork> =
+      Object.fromEntries(
+        batch.map((account) => [normalizeEVMAddress(account.address), account])
+      )
+
+    const addressesToFetch = Object.keys(
+      addressesToFetchMap
+    ) as NormalizedEVMAddress[]
+
+    logger.info(
+      "Looking up addresses for enrichment",
+      batchId,
+      addressesToFetch,
+      addressesToFetch.length
+    )
+
+    const callData = addressesToFetch.flatMap((addr) =>
+      [
+        contract.interface.encodeFunctionData("getBalance", [addr]),
+        contract.interface.encodeFunctionData("isContract", [addr]),
+        contract.interface.encodeFunctionData("ensReverseLookup", [
+          ethers.utils.namehash(
+            `${addr.substring(2).toLowerCase()}.addr.reverse`
+          ),
+        ]),
+        contract.interface.encodeFunctionData("unsReverseLookup", [addr]),
+      ].map((call) => [contract.address, call])
+    )
+
+    const response = (await multicall.callStatic.tryBlockAndAggregate(
+      false,
+      callData
+    )) as AggregateContractResponse
+
+    const blockNum = response.blockNumber
+
+    const enrichedAddressesMap: Record<
+      NormalizedEVMAddress,
+      AddressOnNetworkAnnotation
+    > = {}
+
+    const allResults = response.returnData
+
+    addressesToFetch.forEach((key, i) => {
+      const addressOnNetwork = addressesToFetchMap[key]
+      const { address, network } = addressesToFetchMap[key]
+      const addressResults = allResults.slice(4 * i, 4 * i + 4)
+
+      const [balance, isContract, ens] = [
+        ["getBalance", addressResults[0].returnData],
+        ["isContract", addressResults[1].returnData],
+        ["ensReverseLookup", addressResults[2].returnData],
+        ["unsReverseLookup", addressResults[3].returnData],
+      ].map(
+        ([fnName, data]) =>
+          contract.interface.decodeFunctionResult(fnName, data)[0]
+      )
+
+      enrichedAddressesMap[key] = {
+        balance: {
+          address,
+          assetAmount: { asset: network.baseAsset, amount: balance.toBigInt() },
+          retrievedAt: Date.now(),
+          dataSource: "local",
+          network,
+          blockHeight: blockNum.toBigInt(),
+        },
+        hasCode: isContract,
+        nameRecord: {
+          resolved: {
+            nameOnNetwork: { name: ens, network },
+            expiresAt: Date.now() + 10 * SECOND,
+          },
+          system: "ENS",
+          from: { addressOnNetwork },
+        },
+        timestamp: Date.now(),
+      }
+    })
+
+    logger.info("Batch processed:", batchId, "results:", enrichedAddressesMap)
+
+    submitBatchResult(enrichedAddressesMap)
+
+    batch = []
+    batchId += 1
+  }
+
+  lock = runner()
+    .catch((err) => {
+      rejectBatchResult(err)
+    })
+    .finally(() => {
+      batchResultLock = new Promise((resolve, reject) => {
+        submitBatchResult = resolve
+        rejectBatchResult = reject
+      })
+    })
+}
+
+const debouncedResolver = debounce(batchResolveAddressAnnotation, 500, {
+  trailing: true,
+  maxWait: 500,
+})
+
+const resolveAddress = async (
+  chain: ChainService,
+  _name: NameService,
+  address: AddressOnNetwork
+) => {
+  // if we're already processing wait until finished
+  await lock
+  batch.push(address)
+
+  debouncedResolver(chain)
+  // Wait until the resolver actually runs
+  const results = await batchResultLock
+
+  const match = results[normalizeEVMAddress(address.address)]
+
+  if (!match) {
+    throw logger.buildError(
+      "Could not enrich address: ",
+      address,
+      "successfully"
+    )
+  }
+
+  return match
+}
+
+async function genericResolver(
   chainService: ChainService,
   nameService: NameService,
   addressOnNetwork: AddressOnNetwork
-): Promise<AddressOnNetworkAnnotation> {
+) {
   const { address, network } = addressOnNetwork
   const provider = chainService.providerForNetworkOrThrow(network)
+
   const [codeHex, balance, nameRecord] = await Promise.all([
     provider.getCode(address),
     chainService.getLatestBaseAccountBalance(addressOnNetwork),
     nameService.lookUpName(addressOnNetwork),
   ])
+
   return {
     balance,
     nameRecord,
@@ -33,12 +354,12 @@ export async function enrichAddressOnNetwork(
   nameService: NameService,
   addressOnNetwork: AddressOnNetwork
 ): Promise<EnrichedAddressOnNetwork> {
+  const resolve = sameNetwork(addressOnNetwork.network, ETHEREUM)
+    ? resolveAddress
+    : genericResolver
+
   return {
     ...addressOnNetwork,
-    annotation: await resolveAddressAnnotation(
-      chainService,
-      nameService,
-      addressOnNetwork
-    ),
+    annotation: await resolve(chainService, nameService, addressOnNetwork),
   }
 }

--- a/background/services/enrichment/tests/transactions.integration.test.ts
+++ b/background/services/enrichment/tests/transactions.integration.test.ts
@@ -4,11 +4,10 @@ import { ETHEREUM } from "../../../constants"
 import {
   createChainService,
   createIndexingService,
-  createNameService,
   createAnyEVMBlock,
 } from "../../../tests/factories"
 import { makeSerialFallbackProvider } from "../../chain/serial-fallback-provider"
-import { annotationsFromLogs } from "../transactions"
+import { parseTransactionLogs } from "../transactions"
 
 // These logs reference transaction https://etherscan.io/tx/0x0ba306853f8be38d54327675f14694d582a14759b851f2126dd900bef0aff840
 // prettier-ignore
@@ -27,14 +26,10 @@ describe("Enrichment Service Transactions", () => {
       const indexingServicePromise = createIndexingService({
         chainService: chainServicePromise,
       })
-      const nameServicePromise = createNameService({
-        chainService: chainServicePromise,
-      })
 
-      const [chainService, indexingService, nameService] = await Promise.all([
+      const [chainService, indexingService] = await Promise.all([
         chainServicePromise,
         indexingServicePromise,
-        nameServicePromise,
       ])
 
       await chainService.startService()
@@ -64,10 +59,9 @@ describe("Enrichment Service Transactions", () => {
         .stub(chainService, "providerForNetworkOrThrow")
         .returns(makeSerialFallbackProvider("1", []))
 
-      const subannotations = await annotationsFromLogs(
+      const subannotations = await parseTransactionLogs(
         chainService,
         indexingService,
-        nameService,
         TEST_ERC20_LOGS,
         ETHEREUM,
         2,


### PR DESCRIPTION
At the moment, during enrichment, we have to dispatch 2 RPC calls for name resolution with ENS alone. The first to get the resolver and another to perform the actual lookup. Additionally, we also need to run a query for balances and retrieve the address's code to determine if we're dealing with a contract address. 

For a simple ETH transfer this is fine, but for something involving a contract, like an erc20 transfer or a swap, this can involve a lot of addresses which in turn result in a significant amount of requests being made. This is further worsened by the fact that during initial activity load we're also querying block, transaction, and receipts data.

This PR implements batch processing for address enrichment and, on-chain data resolution for enrichment requests, reducing RPC calls by as much as 87.5% during account onboarding, account switching and extension startup. This could be improved further by caching certain results by block height, since we're not performing special enrichment lookups for transactions already mined.

The deployed contract's source is here: https://gist.github.com/hyphenized/decfe5f079fc9c07d1f87939311bc16f

## To Test
- [ ] Switch to `main`, open the network inspector on the background page, then load an account wait a couple of mins.
- [ ] Switch to this branch, reinstall the extension and go through the same process
- [ ] Test extension reload (before and after activity load), onboarding and switching accounts, check performance and requests being made.

Latest build: [extension-builds-3538](https://github.com/tahowallet/extension/suites/14169596968/artifacts/794181603) (as of Mon, 10 Jul 2023 02:34:37 GMT).