### PR TITLE
Remove waiting for Loading Doggo component in E2E tests

### DIFF
--- a/e2e-tests/nfts.spec.ts
+++ b/e2e-tests/nfts.spec.ts
@@ -50,10 +50,9 @@ test.describe("NFTs", () => {
 
       await walletPageHelper.navigateTo("NFTs")
 
-      await expect(page.getByTestId("loading_doggo")).toBeVisible()
-
       // Wait until load finishes
       await expect(page.getByTestId("loading_doggo")).not.toBeVisible()
+
       shouldInterceptRequests = false
     })
 


### PR DESCRIPTION
### What

If the NFT page is loading really fast then the "loading doggo" animation may not be visible for long enough to allow the e2e test to catch that element. As the loader itself is not necessary for the rest of the test let's omit testing for loader visibility, we can just test if the loader disappeared.

Latest build: [extension-builds-3541](https://github.com/tahowallet/extension/suites/14183949363/artifacts/795270419) (as of Mon, 10 Jul 2023 14:09:54 GMT).