### PR TITLE
Sticky Defaults: Make Taho-as-default replace MetaMask in almost all cases

### DIFF
--- a/background/redux-slices/utils/contract-utils.ts
+++ b/background/redux-slices/utils/contract-utils.ts
@@ -1,4 +1,4 @@
-import TallyWindowProvider from "@tallyho/window-provider"
+import TahoWindowProvider from "@tallyho/window-provider"
 import { Contract, ethers, ContractInterface } from "ethers"
 import Emittery from "emittery"
 import TallyWeb3Provider from "../../tally-provider"
@@ -31,7 +31,7 @@ export const internalProviderPort = {
 }
 /* eslint-enable @typescript-eslint/no-explicit-any,@typescript-eslint/explicit-module-boundary-types */
 
-export const internalProvider = new TallyWindowProvider(internalProviderPort)
+export const internalProvider = new TahoWindowProvider(internalProviderPort)
 
 export function getProvider(this: unknown): TallyWeb3Provider {
   return new TallyWeb3Provider(internalProvider)

--- a/env.d.ts
+++ b/env.d.ts
@@ -17,13 +17,13 @@ declare module "webext-redux/lib/strategies/deepDiff/patch" {
 
 declare module "styled-jsx/style"
 
-type WalletProvider = {
+type BaseWalletProvider = {
   providerInfo?: {
     label: string
     injectedNamespace: string
     iconURL: string
     identityFlag?: string
-    checkIdentity?: () => boolean
+    checkIdentity?: (provider: WalletProvider) => boolean
   }
   on: (
     eventName: string | symbol,
@@ -33,12 +33,16 @@ type WalletProvider = {
     eventName: string | symbol,
     listener: (...args: unknown[]) => void
   ) => unknown
+}
+
+type WalletProvider = BaseWalletProvider & {
   [optionalProps: string]: unknown
 }
 
-type TallyProvider = WalletProvider & {
+type TahoProvider = BaseWalletProvider & {
   isTally: true
-  send: (method: string, params: unknown[]) => Promise<void>
+  tahoSetAsDefault: boolean
+  send: (method: string, params: unknown[]) => void | Promise<unknown>
 }
 
 type WindowEthereum = WalletProvider & {
@@ -61,7 +65,7 @@ interface Window {
     ) => WalletProvider["providerInfo"]
     addProvider: (newProvider: WalletProvider) => void
   }
-  tally?: TallyProvider
+  tally?: TahoProvider
   ethereum?: WindowEthereum
   oldEthereum?: WindowEthereum
 }

--- a/provider-bridge/index.ts
+++ b/provider-bridge/index.ts
@@ -69,7 +69,7 @@ export function connectProviderBridge(): void {
   })
 }
 
-export function injectTallyWindowProvider(): void {
+export function injectTahoWindowProvider(): void {
   if (document.contentType !== "text/html") return
 
   try {

--- a/provider-bridge/index.ts
+++ b/provider-bridge/index.ts
@@ -30,7 +30,15 @@ export function connectProviderBridge(): void {
         const faviconUrl = largestFavicon?.href ?? ""
         const { title } = window.document ?? ""
 
-        event.data.request.params.push(title, faviconUrl)
+        if (event.data.request.method === "eth_requestAccounts") {
+          // For eth_requestAccounts specifically, we force the parameters as
+          // the dApp should be sending none, but some send parameters that look
+          // more like what you'd expect on wallet_requestPermissions.
+          // eslint-disable-next-line no-param-reassign
+          event.data.request.params = [title, faviconUrl]
+        } else {
+          event.data.request.params.push(title, faviconUrl)
+        }
       }
 
       // TODO: replace with better logging before v1. Now it's invaluable in debugging.

--- a/src/provider-bridge.ts
+++ b/src/provider-bridge.ts
@@ -1,7 +1,7 @@
 import {
-  injectTallyWindowProvider,
+  injectTahoWindowProvider,
   connectProviderBridge,
 } from "@tallyho/provider-bridge"
 
-injectTallyWindowProvider()
+injectTahoWindowProvider()
 connectProviderBridge()

--- a/src/window-provider.ts
+++ b/src/window-provider.ts
@@ -113,6 +113,17 @@ if (!window.walletRouter) {
           this.currentProvider = this.lastInjectedProvider ?? this.tallyProvider
         }
 
+        // Make the new "current provider" first in the provider list. This
+        // makes it so that frameworks like wagmi that rely on the first item
+        // in the list being the default browser wallet correctly see either
+        // Taho (when default) or not-Taho (when not default).
+        this.providers = [
+          this.currentProvider,
+          ...this.providers.filter(
+            (provider: WalletProvider) => provider !== this.currentProvider
+          ),
+        ]
+
         if (
           shouldReload &&
           (window.location.href.includes("app.uniswap.org") ||
@@ -209,7 +220,7 @@ Object.defineProperty(window, "ethereum", {
           !(prop in window.walletRouter.currentProvider) &&
           prop in window.walletRouter
         ) {
-          // let's publish the api of `window.walletRoute` also on `window.ethereum` for better discoverability
+          // let's publish the api of `window.walletRouter` also on `window.ethereum` for better discoverability
 
           // @ts-expect-error ts accepts symbols as index only from 4.4
           // https://stackoverflow.com/questions/59118271/using-symbol-as-object-key-type-in-typescript

--- a/src/window-provider.ts
+++ b/src/window-provider.ts
@@ -3,21 +3,22 @@ import {
   WindowListener,
   WindowRequestEvent,
 } from "@tallyho/provider-bridge-shared"
-import TallyWindowProvider from "@tallyho/window-provider"
+import TahoWindowProvider from "@tallyho/window-provider"
 
+const tahoWindowProvider: TahoProvider = new TahoWindowProvider({
+  postMessage: (data: WindowRequestEvent) =>
+    window.postMessage(data, window.location.origin),
+  addEventListener: (fn: WindowListener) =>
+    window.addEventListener("message", fn, false),
+  removeEventListener: (fn: WindowListener) =>
+    window.removeEventListener("message", fn, false),
+  origin: window.location.origin,
+})
 // The window object is considered unsafe, because other extensions could have modified them before this script is run.
 // For 100% certainty we could create an iframe here, store the references and then destoroy the iframe.
 //   something like this: https://speakerdeck.com/fransrosen/owasp-appseceu-2018-attacking-modern-web-technologies?slide=95
 Object.defineProperty(window, "tally", {
-  value: new TallyWindowProvider({
-    postMessage: (data: WindowRequestEvent) =>
-      window.postMessage(data, window.location.origin),
-    addEventListener: (fn: WindowListener) =>
-      window.addEventListener("message", fn, false),
-    removeEventListener: (fn: WindowListener) =>
-      window.removeEventListener("message", fn, false),
-    origin: window.location.origin,
-  }),
+  value: tahoWindowProvider,
   writable: false,
   configurable: false,
 })

--- a/src/window-provider.ts
+++ b/src/window-provider.ts
@@ -64,7 +64,7 @@ function wrapMetaMaskProvider(provider: WalletProvider): WalletProvider {
     Object.keys(provider).filter((key) => key.startsWith("is")).length === 1
   ) {
     const wrapper = new Proxy(provider, {
-      get(target, prop, receiver) {
+      get(target, prop) {
         if (
           window.walletRouter &&
           window.walletRouter.currentProvider === tahoWindowProvider &&
@@ -81,11 +81,11 @@ function wrapMetaMaskProvider(provider: WalletProvider): WalletProvider {
             // attempt at connecting.
             tahoWindowProvider,
             prop,
-            target
+            tahoWindowProvider
           )
         }
 
-        return Reflect.get(target, prop, receiver)
+        return Reflect.get(target, prop, target)
       },
     })
 
@@ -281,7 +281,7 @@ Object.defineProperty(window, "ethereum", {
     }
 
     cachedWindowEthereumProxy = new Proxy(window.walletRouter.currentProvider, {
-      get(target, prop, receiver) {
+      get(target, prop) {
         if (
           window.walletRouter &&
           window.walletRouter.currentProvider === tahoWindowProvider &&
@@ -317,7 +317,7 @@ Object.defineProperty(window, "ethereum", {
           // attempt at connecting.
           window.walletRouter?.currentProvider ?? target,
           prop,
-          receiver
+          target
         )
       },
     })

--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -72,7 +72,7 @@ const METAMASK_STATE_MOCK = {
   isPermanentlyDisconnected: false,
 }
 
-export default class TallyWindowProvider extends EventEmitter {
+export default class TahoWindowProvider extends EventEmitter {
   // TODO: This should come from the background with onConnect when any interaction is initiated by the dApp.
   // onboard.js relies on this, or uses a deprecated api. It seemed to be a reasonable workaround for now.
   chainId = "0x1"
@@ -81,11 +81,11 @@ export default class TallyWindowProvider extends EventEmitter {
 
   connected = false
 
-  isTally = true
+  isTally: true = true
 
   isMetaMask = false
 
-  tallySetAsDefault = false
+  tahoSetAsDefault = false
 
   isWeb3 = true
 
@@ -141,7 +141,7 @@ export default class TallyWindowProvider extends EventEmitter {
       }
 
       if (isTallyConfigPayload(result)) {
-        const wasTallySetAsDefault = this.tallySetAsDefault
+        const wasTallySetAsDefault = this.tahoSetAsDefault
 
         window.walletRouter?.shouldSetTallyForCurrentProvider(
           result.defaultWallet,
@@ -167,7 +167,7 @@ export default class TallyWindowProvider extends EventEmitter {
             this._state = METAMASK_STATE_MOCK
           }
 
-          this.tallySetAsDefault = result.defaultWallet
+          this.tahoSetAsDefault = result.defaultWallet
         }
 
         // When the default state flips, reroute any unresolved requests to the
@@ -175,7 +175,7 @@ export default class TallyWindowProvider extends EventEmitter {
         if (
           process.env.ENABLE_UPDATED_DAPP_CONNECTIONS === "true" &&
           wasTallySetAsDefault &&
-          !this.tallySetAsDefault
+          !this.tahoSetAsDefault
         ) {
           const existingRequests = [...this.requestResolvers.entries()]
           this.requestResolvers.clear()

--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -104,6 +104,8 @@ export default class TahoWindowProvider extends EventEmitter {
 
   _state?: typeof METAMASK_STATE_MOCK
 
+  _metamask?: this
+
   providerInfo = {
     label: "Taho",
     injectedNamespace: "tally",
@@ -155,18 +157,6 @@ export default class TahoWindowProvider extends EventEmitter {
             currentHost.includes(host)
           )
         ) {
-          this.isMetaMask = result.defaultWallet
-
-          if (
-            this.isMetaMask &&
-            // This is internal to MetaMask but accessed by this dApp
-            // TODO: Improve MetaMask provider impersonation
-            currentHost.includes("core.app")
-          ) {
-            // eslint-disable-next-line no-underscore-dangle
-            this._state = METAMASK_STATE_MOCK
-          }
-
           this.tahoSetAsDefault = result.defaultWallet
         }
 


### PR DESCRIPTION
## Background

Up until now, Taho's approach to being marked as default was meant to
be roughly:

- If Taho is marked as default, and the dApp supports showing a non-MetaMask
  provider at `window.ethereum`, make Taho that provider.
- If Taho is marked as default, and the dApp *doesn't* support showing a non
  MetaMask provider, have Taho impersonate MetaMask so that users can still
  connect using Taho.
- If Taho is marked as not-default, leave everything untouched, and only
  show Taho for dApps that specifically look for it (typically at `window.tally`,
  but sometimes in `window.ethereum.providers`).

For this to work, the window provider was tracking an allowlist of sites to
impersonate MetaMask on, and it was *also* tracking an allowlist of sites to
do additional tricks on (e.g. returning a blank `providers` array for sites
that detect MetaMask and don't look for any other wallet). There were other
tricks also being done to try to discern between scenarios, etc.

Other wallets just throw their hands up and attempt to impersonate MetaMask
most/all the time, leading to escalating wars with dApp frameworks to detect
these behaviors.

## Revised Approach

This PR throws all of that away. It was confusing for users (do you click on
MetaMask? Browser/Injected? What happens if Taho isn't default? What about
the times when MetaMask impersonation isn't hardcoded for a site?), and it
was difficult to maintain (allowlists of specific sites are not realistically
a scalable long-term approach).

Instead, having Taho set as default (a reminder that as of #3492, this is
represented in the UI as a toggle between “connect with MetaMask” and “connect
with Taho”) should mean two things:

- Trying to connect to MetaMask will *always* use Taho.
- For dApps that also specifically detect Taho, they may *also* allow connecting
  with Taho. If Taho is set as default, attempting to connect with MetaMask will
  still connect with Taho.

On the flip side, if Taho is not set as default, it should mean two things:

- Trying to connect to MetaMask will *always* use whatever was presenting
  as MetaMask before Taho got involved.
- For dApps that also specifically detect Taho, they will allow connecting
  with Taho still.

### Technical Details

How we do this is straightforward: any provider on the `providers` array
that presents as MetaMask (our heuristic: `isMetaMask` returns `true` AND
there are no other `is*` methods on the provider) is wrapped in a one-time
proxy. That proxy passes everything through to the wrapped provider, *unless*
Taho has been set to present as MetaMask by the user (an explicit choice).
In this case, a subset of functions are always redirected to Taho, including
account and RPC requests. Additionally, any calls to `isMetaMask` on
`window.ethereum` return `true` if Taho is set to default, even though the
provider presented on `window.ethereum` is the Taho provider.

We do two more small things:
- When Taho is set as default, it is set as the first provider in the providers
  array. When it is not, it is removed from the front of the providers list. This
  allows MetaMask or other wallet usage for dApps that use a framework like wagmi,
  which especially in older versions only used the first wallet in the providers
  array for connections. Examples of dApps that show this behavior include Lens
  and Vela (e.g. see [this bug report in Discord](https://discord.com/channels/808358975287722045/888500174685614090/1127318749746311258)).
- When Taho is set as default by the user and MetaMask is not installed, a mock
  MetaMask is presented to the dApp that reroutes calls to Taho. If Taho is
  switched back to not default, the mock is removed. This allows dApps like
  bitcoinbridge.network that only allow connecting via MetaMask to work with
  Taho even if MetaMask is not installed.

The net result is that the “act as MetaMask”/“Taho as default” toggle should
behave consistently across all dApps. Famous last words :)

Finally, we fix a small issue with eth_requestAccounts handling on certain dApps.
Not related to MetaMask impersonation really, but knockin' bugs out.

## Testing

- This is going to require doing some relatively extensive testing in our
  release QA dApps to make sure that MetaMask is replaced when Taho is set
  as default and not when
  it is not.
- All these should also be replicated with Taho as default and not and MetaMask
  disabled (to ensure the dApp registers MetaMask as uninstalled when Taho is
  not default, and allows interaction as MetaMask when Taho is default).
- We should also check Lens (https://claim.lens.xyz/) to make sure the Browser
  connection uses Taho when default, and MetaMask when not.
- Finally, the dApps in the issues below should be tested to make sure they're
  all working!

Fixes #3433, fixes #3412, fixes #3368, fixes #3242, fixes #3231, fixes #2506, fixes #2706, fixes #2818.

Latest build: [extension-builds-3546](https://github.com/tahowallet/extension/suites/14241880950/artifacts/799754754) (as of Wed, 12 Jul 2023 12:06:52 GMT).