### PR TITLE
Buggity fixes: two small bug fixes

### DIFF
--- a/background/lib/priceOracle.ts
+++ b/background/lib/priceOracle.ts
@@ -152,6 +152,10 @@ const getRatesForTokens = async (
     }
   }[]
 > => {
+  if (SPOT_PRICE_ORACLE_CONSTANTS[network.chainID] === undefined) {
+    return []
+  }
+
   const multicall = new ethers.Contract(
     MULTICALL_CONTRACT_ADDRESS,
     MULTICALL_ABI,

--- a/background/services/internal-signer/index.ts
+++ b/background/services/internal-signer/index.ts
@@ -334,8 +334,6 @@ export default class InternalSignerService extends BaseService<Events> {
         this.#hiddenAccounts = {
           ...plainTextVault.hiddenAccounts,
         }
-
-        this.#emitInternalSigners()
       }
     }
 
@@ -347,6 +345,8 @@ export default class InternalSignerService extends BaseService<Events> {
     }
 
     this.#unlock()
+    this.#emitInternalSigners()
+
     return true
   }
 


### PR DESCRIPTION
Two fixes here, one for a small edge case in internal signer emission
that meant that if for some reason the internal signers data was cleared
in redux, it would never be correctly repopulated (expectation is that
there's no production scenario that would really trigger this).

The other is an issue where adding a network to the extension that didn't
have an associated spot price oracle listed would cause price lookups for
that network to fail, and this would cascade into failing all price lookups.

The correct fix for the latter is probably to make price lookups less sensitive
to individual failure, but for now I'm making the spot price oracle bit be
safe for networks that don't have an entry in the spot price oracle list.

Latest build: [extension-builds-3558](https://github.com/tahowallet/extension/suites/14438222069/artifacts/814921375) (as of Thu, 20 Jul 2023 10:37:18 GMT).