### PR TITLE
Add bigint filter for jsondiffpatch

### DIFF
--- a/background/differ.ts
+++ b/background/differ.ts
@@ -1,0 +1,18 @@
+import { DiffContext, Filter, create } from "jsondiffpatch"
+
+const differ = create()
+
+const bigintDiffFilter: Filter<DiffContext> = (context) => {
+  if (typeof context.left === "bigint" && typeof context.right === "bigint") {
+    if (context.left !== context.right) {
+      context.setResult([context.left, context.right])
+    }
+  }
+}
+bigintDiffFilter.filterName = "bigint"
+
+differ.processor.pipes.diff.before("objects", bigintDiffFilter)
+
+export const diff = differ.diff.bind(differ)
+export const patch = differ.patch.bind(differ)
+export type { Delta } from "jsondiffpatch"

--- a/background/index.ts
+++ b/background/index.ts
@@ -1,10 +1,10 @@
 import browser from "webextension-polyfill"
 
 import { Store as ProxyStore } from "webext-redux"
-import { Delta, patch as patchDeepDiff } from "jsondiffpatch"
 import { produce } from "immer"
 import { AnyAction } from "@reduxjs/toolkit"
 
+import { Delta, patch as patchDeepDiff } from "./differ"
 import Main from "./main"
 import { encodeJSON, decodeJSON } from "./lib/utils"
 

--- a/background/main.ts
+++ b/background/main.ts
@@ -1,12 +1,12 @@
 import browser, { runtime } from "webextension-polyfill"
 import { alias, wrapStore } from "webext-redux"
-import { diff as deepDiff } from "jsondiffpatch"
 import { configureStore, isPlain, Middleware } from "@reduxjs/toolkit"
 import { devToolsEnhancer } from "@redux-devtools/remote"
 import { PermissionRequest } from "@tallyho/provider-bridge-shared"
 import { debounce } from "lodash"
 import { utils } from "ethers"
 
+import { diff as deepDiff } from "./differ"
 import {
   decodeJSON,
   encodeJSON,


### PR DESCRIPTION
In the current implementation, `bigints` are treated as objects and are incorrectly excluded from generated patches. This fixes `bigint` diffing by adding a handler for these cases to the `jsondiffpatch` pipeline.

## To Test
- [x] Send assets
- [x] Check that balance changes after transaction succeeds

Latest build: [extension-builds-3561](https://github.com/tahowallet/extension/suites/14449081920/artifacts/815732866) (as of Thu, 20 Jul 2023 17:02:04 GMT).