### PR TITLE
Fix incorrect build asset uploaded on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,14 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           POAP_API_KEY: ${{ secrets.POAP_API_KEY }}
           DAYLIGHT_API_KEY: ${{ secrets.DAYLIGHT_API_KEY }}
+      - name: Create Release and Upload Artifacts
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: dist/*.zip
+          draft: true
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref, '-pre') || contains(github.ref, 'v0.') }}
       - name: Upload build asset
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/upload-artifact@v3
@@ -80,6 +88,7 @@ jobs:
         run: |
           echo 'USE_ANALYTICS_SOURCE="BETA"' >> .env
           yarn build
+          find dist -name "*.zip" -exec sh -c 'mv "$1" "${1%.zip}-fork.zip"' _ {} \;
         env:
           ALCHEMY_KEY: ${{ secrets.ALCHEMY_API_KEY }}
           BLOCKNATIVE_API_KEY: ${{ secrets.BLOCKNATIVE_API_KEY }}
@@ -96,14 +105,6 @@ jobs:
         with:
           name: extension-builds-fork-${{ github.event.number || github.event.head_commit.id }}
           path: dist/*.zip
-      - name: Create Release and Upload Artifacts
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: dist/*.zip
-          draft: true
-          generate_release_notes: true
-          prerelease: ${{ contains(github.ref, '-pre') || contains(github.ref, 'v0.') }}
   test:
     runs-on: ubuntu-latest
     steps:
@@ -222,7 +223,7 @@ jobs:
         with:
           name: extension-builds-fork-${{ github.event.number || github.event.head_commit.id }}
       - name: Extract extension
-        run: unzip -o chrome.zip -d dist/chrome
+        run: unzip -o chrome-fork.zip -d dist/chrome
       - name: Cache Hardhat
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Added a suffix to the fork-related assets and changed the workflow steps to publish the correct production build as the release asset.

Latest build: [extension-builds-3564](https://github.com/tahowallet/extension/suites/14480268296/artifacts/818192057) (as of Fri, 21 Jul 2023 19:49:40 GMT).