### PR TITLE
Add dev 0x API key to dev build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
           yarn build
         env:
           ALCHEMY_KEY: ${{ secrets.DEV_ALCHEMY_API_KEY || 'oV1Rtjh61hGa97X2MTqMY9kEUcpxP-6K' }}
+          ZEROX_API_KEY: ${{ secrets.DEV_ZEROX_API_KEY }}
           BLOCKNATIVE_API_KEY: ${{ secrets.DEV_BLOCKNATIVE_API_KEY || 'f60816ff-da02-463f-87a6-67a09c6d53fa' }}
           DAYLIGHT_API_KEY: ${{ secrets.DAYLIGHT_API_KEY }}
           COMMIT_SHA: ${{ github.sha }}


### PR DESCRIPTION
The ungated 0x API has been sunset, meaning we need an API key for dev builds to work.

## Testing

- [ ] Install the build from this PR comment and verify that entering a swap pair and one amount fills in the other amount correctly.

Latest build: [extension-builds-3565](https://github.com/tahowallet/extension/suites/14481912198/artifacts/818327456) (as of Fri, 21 Jul 2023 21:16:07 GMT).