### PR TITLE
Fix assertions made on the latest transaction

### DIFF
--- a/e2e-tests/regular/transactions.spec.ts
+++ b/e2e-tests/regular/transactions.spec.ts
@@ -195,10 +195,12 @@ test.describe("Transactions", () => {
           latestSentTx.getByText(/^[a-zA-Z]{3} \d{1,2}$/)
         ).toBeVisible()
         await expect(
-          popup.getByTestId("activity_list_item_amount").getByText(/^0$/)
+          latestSentTx.getByTestId("activity_list_item_amount").getByText(/^0$/)
         ).toBeVisible()
         await expect(
-          popup.getByTestId("activity_list_item_amount").getByText(/^ETH$/)
+          latestSentTx
+            .getByTestId("activity_list_item_amount")
+            .getByText(/^ETH$/)
         ).toBeVisible()
         await expect(latestSentTx.getByText(/^To: 0x4774…875a6$/)).toBeVisible()
 
@@ -248,10 +250,12 @@ test.describe("Transactions", () => {
           latestSentTx.getByText(/^[a-zA-Z]{3} \d{1,2}$/)
         ).toBeVisible()
         await expect(
-          popup.getByTestId("activity_list_item_amount").getByText(/^0$/)
+          latestSentTx.getByTestId("activity_list_item_amount").getByText(/^0$/)
         ).toBeVisible()
         await expect(
-          popup.getByTestId("activity_list_item_amount").getByText(/^ETH$/)
+          latestSentTx
+            .getByTestId("activity_list_item_amount")
+            .getByText(/^ETH$/)
         ).toBeVisible()
         await expect(latestSentTx.getByText(/^To: 0x4774…875a6$/)).toBeVisible()
 


### PR DESCRIPTION
There is a stage in the tests when we want to verify the attributes of the latest transaction. By mistake we did some of the checks on an objet that wasn't a latest transaction, but on an object of 'any' transaction. The assertion was failing if more than one object was detected.