### PR TITLE
Update release-test-list.md: changed outdated terminology and added tests for new features

### DIFF
--- a/.github/workflows/test-list/release-test-list.md
+++ b/.github/workflows/test-list/release-test-list.md
@@ -28,28 +28,31 @@ This release checklist should be performed before release is published.
    - [ ] check NFTs
    - [ ] check abilities (abilities should not be displayed)
    - [ ] check activities
-   - [ ] check overview page
+   - [ ] check portfolio page
+   - [ ] check export options (export recovery phase and export private key should not be available)
 2. Add read-only account with UNS
    - [ ] check assets
    - [ ] check balance
    - [ ] check NFTs
    - [ ] check abilities (abilities should not be displayed)
    - [ ] check activities
-   - [ ] check overview page
+   - [ ] check portfolio page
+   - [ ] check export options (export recovery phase and export private key should not be available)
 3. Add read-only account with 0x address
    - [ ] check assets
    - [ ] check balance
    - [ ] check NFTs
    - [ ] check abilities (abilities should not be displayed)
    - [ ] check activities
-   - [ ] check overview page
+   - [ ] check portfolio page
+   - [ ] check export options (export recovery phase and export private key should not be available)
 4. Import account with a seed phrase
    - [ ] check assets
    - [ ] check balance
    - [ ] check NFTs
    - [ ] check abilities
    - [ ] check activities
-   - [ ] check overview page
+   - [ ] check portfolio page
    - [ ] check seed phrase export
    - [ ] check private key export for first account
 5. Add another account from the same seed phrase
@@ -58,7 +61,7 @@ This release checklist should be performed before release is published.
    - [ ] check NFTs
    - [ ] check abilities
    - [ ] check activities
-   - [ ] check overview page
+   - [ ] check portfolio page
    - [ ] check private key export for second account
 6. Add account with a Ledger
    - [ ] check assets
@@ -66,14 +69,14 @@ This release checklist should be performed before release is published.
    - [ ] check NFTs
    - [ ] check abilities
    - [ ] check activities
-   - [ ] check overview page
+   - [ ] check portfolio page
 7. Create new wallet
    - [ ] check assets
    - [ ] check balance
    - [ ] check NFTs
    - [ ] check abilities
    - [ ] check activities
-   - [ ] check overview page
+   - [ ] check portfolio page
    - [ ] check private key export
 8. Add account with private key
    - [ ] check assets
@@ -81,7 +84,7 @@ This release checklist should be performed before release is published.
    - [ ] check NFTs
    - [ ] check abilities
    - [ ] check activities
-   - [ ] check overview page
+   - [ ] check portfolio page
    - [ ] check private key export
 9. Add account with JSON keystore
    - [ ] check assets
@@ -89,7 +92,7 @@ This release checklist should be performed before release is published.
    - [ ] check NFTs
    - [ ] check abilities
    - [ ] check activities
-   - [ ] check overview page
+   - [ ] check portfolio page
    - [ ] check private key export
 
 ### 🗑️ Remove account

--- a/.github/workflows/test-list/release-test-list.md
+++ b/.github/workflows/test-list/release-test-list.md
@@ -70,6 +70,7 @@ This release checklist should be performed before release is published.
    - [ ] check abilities
    - [ ] check activities
    - [ ] check portfolio page
+   - [ ] check export options (export recovery phase and export private key should not be available)
 7. Create new wallet
    - [ ] check assets
    - [ ] check balance


### PR DESCRIPTION
- Changed "overview" to "portfolio" to match the new name of the page in the extension
- Added a test to read-only accounts so that we're explicitly checking that these accounts don't have export options for private key and recovery phrase.

Latest build: [extension-builds-3575](https://github.com/tahowallet/extension/suites/14642864832/artifacts/830631345) (as of Fri, 28 Jul 2023 13:08:31 GMT).