### PR TITLE
Fix typo on activity section default text

### DIFF
--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -838,7 +838,7 @@
   },
   "wallet": {
     "activities": {
-      "defaultHistoricalActivityExplainer": "All your new transaction will show up here.",
+      "defaultHistoricalActivityExplainer": "All your new transactions will show up here.",
       "historicalActivityExplainer": "Taho will populate your historical activity over time; this may take an hour or more for accounts that have been active for a long time. For new accounts, new activity will show up here.",
       "endOfList": "You have reached the end of activity list.",
       "moreHistory": "For more history visit",


### PR DESCRIPTION
When there are no activities listed on the Activity pane I noticed that there was a typo in the default text.

Latest build: [extension-builds-3584](https://github.com/tahowallet/extension/suites/14671307315/artifacts/832623799) (as of Sun, 30 Jul 2023 05:23:40 GMT).