### PR TITLE
Change current provider on timeouted RPC requests

### DIFF
--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -183,7 +183,7 @@ export const FLASHBOTS_DOCS_URL =
   "https://docs.flashbots.net/flashbots-protect/rpc/mev-share"
 
 export const CHAIN_ID_TO_RPC_URLS: {
-  [chainId: string]: Array<string> | undefined
+  [chainId: string]: string[]
 } = {
   [ROOTSTOCK.chainID]: ["https://public-node.rsk.co"],
   [POLYGON.chainID]: [

--- a/background/services/chain/serial-fallback-provider.ts
+++ b/background/services/chain/serial-fallback-provider.ts
@@ -72,6 +72,9 @@ const WAIT_BEFORE_SEND_AGAIN = 100
 const BALANCE_TTL = 1 * SECOND
 // How often to cleanup our hasCode and balance caches.
 const CACHE_CLEANUP_INTERVAL = 10 * SECOND
+// How long to wait for a provider to respond before falling back to the next provider.
+const PROVIDER_REQUEST_TIMEOUT = 5 * SECOND
+
 /**
  * Wait the given number of ms, then run the provided function. Returns a
  * promise that will resolve after the delay has elapsed and the passed
@@ -1021,11 +1024,19 @@ function getProviderCreator(
     return new WebSocketProvider(rpcUrl)
   }
 
-  if (/rpc\.ankr\.com|1rpc\.io|polygon-rpc\.com/.test(url.hostname)) {
-    return new JsonRpcBatchProvider(rpcUrl)
+  if (/rpc\.ankr\.com|1rpc\.io|polygon-rpc\.com/.test(url.href)) {
+    return new JsonRpcBatchProvider({
+      url: rpcUrl,
+      throttleLimit: 1,
+      timeout: PROVIDER_REQUEST_TIMEOUT,
+    })
   }
 
-  return new JsonRpcProvider(rpcUrl)
+  return new JsonRpcProvider({
+    url: rpcUrl,
+    throttleLimit: 1,
+    timeout: PROVIDER_REQUEST_TIMEOUT,
+  })
 }
 
 export function makeFlashbotsProviderCreator(): ProviderCreator {

--- a/background/services/chain/tests/serial-fallback-provider.integration.test.ts
+++ b/background/services/chain/tests/serial-fallback-provider.integration.test.ts
@@ -3,6 +3,7 @@ import Sinon, * as sinon from "sinon"
 import { ETHEREUM } from "../../../constants"
 import { wait } from "../../../lib/utils"
 import SerialFallbackProvider from "../serial-fallback-provider"
+import { waitFor } from "../../../tests/utils"
 
 const sandbox = sinon.createSandbox()
 
@@ -19,7 +20,9 @@ describe("Serial Fallback Provider", () => {
       .callsFake(async () => "success")
     alchemySendStub = sandbox
       .stub(mockAlchemyProvider, "send")
-      .callsFake(async () => "success")
+      .callsFake(async () => {
+        return "success"
+      })
     fallbackProvider = new SerialFallbackProvider(ETHEREUM.chainID, [
       {
         type: "generic",
@@ -74,6 +77,9 @@ describe("Serial Fallback Provider", () => {
       genericSendStub.onCall(0).throws("bad response")
       genericSendStub.onCall(1).returns(ETHEREUM.chainID)
       genericSendStub.onCall(2).returns("success")
+
+      await waitFor(() => expect(genericSendStub.called).toEqual(true))
+
       await expect(
         fallbackProvider.send("eth_getBalance", [])
       ).resolves.toEqual("success")
@@ -87,6 +93,9 @@ describe("Serial Fallback Provider", () => {
       genericSendStub.onCall(0).throws("missing response")
       genericSendStub.onCall(1).returns(ETHEREUM.chainID)
       genericSendStub.onCall(2).returns("success")
+
+      await waitFor(() => expect(genericSendStub.called).toEqual(true))
+
       await expect(
         fallbackProvider.send("eth_getBalance", [])
       ).resolves.toEqual("success")
@@ -100,6 +109,9 @@ describe("Serial Fallback Provider", () => {
       genericSendStub.onCall(0).throws("we can't execute this request")
       genericSendStub.onCall(1).returns(ETHEREUM.chainID)
       genericSendStub.onCall(2).returns("success")
+
+      await waitFor(() => expect(genericSendStub.called).toEqual(true))
+
       await expect(
         fallbackProvider.send("eth_getBalance", [])
       ).resolves.toEqual("success")
@@ -110,14 +122,16 @@ describe("Serial Fallback Provider", () => {
     })
 
     it("should switch to next provider after three bad responses", async () => {
-      genericSendStub.throws("bad response")
+      genericSendStub.throws("bad result from backend")
       alchemySendStub.onCall(0).returns(ETHEREUM.chainID)
       alchemySendStub.onCall(1).returns("success")
+
+      await waitFor(() => expect(genericSendStub.called).toEqual(true))
 
       await expect(
         fallbackProvider.send("eth_getBalance", [])
       ).resolves.toEqual("success")
-      // 1 try and 3 retries of eth_getBalance
+
       expect(
         genericSendStub.args.filter((args) => args[0] === "eth_getBalance")
           .length
@@ -204,12 +218,15 @@ describe("Serial Fallback Provider", () => {
       // Accessing private property
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((fallbackProvider as any).currentProviderIndex).toEqual(0)
+
+      await waitFor(() => expect(genericSendStub.called).toEqual(true))
+
       await expect(
         fallbackProvider.send("eth_getBalance", [])
       ).resolves.toEqual("success")
       // Accessing private property
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((fallbackProvider as any).currentProviderIndex).toEqual(1)
+      expect((fallbackProvider as any).currentProviderIndex).toEqual(0)
     })
   })
 })

--- a/background/tests/utils.ts
+++ b/background/tests/utils.ts
@@ -1,4 +1,6 @@
 import browser from "webextension-polyfill"
+// eslint-disable-next-line import/no-extraneous-dependencies
+export { waitFor } from "@testing-library/dom"
 
 type LocalStorageMock = Record<string, Record<string, unknown>>
 

--- a/scripts/unreliable-rpc-provider-utils.ts
+++ b/scripts/unreliable-rpc-provider-utils.ts
@@ -1,0 +1,12 @@
+export const patchRPCURL = (url: string): string =>
+  `http://localhost:9000?rpc=${url}`
+
+export const patchRPCURLS = (
+  chainIDToRPCMap: Record<string, string[]>
+): typeof chainIDToRPCMap =>
+  Object.fromEntries(
+    Object.entries(chainIDToRPCMap).map(([_, urls]) => [
+      _,
+      urls.map(patchRPCURL),
+    ])
+  )

--- a/scripts/unreliable-rpc-provider.mjs
+++ b/scripts/unreliable-rpc-provider.mjs
@@ -1,0 +1,104 @@
+/* eslint-disable */
+/**
+ * This is a simple proxy server that will randomly throttle or timeout
+ * requests and is used to test the reliability of the SerialFallbackProvider.
+ */
+import http from "http"
+import fetch from "node-fetch"
+import _ from "lodash"
+
+const PORT = 9000
+
+const throttleResponse = {
+  jsonrpc: "2 .0 ",
+  id: null,
+  error: "Whomp, too many requests",
+}
+1
+/**
+ *  Returns a function that will return true `chance` percent of the time.
+ */
+function makeChance(chance) {
+  return () => Math.random() < chance / 100
+}
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms))
+
+const isThrottled = makeChance(20)
+const isTimeout = makeChance(20)
+
+const stats = { timeout: 0, throttle: 0, proxied: 0 }
+
+/**
+ * Time until the server will timeout a request and close the socket.
+ */
+const RESPONSE_TIMEOUT = 20_000
+
+const server = http.createServer(async (req, res) => {
+  const payload = JSON.stringify(throttleResponse)
+
+  const url = new URL(req.url, `http://${req.headers.host}`)
+
+  const targetURL = url.searchParams.get("rpc")
+
+  if (!targetURL) {
+    res.writeHead(500).end("missing target url")
+    return
+  }
+
+  if (isThrottled()) {
+    stats.throttle += 1
+
+    res
+      .writeHead(429, {
+        "content-type": "application/json",
+        "content-length": Buffer.byteLength(payload),
+        "Access-Control-Allow-Origin": "no-cors",
+      })
+      .end(payload)
+  } else if (isTimeout()) {
+    stats.timeout += 1
+
+    await wait(RESPONSE_TIMEOUT)
+    res.destroy()
+  } else {
+    stats.proxied += 1
+
+    const data = await new Promise((resolve, rej) => {
+      let body = ""
+      req
+        .on("data", (chunk) => {
+          body += chunk
+        })
+        .on("end", () => {
+          resolve(body)
+        })
+        .on("error", () => {
+          rej()
+          req.destroy()
+        })
+    })
+
+    fetch(targetURL, {
+      method: req.method,
+      ...(req.method === "POST" ? { body: data } : {}),
+      headers: _.omit(req.headers, "host"),
+    })
+      .then(async (targetResponse) => {
+        const body = await targetResponse.text()
+        res
+          .writeHead(targetResponse.status, {
+            "Content-Type": "application/json",
+          })
+          .end(body)
+      })
+      .catch((err) => {
+        console.log("Error retrieving: ", targetURL, err)
+        res.writeHead(500).end()
+      })
+  }
+})
+
+server.listen(PORT)
+
+setInterval(() => console.log(stats), 5000)


### PR DESCRIPTION
### What
If some RPC request fails because of a timeout we should change to a different RPC provider. Tested on reproduced problem with `ankr` RPC

#### TODO:

- [x] `await this.currentProvider.send(method, params)` - is swallowing 429 request's error, can we rethrow it so we don't have to wait for timeouts?
- [x] we should loop providers - if the last provider on the list has been used let's set the first provider as current - lmk if you think it is a good idea 🤔

## How to test
- Patch default providers https://github.com/tahowallet/extension/blob/7c88a8629088ce2e718e5cbc48571f99534f1a03/background/constants/networks.ts#L185 using `patchRPCURLS` from https://github.com/tahowallet/extension/blob/7c88a8629088ce2e718e5cbc48571f99534f1a03/scripts/unreliable-rpc-provider-utils.ts
- Run `node scripts/unreliable-rpc-provider.mjs`
- Reinstall the extension, open the background inspector and check that providers are being switched on timeouts/server errors
- Onboard an account, perform a few actions. Verify the wallet is handling errors gracefully

Latest build: [extension-builds-3587](https://github.com/tahowallet/extension/suites/14751539578/artifacts/838585130) (as of Wed, 02 Aug 2023 07:27:53 GMT).