### PR TITLE
DAppstrosities: Fix a few observed dApp connection issues

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -25,6 +25,7 @@ type BaseWalletProvider = {
     identityFlag?: string
     checkIdentity?: (provider: WalletProvider) => boolean
   }
+  emit: (eventName: string | symbol, ...args: unknown[]) => boolean
   on: (
     eventName: string | symbol,
     listener: (...args: unknown[]) => void
@@ -60,6 +61,7 @@ interface Window {
       shouldReload?: boolean
     ) => void
     routeToNewNonTahoDefault: (request: unknown) => Promise<unknown>
+    reemitTahoEvent: (event: string | symbol, ...args: unknown[]) => boolean
     getProviderInfo: (
       provider: WalletProvider
     ) => WalletProvider["providerInfo"]

--- a/src/window-provider.ts
+++ b/src/window-provider.ts
@@ -195,13 +195,15 @@ if (!window.walletRouter) {
     ]),
   ].filter((item) => item !== undefined)
 
+  const wrappedLastInjectedProvider: WalletProvider | undefined =
+    window.ethereum === undefined
+      ? undefined
+      : wrapMetaMaskProvider(window.ethereum).provider
+
   Object.defineProperty(window, "walletRouter", {
     value: {
       currentProvider: window.tally,
-      lastInjectedProvider:
-        window.ethereum === undefined
-          ? undefined
-          : wrapMetaMaskProvider(window.ethereum),
+      lastInjectedProvider: wrappedLastInjectedProvider,
       tallyProvider: window.tally,
       providers: dedupedProviders,
       shouldSetTallyForCurrentProvider(

--- a/src/window-provider.ts
+++ b/src/window-provider.ts
@@ -37,6 +37,7 @@ const tahoRoutedProperties = new Set(
 // function below.
 const metaMaskMock: WalletProvider = {
   isMetaMask: true,
+  emit: (_: string | symbol, ...__: unknown[]) => false,
   on: () => {},
   removeListener: () => {},
   _state: {
@@ -261,6 +262,17 @@ if (!window.walletRouter) {
             iconURL: "TODO",
           }
         )
+      },
+      reemitTahoEvent(event: string | symbol, ...args: unknown[]): boolean {
+        if (
+          this.currentProvider !== this.tallyProvider ||
+          this.lastInjectedProvider === undefined ||
+          this.currentProvider === this.lastInjectedProvider
+        ) {
+          return false
+        }
+
+        return this.lastInjectedProvider.emit(event, ...args)
       },
       setSelectedProvider() {},
       addProvider(newProvider: WalletProvider) {

--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -367,6 +367,17 @@ export default class TahoWindowProvider extends EventEmitter {
     })
   }
 
+  override emit(event: string | symbol, ...args: unknown[]): boolean {
+    const hadAdditionalListeners = window.walletRouter?.reemitTahoEvent(
+      event,
+      ...args
+    )
+
+    const hadDirectListeners = super.emit(event, ...args)
+
+    return hadAdditionalListeners || hadDirectListeners
+  }
+
   handleChainIdChange(chainId: string): void {
     this.chainId = chainId
     this.emit("chainChanged", chainId)


### PR DESCRIPTION
- Uniswap should now update default wallet without reloads (closes #3578).
- Stargate should correctly handle transfers when the chain needs to be changed behind the scenes.
- Generally sites that may interact with event handlers before Taho's default status is read should no longer have issues.

## Testing

- [x] Go to Uniswap with Taho as default and try to connect with MetaMask. In the popup, switch away from Taho as default. MetaMask should connect normally.
- [x] Go to Uniswap with Taho as default and try to connect with MetaMask. In the popup, reject. Switch Taho as default off in the popover. Try to connect with MetaMask again. MetaMask should connect normally.
- [x] Go to Uniswap with Taho as not-default. Switch Taho as default on in the popover. Try to connect with MetaMask. Taho should connect normally.
- [x] Go to Stargate with Taho as default. Connect. Set up a swap from a *different* network than the one you connected on (I typically connect on Ethereum mainnet, then set a swap from Arbitrum ETH to mainnet ETH). Try to submit the transaction. You should get a transaction confirmation.

Latest build: [extension-builds-3593](https://github.com/tahowallet/extension/suites/14936639887/artifacts/851517366) (as of Wed, 09 Aug 2023 02:29:24 GMT).