### PR TITLE
Updates to release checklist: Removed Mintkudos test

### DIFF
--- a/.github/workflows/test-list/release-test-list.md
+++ b/.github/workflows/test-list/release-test-list.md
@@ -217,7 +217,7 @@ This release checklist should be performed before release is published.
 - [ ] connect to [SpookySwap](https://spooky.fi/#/)
 - [ ] connect to [Velodrome](https://app.velodrome.finance/swap)
 - [ ] connect to [GMX](https://app.gmx.io/#/trade)
-- [ ] connect to [Mintkudos](https://mintkudos.xyz/)
+- [ ] connect to [MetaMask Test dApp](https://metamask.github.io/test-dapp/) & verify Personal Sign
 
 ### 🎭 Sign in with Ethereum
 


### PR DESCRIPTION
Mintkudos site's been sunset; Added explicit test for Personal Sign

Latest build: [extension-builds-3600](https://github.com/tahowallet/extension/suites/15107712796/artifacts/863252032) (as of Tue, 15 Aug 2023 13:27:27 GMT).