### PR TITLE
v0.47.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -51,6 +51,7 @@ body:
       label: Version
       description: What version of the extension are you running?
       options:
+        - v0.47.0
         - v0.46.1
         - v0.46.0
         - v0.45.0

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Taho",
-  "version": "0.46.1",
+  "version": "0.47.0",
   "description": "The community owned and operated Web3 wallet.",
   "homepage_url": "https://taho.xyz",
   "author": "https://taho.xyz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tallyho/tally-extension",
   "private": true,
-  "version": "0.46.1",
+  "version": "0.47.0",
   "description": "Taho, the community owned and operated Web3 wallet.",
   "main": "index.js",
   "repository": "git@github.com:thesis/tally-extension.git",


### PR DESCRIPTION
## Highlights

- Further performance improvements.
- Groundwork to rename backend dApp connection things (for the provider) to Taho naming.

## What's Changed
* v0.46.1 by @Shadowfiend in https://github.com/tahowallet/extension/pull/3598
* Updates to release checklist: Removed Mintkudos test by @andreachapman in https://github.com/tahowallet/extension/pull/3600
* Revert "Revert "Debounce dispatched state diffs"" by @hyphenized in https://github.com/tahowallet/extension/pull/3579
* Underbridge: Drop updated dApp connections feature flag, further Taho renames by @Shadowfiend in https://github.com/tahowallet/extension/pull/3595


**Full Changelog**: https://github.com/tahowallet/extension/compare/v0.46.1...v0.47.0

Latest build: [extension-builds-3601](https://github.com/tahowallet/extension/suites/15160003504/artifacts/866327987) (as of Wed, 16 Aug 2023 19:09:51 GMT).