### PR TITLE
Unsettled Networks: Clear an origin's current network when revoking dApp permissions

### DIFF
--- a/background/services/internal-ethereum-provider/db.ts
+++ b/background/services/internal-ethereum-provider/db.ts
@@ -53,6 +53,22 @@ export class InternalEthereumProviderDatabase extends Dexie {
     return this.currentNetwork.put({ origin, network })
   }
 
+  /**
+   * Clear origin's current network state if it is the same as the passed
+   * chainId.
+   */
+  async unsetCurrentNetworkForOrigin(
+    origin: string,
+    chainId: string,
+  ): Promise<void> {
+    const originMatches =
+      (await this.currentNetwork.where({ origin, chainId }).count()) > 0
+
+    if (originMatches) {
+      await this.currentNetwork.delete(origin)
+    }
+  }
+
   async getCurrentNetworkForOrigin(
     origin: string,
   ): Promise<EVMNetwork | undefined> {

--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -539,6 +539,20 @@ export default class InternalEthereumProviderService extends BaseService<Events>
     await this.db.setCurrentChainIdForOrigin(origin, supportedNetwork)
   }
 
+  /**
+   * Clears the current network for the given origin if and only if it matches
+   * the passed chain id.
+   *
+   * If the origin has a different chain id set as the current network, the
+   * current network will be left in place.
+   */
+  async unsetCurrentNetworkForOrigin(
+    origin: string,
+    chainId: string,
+  ): Promise<void> {
+    await this.db.unsetCurrentNetworkForOrigin(origin, chainId)
+  }
+
   private async signData(
     {
       input,

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -430,6 +430,13 @@ export default class ProviderBridgeService extends BaseService<Events> {
 
     this.#pendingPermissionsRequests[permission.origin]?.("Time to move on")
 
+    // If the removed permission is for the origin's current network, clear
+    // that state so the origin isn't stuck on a disconnected network.
+    this.internalEthereumProviderService.unsetCurrentNetworkForOrigin(
+      permission.origin,
+      permission.chainID,
+    )
+
     if (deleted > 0) {
       this.notifyContentScriptsAboutAddressChange()
     }


### PR DESCRIPTION
Draft until I fill in some testing details.

The actual implementation is a little more subtle: permissions are for an origin AND a network. If the permission being cleared is for the origin's current network, as tracked in the `InternalEthereumProvider`, then that current network is cleared so that future interactions can set it.

Latest build: [extension-builds-3616](https://github.com/tahowallet/extension/suites/15762123848/artifacts/899755021) (as of Sat, 02 Sep 2023 20:14:11 GMT).