### PR TITLE
Group private keys when categorizing

### DIFF
--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -344,7 +344,7 @@ export type AccountTotal = AddressOnNetwork & {
 function signerIdFor(accountSigner: AccountSigner): string | null {
   switch (accountSigner.type) {
     case "private-key":
-      return accountSigner.walletID
+      return "private-key"
     case "keyring":
       return accountSigner.keyringID
     case "ledger":


### PR DESCRIPTION
When the signer id abstraction was introduced, I misunderstood each private key as needing to be treated as its own signer. In fact, we treat, on the UI side, all private keys as a single signer group. To fix this, rather than return the wallet id for the signer in these cases, we just return the constant string `"private-key"`. This ensures all private keys are categorized together.

## Testing

- [x] Import 2 or more private keys. Observe that they are under one category in the account list (see below). On the previous release version, they should be listed as distinct categories. For simplicity, you can use `0c1cd323ff8fd5b34f260d580c3a843f3e06c3e1e31c357d38a4a22e8b26809b` (used for testing 0-leading private key imports) and `1c1cd323ff8fd5b34f260d580c3a843f3e06c3e1e31c357d38a4a22e8b26809b` (swaps the 0 to a 1 in the previous key) as private keys.

<img width="390" alt="Screenshot 2023-09-02 at 23 50 04" src="https://github.com/tahowallet/extension/assets/8245/f148fcb4-3314-47dd-b72b-1eea9fe30fb1">


Fixes #3606.

Latest build: [extension-builds-3618](https://github.com/tahowallet/extension/suites/15767975455/artifacts/899975852) (as of Sun, 03 Sep 2023 04:04:18 GMT).