### PR TITLE
Joint Privacy: Rework analytics service event management and add signing tracking

### DIFF
--- a/background/lib/posthog.ts
+++ b/background/lib/posthog.ts
@@ -9,6 +9,8 @@ export enum AnalyticsEvent {
   ANALYTICS_TOGGLED = "Analytics Toggled",
   DEFAULT_WALLET_TOGGLED = "Default Wallet Toggled",
   TRANSACTION_SIGNED = "Transaction Signed",
+  DATA_SIGNED = "Data Signed",
+  SIGNATURE_FAILED = "Signature Failed",
   NEW_ACCOUNT_TO_TRACK = "Address added to tracking on network",
   CUSTOM_CHAIN_ADDED = "Custom chain added",
   DAPP_CONNECTED = "Dapp Connected",

--- a/background/main.ts
+++ b/background/main.ts
@@ -949,12 +949,6 @@ export default class Main extends BaseService<never> {
           const signedTransactionResult =
             await this.signingService.signTransaction(request, accountSigner)
           await this.store.dispatch(transactionSigned(signedTransactionResult))
-          this.analyticsService.sendAnalyticsEvent(
-            AnalyticsEvent.TRANSACTION_SIGNED,
-            {
-              chainId: request.chainID,
-            },
-          )
         } catch (exception) {
           logger.error("Error signing transaction", exception)
           this.store.dispatch(

--- a/background/main.ts
+++ b/background/main.ts
@@ -304,12 +304,9 @@ export default class Main extends BaseService<never> {
 
   static create: ServiceCreatorFunction<never, Main, []> = async () => {
     const preferenceService = PreferenceService.create()
-    const analyticsService = AnalyticsService.create(preferenceService)
 
-    const internalSignerService = InternalSignerService.create(
-      preferenceService,
-      analyticsService,
-    )
+    const internalSignerService =
+      InternalSignerService.create(preferenceService)
     const chainService = ChainService.create(
       preferenceService,
       internalSignerService,
@@ -340,6 +337,12 @@ export default class Main extends BaseService<never> {
       internalSignerService,
       ledgerService,
       chainService,
+    )
+
+    const analyticsService = AnalyticsService.create(
+      internalSignerService,
+      signingService,
+      preferenceService,
     )
 
     const nftsService = NFTsService.create(chainService)

--- a/background/services/internal-signer/tests/index.integration.test.ts
+++ b/background/services/internal-signer/tests/index.integration.test.ts
@@ -15,7 +15,6 @@ import {
 import {
   createTransactionRequest,
   createPreferenceService,
-  createAnalyticsService,
 } from "../../../tests/factories"
 
 const validMnemonics = {
@@ -44,11 +43,7 @@ const dateNowValue = 1000000000000
 
 const startInternalSignerService = async () => {
   const preferencesService = createPreferenceService()
-  const analyticsService = createAnalyticsService()
-  const service = await InternalSignerService.create(
-    preferencesService,
-    analyticsService,
-  )
+  const service = await InternalSignerService.create(preferencesService)
 
   await service.startService()
 

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -274,7 +274,6 @@ export default class ProviderBridgeService extends BaseService<Events> {
 
       if (typeof persistedPermission !== "undefined") {
         // if agrees then let's return the account data
-
         response.result = await this.routeContentScriptRPCRequest(
           persistedPermission,
           "eth_accounts",

--- a/background/tests/factories.ts
+++ b/background/tests/factories.ts
@@ -66,18 +66,8 @@ const createRandom0xHash = () =>
 export const createPreferenceService = async (): Promise<PreferenceService> =>
   PreferenceService.create()
 
-export async function createAnalyticsService(overrides?: {
-  chainService?: Promise<ChainService>
-  preferenceService?: Promise<PreferenceService>
-}): Promise<AnalyticsService> {
-  const preferenceService =
-    overrides?.preferenceService ?? createPreferenceService()
-  return AnalyticsService.create(preferenceService)
-}
-
 type CreateInternalSignerServiceOverrides = {
   preferenceService?: Promise<PreferenceService>
-  analyticsService?: Promise<AnalyticsService>
 }
 
 export const createInternalSignerService = async (
@@ -85,7 +75,6 @@ export const createInternalSignerService = async (
 ): Promise<InternalSignerService> =>
   InternalSignerService.create(
     overrides.preferenceService ?? createPreferenceService(),
-    overrides.analyticsService ?? createAnalyticsService(),
   )
 
 type CreateChainServiceOverrides = {
@@ -160,6 +149,23 @@ export const createSigningService = async (
     overrides.ledgerService ?? createLedgerService(),
     overrides.chainService ?? createChainService(),
   )
+
+export async function createAnalyticsService(overrides?: {
+  preferenceService?: Promise<PreferenceService>
+  internalSignerService?: Promise<InternalSignerService>
+  signingService?: Promise<SigningService>
+}): Promise<AnalyticsService> {
+  const preferenceService =
+    overrides?.preferenceService ?? createPreferenceService()
+  const internalSignerService =
+    overrides?.internalSignerService ?? createInternalSignerService()
+  const signerService = overrides?.signingService ?? createSigningService()
+  return AnalyticsService.create(
+    internalSignerService,
+    signerService,
+    preferenceService,
+  )
+}
 
 export const createAbilitiesService = async (
   overrides: CreateAbilitiesServiceOverrides = {},


### PR DESCRIPTION
This PR does two core things:
- Moves responsibility for more event tracking into the AnalyticsService itself.
- Adds tracking events for when data is signed and when there is an error signing data or transactions. The data signed and signature are not sent to Posthog, and in the case of errors only a generic set of errors is sent (rather than full error data).

Note that there is still a lot of unnecessary event management happening in `Main`, which should just be event observations from `AnalyticsService`. These can be handled at a later time.

Latest build: [extension-builds-3623](https://github.com/tahowallet/extension/suites/15873783826/artifacts/905833489) (as of Wed, 06 Sep 2023 10:24:01 GMT).