### PR TITLE
v0.49.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -51,6 +51,7 @@ body:
       label: Version
       description: What version of the extension are you running?
       options:
+        - v0.49.0
         - v0.48.0
         - v0.47.0
         - v0.46.1

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Taho",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "The community owned and operated Web3 wallet.",
   "homepage_url": "https://taho.xyz",
   "author": "https://taho.xyz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tallyho/tally-extension",
   "private": true,
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Taho, the community owned and operated Web3 wallet.",
   "main": "index.js",
   "repository": "git@github.com:thesis/tally-extension.git",


### PR DESCRIPTION
## Highlights
- Fixed an issue where valid private keys would not be accepted. These always had one or more `0`s at the beginning.
- Fixed an issue where certain types of errors were causing sites not to load correctly.

## What's Changed
* v0.48.0 by @Shadowfiend in https://github.com/tahowallet/extension/pull/3610
* Attempt to import private key to validate it by @jagodarybacka in https://github.com/tahowallet/extension/pull/3614
* Group private keys when categorizing by @Shadowfiend in https://github.com/tahowallet/extension/pull/3618
* Assert URL of the scan website opened for unverified assets by @michalinacienciala in https://github.com/tahowallet/extension/pull/3602
* Handle invalid responses on batch rpc providers by @hyphenized in https://github.com/tahowallet/extension/pull/3615
* Joint Privacy: Rework analytics service event management and add signing tracking by @Shadowfiend in https://github.com/tahowallet/extension/pull/3623


**Full Changelog**: https://github.com/tahowallet/extension/compare/v0.48.0...v0.49.0

Latest build: [extension-builds-3625](https://github.com/tahowallet/extension/suites/15924368205/artifacts/909765830) (as of Thu, 07 Sep 2023 20:56:50 GMT).