### PR TITLE
Run pledge sync daily

### DIFF
--- a/.github/workflows/pledge-signer-sync/pledge-sync.js
+++ b/.github/workflows/pledge-signer-sync/pledge-sync.js
@@ -22,8 +22,8 @@ if (!GALXE_ACCESS_TOKEN || !FIRESTORE_USER || !FIRESTORE_PASSWORD) {
   process.exit(1)
 }
 
-// Limit sync range to last 4 days ( 2 days from last sync + 2 days from now )
-const TARGET_DATE = new Date(Date.now() - 4 * 24 * 60 * 60_000)
+// Limit sync range to last 2 days (1 day from the last sync + 1 day margin)
+const TARGET_DATE = new Date(Date.now() - 2 * 24 * 60 * 60_000)
 
 const wait = (ms) =>
   new Promise((r) => {

--- a/.github/workflows/sync-pledge.yml
+++ b/.github/workflows/sync-pledge.yml
@@ -2,7 +2,7 @@ name: Sync pledge
 
 on:
   schedule:
-    - cron: "0 0 */3 * *"
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We want to update the pledge sync job to run daily rather than every three days so that no new pledge signers (or old community who havent signed, but now need to) are missed.

Latest build: [extension-builds-3626](https://github.com/tahowallet/extension/suites/16161486375/artifacts/922815423) (as of Thu, 14 Sep 2023 10:48:13 GMT).