### PR TITLE
Sepolia support - small fixes

### DIFF
--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -101,7 +101,7 @@ export const ARBITRUM_SEPOLIA: EVMNetwork = {
   baseAsset: ARBITRUM_SEPOLIA_ETH,
   chainID: "421614",
   family: "EVM",
-  coingeckoPlatformID: "ethereum",
+  coingeckoPlatformID: "arbitrum-one",
 }
 
 export const ZK_SYNC: EVMNetwork = {

--- a/background/services/chain/taho-provider.ts
+++ b/background/services/chain/taho-provider.ts
@@ -15,7 +15,7 @@ import { ConnectionInfo } from "@ethersproject/web"
 // upcoming patch, but as it's release date is unknown, we're adding the Sepolia
 // support by creating `TahoAlchemyProvider` class that handles this case.
 // In the future we may want to add there another case, for `arbitrum-sepolia`,
-// but we can't do that at this moment, as Alchemy dos not offers an RPC for
+// but we can't do that at this moment, as Alchemy does not offer an RPC for
 // Arbitrum Sepolia yet.
 export default class TahoAlchemyProvider extends AlchemyProvider {
   static override getUrl(network: Network, apiKey: string): ConnectionInfo {

--- a/background/services/chain/taho-provider.ts
+++ b/background/services/chain/taho-provider.ts
@@ -5,6 +5,18 @@ import {
 } from "@ethersproject/providers"
 import { ConnectionInfo } from "@ethersproject/web"
 
+// We want to add Sepolia to the list of Alchemy-supported chains. This will
+// allow the extension to fill the list of historical transactions on that
+// chain.
+// We can't just add `SEPOLIA` to `ALCHEMY_SUPPORTED_CHAIN_IDS` because the
+// `@ethersproject/providers@5.7.2` package that we use as a project dependency
+// does not support Sepolia yet (no `sepolia` case in the `getUrl` function of
+// `./src.ts/alchemy-provider.ts`). The support is planned to be added in the
+// upcoming patch, but as it's release date is unknown, we're adding the Sepolia
+// support by creating `TahoAlchemyProvider` class that handles this case.
+// In the future we may want to add there another case, for `arbitrum-sepolia`,
+// but we can't do that at this moment, as Alchemy dos not offers an RPC for
+// Arbitrum Sepolia yet.
 export default class TahoAlchemyProvider extends AlchemyProvider {
   static override getUrl(network: Network, apiKey: string): ConnectionInfo {
     let host = null

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -545,7 +545,6 @@
     "beta": "Mainnet (beta)",
     "testnet": "Test Network",
     "l2": "L2 scaling solution",
-    "l2Testnet": "L2 Test Network",
     "compatibleChain": "EVM-compatible blockchain",
     "avalanche": "Mainnet C-Chain",
     "connected": "Connected"

--- a/ui/components/TopMenu/TopMenuProtocolList.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolList.tsx
@@ -49,7 +49,7 @@ const testNetworks = [
   },
   {
     network: ARBITRUM_SEPOLIA,
-    info: i18n.t("protocol.l2Testnet"),
+    info: i18n.t("protocol.testnet"),
     isDisabled: false,
   },
 ]


### PR DESCRIPTION
In this PR we address the leftover comments from the review of https://github.com/tahowallet/extension/pull/3633 (_Add support for Mainnet Sepolia and Arbitrum Sepolia testnets_).

Latest build: [extension-builds-3636](https://github.com/tahowallet/extension/suites/16906558298/artifacts/965879218) (as of Thu, 05 Oct 2023 11:15:11 GMT).