### PR TITLE
Update e2e tests after change of testing accounts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,20 +237,20 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ci/cache
-          # 17094516 is a forking block used in the tests.
-          key: hardhat-17094516-${{ github.ref_name }}
+          # 18291960 is a forking block used in the tests.
+          key: hardhat-18291960-${{ github.ref_name }}
           restore-keys: |
-            hardhat-17094516-
+            hardhat-18291960-
             hardhat-
       - name: Run Hardhat
         env:
           CHAIN_API_URL: https://eth-mainnet.g.alchemy.com/v2/${{ secrets.DEV_ALCHEMY_API_KEY }}
           MAINNET_FORK_CHAIN_ID: 1337
           # We're using a fixed block number as a start of the fork to get
-          # consistent behavior in tests. The `17094516` block is a block at
-          # which the wallet used in tests (`testertesting.eth`) had multiple
-          # assets.
-          FORKING_BLOCK: 17094516
+          # consistent behavior in tests. The `18291960` block is a block at
+          # which the wallet used in tests (`testertesting.eth`) had the two
+          # assets used in e2e tests.
+          FORKING_BLOCK: 18291960
         run: |
           cd ci
           yarn install
@@ -278,4 +278,4 @@ jobs:
         if: always()
         with:
           path: ci/cache
-          key: hardhat-17094516-${{ github.ref_name }}-${{ hashFiles('ci/cache/**/*.json') }}
+          key: hardhat-18291960-${{ github.ref_name }}-${{ hashFiles('ci/cache/**/*.json') }}

--- a/e2e-tests/fork-based/transactions.spec.ts
+++ b/e2e-tests/fork-based/transactions.spec.ts
@@ -33,7 +33,7 @@ test.describe("Transactions", () => {
        */
       const ethAsset = popup.locator(".asset_list_item").first() // We use `.first()` because the base asset should be first on the list
       await expect(ethAsset.getByText(/^ETH$/)).toBeVisible()
-      await expect(ethAsset.getByText(/^0\.(1|1021)$/)).toBeVisible()
+      await expect(ethAsset.getByText(/^0\.0386$/)).toBeVisible()
       await expect(ethAsset.getByText(/^\$(0|\d+\.\d{2})$/)).toBeVisible()
       await ethAsset.locator(".asset_icon_send").click({ trial: true })
       await ethAsset.locator(".asset_icon_swap").click({ trial: true })
@@ -54,7 +54,7 @@ test.describe("Transactions", () => {
         /^Ethereum$/,
         account2.name,
         "ETH",
-        "0\\.1021",
+        "0\\.0386",
         true,
       )
 
@@ -121,7 +121,7 @@ test.describe("Transactions", () => {
         /^Ethereum$/,
         account2.name,
         /^ETH$/,
-        /^0\.0914$/,
+        /^0\.0284$/,
         "base",
       )
       // This is what we expect currently on forked network. If ve ever fix
@@ -202,37 +202,37 @@ test.describe("Transactions", () => {
       await walletPageHelper.assertAnalyticsBanner()
 
       /**
-       * Verify KEEP is visible on the asset list and has the correct balance
+       * Verify DAI is visible on the asset list and has the correct balance
        */
-      const keepAsset = popup
+      const daiAsset = popup
         .locator(".asset_list_item")
-        .filter({ has: popup.locator("span").filter({ hasText: /^KEEP$/ }) })
-      await expect(keepAsset.getByText(/^65\.88$/)).toBeVisible({
+        .filter({ has: popup.locator("span").filter({ hasText: /^DAI$/ }) })
+      await expect(daiAsset.getByText(/^2\.62$/)).toBeVisible({
         timeout: 120000,
       })
-      await expect(keepAsset.getByText(/^\$\d+\.\d{2}$/)).toBeVisible({
+      await expect(daiAsset.getByText(/^\$\d+\.\d{2}$/)).toBeVisible({
         timeout: 120000,
       })
-      await keepAsset.locator(".asset_icon_send").click({ trial: true })
-      await keepAsset.locator(".asset_icon_swap").click({ trial: true })
+      await daiAsset.locator(".asset_icon_send").click({ trial: true })
+      await daiAsset.locator(".asset_icon_swap").click({ trial: true })
 
       /**
        * Click on the Send button (from asset list)
        */
-      await keepAsset.locator(".asset_icon_send").click()
+      await daiAsset.locator(".asset_icon_send").click()
     })
 
     await test.step("Setup transaction", async () => {
       /**
-       * Check if "Send asset" has opened on Ethereum network, with KEEP asset
+       * Check if "Send asset" has opened on Ethereum network, with DAI asset
        * already selected. Verify elements on the page. Make sure `Continue`
        * isn't active.
        */
       await transactionsHelper.assertUnfilledSendAssetScreen(
         /^Ethereum$/,
         account2.name,
-        "KEEP",
-        "65\\.88",
+        "DAI",
+        "2\\.62",
         false,
       )
 
@@ -270,7 +270,7 @@ test.describe("Transactions", () => {
         "0x47745a7252e119431ccf973c0ebd4279638875a6",
         "0x4774…875a6",
         "1\\.25",
-        "KEEP",
+        "DAI",
         false,
       )
 
@@ -298,10 +298,10 @@ test.describe("Transactions", () => {
       await assetsHelper.assertAssetDetailsPage(
         /^Ethereum$/,
         account2.name,
-        /^KEEP$/,
-        /^65\.88$/,
+        /^DAI$/,
+        /^2\.62$/,
         "knownERC20",
-        "https://etherscan.io/token/0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
+        "https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f",
       )
       // This is what we expect currently on a forked network.
       await expect(
@@ -343,19 +343,19 @@ test.describe("Transactions", () => {
       await walletPageHelper.assertAnalyticsBanner()
 
       /**
-       * Verify KEEP is visible on the asset list and has the correct balance
+       * Verify DAI is visible on the asset list and has the correct balance
        */
-      const keepAsset = popup
+      const daiAsset = popup
         .locator("div.asset_list_item")
-        .filter({ has: popup.locator("span").filter({ hasText: /^KEEP$/ }) })
-      await expect(keepAsset.getByText(/^65\.88$/)).toBeVisible({
+        .filter({ has: popup.locator("span").filter({ hasText: /^DAI$/ }) })
+      await expect(daiAsset.getByText(/^2\.62$/)).toBeVisible({
         timeout: 120000,
       })
-      await expect(keepAsset.getByText(/^\$\d+\.\d{2}$/)).toBeVisible({
+      await expect(daiAsset.getByText(/^\$\d+\.\d{2}$/)).toBeVisible({
         timeout: 120000,
       })
-      await keepAsset.locator(".asset_icon_send").click({ trial: true })
-      await keepAsset.locator(".asset_icon_swap").click({ trial: true })
+      await daiAsset.locator(".asset_icon_send").click({ trial: true })
+      await daiAsset.locator(".asset_icon_swap").click({ trial: true })
 
       /**
        * Click on the Send button (from header)
@@ -378,7 +378,7 @@ test.describe("Transactions", () => {
       )
 
       /**
-       *  Click on the tokens selector and pick ERC-20 token (KEEP)
+       *  Click on the tokens selector and pick ERC-20 token (DAI)
        */
       await popup.getByTestId("selected_asset_button").click()
       await expect(popup.getByText(/^Select token$/)).toBeVisible()
@@ -394,34 +394,30 @@ test.describe("Transactions", () => {
       await expect(ethToken.locator(".icon")).toHaveCount(0)
 
       /**
-       *  Verify ERC-20 token (KEEP) is present on the list
+       *  Verify ERC-20 token (DAI) is present on the list
        */
-      const keepToken = await popup
+      const daiToken = await popup
         .locator(".token_group")
-        .filter({ has: popup.locator("div").filter({ hasText: /^KEEP$/ }) })
-      await expect(
-        keepToken.getByText(/^(KeepToken|Keep Network( Token)?)$/),
-      ).toBeVisible()
-      await expect(keepToken.getByText(/^65\.88$/)).toBeVisible()
-      await expect(keepToken.locator(".icon")).toBeVisible()
-      await keepToken.locator(".icon").click({ trial: true }) // TODO: click and verify if correct address is opened
+        .filter({ has: popup.locator("div").filter({ hasText: /^DAI$/ }) })
+      await expect(daiToken.getByText(/^Dai$/)).toBeVisible()
+      await expect(daiToken.getByText(/^2\.62$/)).toBeVisible()
+      await expect(daiToken.locator(".icon")).toBeVisible()
+      await daiToken.locator(".icon").click({ trial: true }) // TODO: click and verify if correct address is opened
 
       /**
-       *  Filter by `keep` and verify that only KEEP token is present
+       *  Filter by `dai` and verify that only DAI token is present
        */
-      await popup.getByPlaceholder("Search by name or address").fill("keep")
-      await expect(
-        keepToken.getByText(/^(KeepToken|Keep Network( Token)?)$/),
-      ).toBeVisible()
-      await expect(keepToken.getByText(/^65\.88$/)).toBeVisible()
-      await expect(keepToken.locator(".icon")).toBeVisible()
-      await keepToken.locator(".icon").click({ trial: true })
-      await expect(popup.locator(".token_group")).toHaveCount(1)
+      await popup.getByPlaceholder("Search by name or address").fill("dai")
+      await expect(daiToken.getByText(/^Dai$/)).toBeVisible()
+      await expect(daiToken.getByText(/^2\.62$/)).toBeVisible()
+      await expect(daiToken.locator(".icon")).toBeVisible()
+      await daiToken.locator(".icon").click({ trial: true })
+      await expect(popup.locator(".token_group")).toHaveCount(2) // On a forked environment the asset list shows `DAI` and `UNIDAIETH`.
 
       /**
-       *  Select KEEP token
+       *  Select DAI token
        */
-      await keepToken.click()
+      await daiToken.click()
 
       /**
        *  Verify elements on the page after selecting token. Make sure
@@ -430,15 +426,15 @@ test.describe("Transactions", () => {
       await transactionsHelper.assertUnfilledSendAssetScreen(
         /^Ethereum$/,
         account2.name,
-        "KEEP",
-        "65\\.88",
+        "DAI",
+        "2\\.62",
         false,
       )
 
       /**
        *  Enter amount and receipient. Verify `Continue` isn't active.
        */
-      await popup.getByPlaceholder(/^0\.0$/).fill("12.3456")
+      await popup.getByPlaceholder(/^0\.0$/).fill("1.3456")
       await expect(
         popup.locator(".value").getByText(/^\$\d+\.\d{2}$/),
       ).toBeVisible()
@@ -468,8 +464,8 @@ test.describe("Transactions", () => {
         "testertesting\\.eth",
         "0x47745a7252e119431ccf973c0ebd4279638875a6",
         "0x4774…875a6",
-        "12\\.34",
-        "KEEP",
+        "1\\.34",
+        "DAI",
         false,
       )
 
@@ -497,10 +493,10 @@ test.describe("Transactions", () => {
       await assetsHelper.assertAssetDetailsPage(
         /^Ethereum$/,
         account2.name,
-        /^KEEP$/,
-        /^53\.54$/,
+        /^DAI$/,
+        /^1\.28$/,
         "knownERC20",
-        "https://etherscan.io/token/0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
+        "https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f",
       )
       // This is what we expect currently on forked network. If ve ever fix
       // displaying activity on fork, we should perform following checks

--- a/e2e-tests/regular/nfts.spec.ts
+++ b/e2e-tests/regular/nfts.spec.ts
@@ -241,7 +241,7 @@ test.describe("NFTs", () => {
         await poapPreview
           .getByRole("link", { name: "POAP" })
           .getAttribute("href"),
-      ).toEqual("https://app.poap.xyz/token/6676760")
+      ).toEqual("https://app.poap.xyz/token/6809595")
 
       // Description
       await expect(
@@ -254,7 +254,7 @@ test.describe("NFTs", () => {
       const poapTraits = poapPreview.getByTestId("nft_properties_list")
 
       await expect(poapTraits.getByText("Event")).toBeVisible()
-      await expect(poapTraits.getByTitle("Taho TEST POAP")).toBeVisible()
+      await expect(poapTraits.getByTitle("Taho TEST POAP 2")).toBeVisible()
       await expect(poapTraits.getByText("Year")).toBeVisible()
       await expect(poapTraits.getByText("2023")).toBeVisible()
 

--- a/e2e-tests/regular/token-trust.spec.ts
+++ b/e2e-tests/regular/token-trust.spec.ts
@@ -3,7 +3,7 @@ import { account1 } from "../utils/onboarding"
 
 // This test verifies functionalites of verified/unverified tokens using a
 // wallet address that control: `e2e.testertesting.eth`
-// (`0x6f1b1f1feb01235e15a7962f16c389c7f8218ed6`).
+// (`0x9d373acbe8540895fa1752ab463ab31bbab2b38f`).
 // The wallet at the moment of writing the test owns several trusted and
 // untrusted tokens. Changes to the types of the assets owned by the wallet may
 // influence the test results, so we should be careful when interacting with it.

--- a/e2e-tests/regular/transactions.spec.ts
+++ b/e2e-tests/regular/transactions.spec.ts
@@ -187,7 +187,7 @@ test.describe("Transactions", () => {
 
       await transactionsHelper.assertActivityItemProperties(
         account2.address,
-        "0x0581…20fc7",
+        "0x6e80…bb017",
         "0x47745A7252e119431CCF973c0eBD4279638875a6",
         "0x4774…875a6",
         /^0\.00001 ETH$/,
@@ -236,7 +236,7 @@ test.describe("Transactions", () => {
 
       await transactionsHelper.assertActivityItemProperties(
         account2.address,
-        "0x0581…20fc7",
+        "0x6e80…bb017",
         "0x47745A7252e119431CCF973c0eBD4279638875a6",
         "0x4774…875a6",
         /^0\.00001 ETH$/,

--- a/e2e-tests/utils/onboarding.ts
+++ b/e2e-tests/utils/onboarding.ts
@@ -32,7 +32,7 @@ export interface Account {
 // The account1 is a 3rd address associated with the testertesting.eth account.
 // It owns some NFTs/badges.
 export const account1: Account = {
-  address: "0x6f1b1f1feb01235e15a7962f16c389c7f8218ed6",
+  address: "0x9d373acbe8540895fa1752ab463ab31bbab2b38f",
   name: /^e2e\.testertesting\.eth$/,
   jsonBody: process.env.E2E_TEST_ONLY_WALLET_JSON_BODY,
   jsonPassword: process.env.E2E_TEST_ONLY_WALLET_JSON_PASSWORD,
@@ -41,7 +41,7 @@ export const account1: Account = {
 // testing, so it's balance may fluctuate. It can be used to test features that
 // don't depend on the constant balance or state of the assets.
 export const account2 = {
-  address: "0x0581470a8b62bd35dbf121a6329d43e7edd20fc7",
+  address: "0x6e80164ea60673d64d5d6228beb684a1274bb017",
   name: /^testertesting\.eth$/,
   jsonBody: process.env.TEST_WALLET_JSON_BODY,
   jsonPassword: process.env.TEST_WALLET_JSON_PASSWORD,


### PR DESCRIPTION
We've rotated the wallets used for testing of the extension and moved some of the assets. The GH secrets got already updated accordingly, we now need to update the addresses of wallets and change some other values used in tests, to fit the assets that we have on the new testing wallets. Changes include:
* switching of `e2e.testertesting.eth` wallet from `0x6f1b1f1feb01235e15a7962f16c389c7f8218ed6` to `0x9d373acbe8540895fa1752ab463ab31bbab2b38f`
* switching of `testertesting.eth` wallet from `0x0581470a8b62bd35dbf121a6329d43e7edd20fc7` to `0x6e80164ea60673d64d5d6228beb684a1274bb017`
* changing the POAP used in the NFTs tests
* changing the number of a forking block (the new testing wallet didn't have any assets yet on an old forking block) and switching to a different asset used in tests of ERC-20 transfers.

Latest build: [extension-builds-3639](https://github.com/tahowallet/extension/suites/17023094929/artifacts/972262600) (as of Mon, 09 Oct 2023 09:58:12 GMT).