### PR TITLE
Check connecting to dapp on different network after disconnecting

### DIFF
--- a/.github/workflows/test-list/release-test-list.md
+++ b/.github/workflows/test-list/release-test-list.md
@@ -237,7 +237,7 @@ This release checklist should be performed before release is published.
 
 - [ ] check `hide balance under $2` option
 - [ ] check bug reports - export logs
-- [ ] check connected dapp - confirm you are able to disconnect from a dapp
+- [ ] check connected dapp - confirm you are able to disconnect from a dapp and connect again on different network
 
 ### ☀️ Abilities
 


### PR DESCRIPTION
We change the release test list to add checking whether disconnecting from dapp via Settings and connecting again on different network is possible.

Latest build: [extension-builds-3654](https://github.com/tahowallet/extension/suites/17889924808/artifacts/1027337007) (as of Fri, 03 Nov 2023 17:15:48 GMT).