### PR TITLE
Do notify: Set up base NotificationService

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ to only rebuild the Firefox extension on change:
 $ yarn start --config-name firefox
 # On change, rebuild the firefox and brave extensions but not others.
 $ yarn start --config-name firefox --config-name brave
+# On change, rebuild the chrome
+$ yarn start --config-name chrome
 ```
 
 ### Note for some Linux distributions

--- a/background/main.ts
+++ b/background/main.ts
@@ -84,10 +84,9 @@ import {
   setShowAnalyticsNotification,
   setSelectedNetwork,
   setAutoLockInterval,
-  togglePushNotifications,
+  toggleNotifications,
   setShownDismissableItems,
   dismissableItemMarkedAsShown,
-  showPushNotifications,
 } from "./redux-slices/ui"
 import {
   estimatedFeesPerGas,
@@ -601,8 +600,6 @@ export default class Main extends BaseService<never> {
     })
 
     this.initializeRedux()
-
-    // shouldShowNotifications
   }
 
   protected override async internalStartService(): Promise<void> {
@@ -1862,7 +1859,7 @@ export default class Main extends BaseService<never> {
           await this.preferenceService.setShouldShowNotifications(
             shouldShowNotifications,
           )
-        this.store.dispatch(togglePushNotifications(isPermissionGranted))
+        this.store.dispatch(toggleNotifications(isPermissionGranted))
       },
     )
 
@@ -2049,10 +2046,6 @@ export default class Main extends BaseService<never> {
       if (port.name !== popupMonitorPortName) return
 
       const { ui } = this.store.getState()
-
-      if (ui.settings.showPushNotifications === undefined) {
-        this.store.dispatch(showPushNotifications(true))
-      }
 
       const openTime = Date.now()
 

--- a/background/main.ts
+++ b/background/main.ts
@@ -198,6 +198,7 @@ import { getPricePoint, getTokenPrices } from "./lib/prices"
 import { makeFlashbotsProviderCreator } from "./services/chain/serial-fallback-provider"
 import { AnalyticsPreferences, DismissableItem } from "./services/preferences"
 import { newPricePoints } from "./redux-slices/prices"
+import NotificationsService from "./services/notifications"
 
 // This sanitizer runs on store and action data before serializing for remote
 // redux devtools. The goal is to end up with an object that is directly
@@ -351,6 +352,11 @@ export default class Main extends BaseService<never> {
       ledgerService,
     )
 
+    const notificationsService = NotificationsService.create(
+      preferenceService,
+      islandService,
+    )
+
     const walletConnectService = isEnabled(FeatureFlags.SUPPORT_WALLET_CONNECT)
       ? WalletConnectService.create(
           providerBridgeService,
@@ -406,6 +412,7 @@ export default class Main extends BaseService<never> {
       await nftsService,
       await walletConnectService,
       await abilitiesService,
+      await notificationsService,
     )
   }
 
@@ -499,6 +506,11 @@ export default class Main extends BaseService<never> {
      * A promise to the Abilities service which takes care of fetching and storing abilities
      */
     private abilitiesService: AbilitiesService,
+
+    /**
+     * A promise to the Notifications service which takes care of observing and delivering notifications
+     */
+    private notificationsService: NotificationsService,
   ) {
     super({
       initialLoadWaitExpired: {
@@ -609,6 +621,7 @@ export default class Main extends BaseService<never> {
       this.nftsService.startService(),
       this.walletConnectService.startService(),
       this.abilitiesService.startService(),
+      this.notificationsService.startService(),
     ]
 
     await Promise.all(servicesToBeStarted)
@@ -632,6 +645,7 @@ export default class Main extends BaseService<never> {
       this.nftsService.stopService(),
       this.walletConnectService.stopService(),
       this.abilitiesService.stopService(),
+      this.notificationsService.stopService(),
     ]
 
     await Promise.all(servicesToBeStopped)
@@ -690,6 +704,9 @@ export default class Main extends BaseService<never> {
     signer: AccountSigner,
     lastAddressInAccount: boolean,
   ): Promise<void> {
+    // FIXME This whole method should be replaced with a call to
+    // FIXME signerService.removeAccount and an event emission that is
+    // FIXME observed by other services, either directly or indirectly.
     this.store.dispatch(deleteAccount(address))
 
     if (signer.type !== AccountType.ReadOnly && lastAddressInAccount) {

--- a/background/main.ts
+++ b/background/main.ts
@@ -87,6 +87,7 @@ import {
   togglePushNotifications,
   setShownDismissableItems,
   dismissableItemMarkedAsShown,
+  showPushNotifications,
 } from "./redux-slices/ui"
 import {
   estimatedFeesPerGas,
@@ -600,6 +601,8 @@ export default class Main extends BaseService<never> {
     })
 
     this.initializeRedux()
+
+    // shouldShowNotifications
   }
 
   protected override async internalStartService(): Promise<void> {
@@ -2045,14 +2048,18 @@ export default class Main extends BaseService<never> {
     runtime.onConnect.addListener((port) => {
       if (port.name !== popupMonitorPortName) return
 
+      const { ui } = this.store.getState()
+
+      if (ui.settings.showPushNotifications === undefined) {
+        this.store.dispatch(showPushNotifications(true))
+      }
+
       const openTime = Date.now()
 
-      const originalNetworkName =
-        this.store.getState().ui.selectedAccount.network.name
+      const originalNetworkName = ui.selectedAccount.network.name
 
       port.onDisconnect.addListener(() => {
-        const networkNameAtClose =
-          this.store.getState().ui.selectedAccount.network.name
+        const networkNameAtClose = ui.selectedAccount.network.name
         this.analyticsService.sendAnalyticsEvent(AnalyticsEvent.UI_SHOWN, {
           openTime: new Date(openTime).toISOString(),
           closeTime: new Date().toISOString(),

--- a/background/main.ts
+++ b/background/main.ts
@@ -1852,6 +1852,15 @@ export default class Main extends BaseService<never> {
     )
 
     uiSliceEmitter.on(
+      "showPushNotifications",
+      async (shouldShowNotifications: boolean) => {
+        await this.preferenceService.setShouldShowNotifications(
+          shouldShowNotifications,
+        )
+      },
+    )
+
+    uiSliceEmitter.on(
       "updateAnalyticsPreferences",
       async (analyticsPreferences: Partial<AnalyticsPreferences>) => {
         await this.preferenceService.updateAnalyticsPreferences(

--- a/background/main.ts
+++ b/background/main.ts
@@ -84,6 +84,7 @@ import {
   setShowAnalyticsNotification,
   setSelectedNetwork,
   setAutoLockInterval,
+  togglePushNotifications,
   setShownDismissableItems,
   dismissableItemMarkedAsShown,
 } from "./redux-slices/ui"
@@ -1852,11 +1853,13 @@ export default class Main extends BaseService<never> {
     )
 
     uiSliceEmitter.on(
-      "showPushNotifications",
+      "shouldShowNotifications",
       async (shouldShowNotifications: boolean) => {
-        await this.preferenceService.setShouldShowNotifications(
-          shouldShowNotifications,
-        )
+        const isPermissionGranted =
+          await this.preferenceService.setShouldShowNotifications(
+            shouldShowNotifications,
+          )
+        this.store.dispatch(togglePushNotifications(isPermissionGranted))
       },
     )
 

--- a/background/main.ts
+++ b/background/main.ts
@@ -2045,14 +2045,14 @@ export default class Main extends BaseService<never> {
     runtime.onConnect.addListener((port) => {
       if (port.name !== popupMonitorPortName) return
 
-      const { ui } = this.store.getState()
-
       const openTime = Date.now()
 
-      const originalNetworkName = ui.selectedAccount.network.name
+      const originalNetworkName =
+        this.store.getState().ui.selectedAccount.network.name
 
       port.onDisconnect.addListener(() => {
-        const networkNameAtClose = ui.selectedAccount.network.name
+        const networkNameAtClose =
+          this.store.getState().ui.selectedAccount.network.name
         this.analyticsService.sendAnalyticsEvent(AnalyticsEvent.UI_SHOWN, {
           openTime: new Date(openTime).toISOString(),
           closeTime: new Date().toISOString(),

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -16,7 +16,7 @@ export const defaultSettings = {
   hideDust: false,
   defaultWallet: false,
   showTestNetworks: false,
-  showPushNotifications: undefined,
+  showNotifications: undefined,
   collectAnalytics: false,
   showAnalyticsNotification: false,
   showUnverifiedAssets: false,
@@ -35,7 +35,7 @@ export type UIState = {
     hideDust: boolean
     defaultWallet: boolean
     showTestNetworks: boolean
-    showPushNotifications?: boolean
+    showNotifications?: boolean
     collectAnalytics: boolean
     showAnalyticsNotification: boolean
     showUnverifiedAssets: boolean
@@ -119,11 +119,11 @@ const uiSlice = createSlice({
         showAnalyticsNotification: false,
       },
     }),
-    togglePushNotifications: (
+    toggleNotifications: (
       immerState,
-      { payload: showPushNotifications }: { payload: boolean },
+      { payload: showNotifications }: { payload: boolean },
     ) => {
-      immerState.settings.showPushNotifications = showPushNotifications
+      immerState.settings.showNotifications = showNotifications
     },
     setShowAnalyticsNotification: (
       state,
@@ -235,7 +235,7 @@ export const {
   toggleUseFlashbots,
   setShowAnalyticsNotification,
   toggleHideBanners,
-  togglePushNotifications,
+  toggleNotifications,
   setSelectedAccount,
   setSnackbarMessage,
   setDefaultWallet,
@@ -259,8 +259,8 @@ export const updateAnalyticsPreferences = createBackgroundAsyncThunk(
   },
 )
 
-export const showPushNotifications = createBackgroundAsyncThunk(
-  "ui/showPushNotifications",
+export const showNotifications = createBackgroundAsyncThunk(
+  "ui/showNotifications",
   async (shouldShowNotifications: boolean) => {
     await emitter.emit("shouldShowNotifications", shouldShowNotifications)
   },
@@ -446,9 +446,9 @@ export const selectCollectAnalytics = createSelector(
   (settings) => settings?.collectAnalytics,
 )
 
-export const selectPushNotifications = createSelector(
+export const selectNotifications = createSelector(
   selectSettings,
-  (settings) => settings?.showPushNotifications,
+  (settings) => settings?.showNotifications,
 )
 
 export const selectHideBanners = createSelector(

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -4,11 +4,7 @@ import { AddressOnNetwork } from "../accounts"
 import { ETHEREUM } from "../constants"
 import { AnalyticsEvent, OneTimeAnalyticsEvent } from "../lib/posthog"
 import { EVMNetwork } from "../networks"
-import {
-  AnalyticsPreferences,
-  DismissableItem,
-  Preferences,
-} from "../services/preferences"
+import { AnalyticsPreferences, DismissableItem } from "../services/preferences"
 import { AccountSignerWithId } from "../signing"
 import { AccountSignerSettings } from "../ui"
 import { AccountState, addAddressNetwork } from "./accounts"
@@ -63,7 +59,7 @@ export type Events = {
   newSelectedAccountSwitched: AddressOnNetwork
   userActivityEncountered: AddressOnNetwork
   newSelectedNetwork: EVMNetwork
-  showPushNotifications: boolean
+  shouldShowNotifications: boolean
   updateAnalyticsPreferences: Partial<AnalyticsPreferences>
   addCustomNetworkResponse: [string, boolean]
   updateAutoLockInterval: number
@@ -123,7 +119,7 @@ const uiSlice = createSlice({
         showAnalyticsNotification: false,
       },
     }),
-    toggleShowPushNotifications: (
+    togglePushNotifications: (
       immerState,
       { payload: showPushNotifications }: { payload: boolean },
     ) => {
@@ -233,13 +229,13 @@ export const {
   setShowingActivityDetail,
   initializationLoadingTimeHitLimit,
   toggleHideDust,
-  toggleShowPushNotifications,
   toggleTestNetworks,
   toggleShowUnverifiedAssets,
   toggleCollectAnalytics,
   toggleUseFlashbots,
   setShowAnalyticsNotification,
   toggleHideBanners,
+  togglePushNotifications,
   setSelectedAccount,
   setSnackbarMessage,
   setDefaultWallet,
@@ -263,13 +259,10 @@ export const updateAnalyticsPreferences = createBackgroundAsyncThunk(
   },
 )
 
-export const togglePushNotifications = createBackgroundAsyncThunk(
-  "ui/showPushNotifications",
-  async (shouldShowPushNotifications: boolean, { dispatch }) => {
-    dispatch(
-      uiSlice.actions.toggleShowPushNotifications(shouldShowPushNotifications),
-    )
-    await emitter.emit("showPushNotifications", shouldShowPushNotifications)
+export const toggleShowPushNotifications = createBackgroundAsyncThunk(
+  "ui/shouldShowNotifications",
+  async (shouldShowNotifications: boolean) => {
+    await emitter.emit("shouldShowNotifications", shouldShowNotifications)
   },
 )
 

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -446,7 +446,7 @@ export const selectCollectAnalytics = createSelector(
   (settings) => settings?.collectAnalytics,
 )
 
-export const selectNotifications = createSelector(
+export const selectShowNotifications = createSelector(
   selectSettings,
   (settings) => settings?.showNotifications,
 )

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -259,7 +259,7 @@ export const updateAnalyticsPreferences = createBackgroundAsyncThunk(
   },
 )
 
-export const showNotifications = createBackgroundAsyncThunk(
+export const setShouldShowNotifications = createBackgroundAsyncThunk(
   "ui/showNotifications",
   async (shouldShowNotifications: boolean) => {
     await emitter.emit("shouldShowNotifications", shouldShowNotifications)

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -16,7 +16,7 @@ export const defaultSettings = {
   hideDust: false,
   defaultWallet: false,
   showTestNetworks: false,
-  showPushNotifications: false,
+  showPushNotifications: undefined,
   collectAnalytics: false,
   showAnalyticsNotification: false,
   showUnverifiedAssets: false,
@@ -35,7 +35,7 @@ export type UIState = {
     hideDust: boolean
     defaultWallet: boolean
     showTestNetworks: boolean
-    showPushNotifications: boolean
+    showPushNotifications?: boolean
     collectAnalytics: boolean
     showAnalyticsNotification: boolean
     showUnverifiedAssets: boolean
@@ -259,8 +259,8 @@ export const updateAnalyticsPreferences = createBackgroundAsyncThunk(
   },
 )
 
-export const toggleShowPushNotifications = createBackgroundAsyncThunk(
-  "ui/shouldShowNotifications",
+export const showPushNotifications = createBackgroundAsyncThunk(
+  "ui/showPushNotifications",
   async (shouldShowNotifications: boolean) => {
     await emitter.emit("shouldShowNotifications", shouldShowNotifications)
   },

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -4,7 +4,11 @@ import { AddressOnNetwork } from "../accounts"
 import { ETHEREUM } from "../constants"
 import { AnalyticsEvent, OneTimeAnalyticsEvent } from "../lib/posthog"
 import { EVMNetwork } from "../networks"
-import { AnalyticsPreferences, DismissableItem } from "../services/preferences"
+import {
+  AnalyticsPreferences,
+  DismissableItem,
+  Preferences,
+} from "../services/preferences"
 import { AccountSignerWithId } from "../signing"
 import { AccountSignerSettings } from "../ui"
 import { AccountState, addAddressNetwork } from "./accounts"
@@ -16,6 +20,7 @@ export const defaultSettings = {
   hideDust: false,
   defaultWallet: false,
   showTestNetworks: false,
+  showPushNotifications: false,
   collectAnalytics: false,
   showAnalyticsNotification: false,
   showUnverifiedAssets: false,
@@ -34,6 +39,7 @@ export type UIState = {
     hideDust: boolean
     defaultWallet: boolean
     showTestNetworks: boolean
+    showPushNotifications: boolean
     collectAnalytics: boolean
     showAnalyticsNotification: boolean
     showUnverifiedAssets: boolean
@@ -57,6 +63,7 @@ export type Events = {
   newSelectedAccountSwitched: AddressOnNetwork
   userActivityEncountered: AddressOnNetwork
   newSelectedNetwork: EVMNetwork
+  showPushNotifications: boolean
   updateAnalyticsPreferences: Partial<AnalyticsPreferences>
   addCustomNetworkResponse: [string, boolean]
   updateAutoLockInterval: number
@@ -116,6 +123,12 @@ const uiSlice = createSlice({
         showAnalyticsNotification: false,
       },
     }),
+    toggleShowPushNotifications: (
+      immerState,
+      { payload: showPushNotifications }: { payload: boolean },
+    ) => {
+      immerState.settings.showPushNotifications = showPushNotifications
+    },
     setShowAnalyticsNotification: (
       state,
       { payload: showAnalyticsNotification }: { payload: boolean },
@@ -220,6 +233,7 @@ export const {
   setShowingActivityDetail,
   initializationLoadingTimeHitLimit,
   toggleHideDust,
+  toggleShowPushNotifications,
   toggleTestNetworks,
   toggleShowUnverifiedAssets,
   toggleCollectAnalytics,
@@ -246,6 +260,16 @@ export const updateAnalyticsPreferences = createBackgroundAsyncThunk(
     await emitter.emit("updateAnalyticsPreferences", {
       isEnabled: collectAnalytics,
     })
+  },
+)
+
+export const togglePushNotifications = createBackgroundAsyncThunk(
+  "ui/showPushNotifications",
+  async (shouldShowPushNotifications: boolean, { dispatch }) => {
+    dispatch(
+      uiSlice.actions.toggleShowPushNotifications(shouldShowPushNotifications),
+    )
+    await emitter.emit("showPushNotifications", shouldShowPushNotifications)
   },
 )
 
@@ -427,6 +451,11 @@ export const selectShowUnverifiedAssets = createSelector(
 export const selectCollectAnalytics = createSelector(
   selectSettings,
   (settings) => settings?.collectAnalytics,
+)
+
+export const selectPushNotifications = createSelector(
+  selectSettings,
+  (settings) => settings?.showPushNotifications,
 )
 
 export const selectHideBanners = createSelector(

--- a/background/services/notifications/index.ts
+++ b/background/services/notifications/index.ts
@@ -31,12 +31,6 @@ export default class NotificationsService extends BaseService<Events> {
     [notificationId: string]: NotificationClickHandler
   } = {}
 
-  protected boundHandleNotificationClicks =
-    this.handleNotificationClicks.bind(this)
-
-  protected boundCleanUpNotificationClickHandler =
-    this.cleanUpNotificationClickHandler.bind(this)
-
   /*
    * Create a new NotificationsService. The service isn't initialized until
    * startService() is called and resolved.
@@ -58,6 +52,12 @@ export default class NotificationsService extends BaseService<Events> {
   protected override async internalStartService(): Promise<void> {
     await super.internalStartService()
 
+    const boundHandleNotificationClicks =
+      this.handleNotificationClicks.bind(this)
+
+    const boundCleanUpNotificationClickHandler =
+      this.cleanUpNotificationClickHandler.bind(this)
+
     // Preference and listener setup.
     // NOTE: Below, we assume if we got `shouldShowNotifications` as true, the
     // browser notifications permission has been granted. The preferences service
@@ -72,17 +72,17 @@ export default class NotificationsService extends BaseService<Events> {
         if (typeof browser !== "undefined") {
           if (isPermissionGranted) {
             browser.notifications.onClicked.addListener(
-              this.boundHandleNotificationClicks,
+              boundHandleNotificationClicks,
             )
             browser.notifications.onClosed.addListener(
-              this.boundCleanUpNotificationClickHandler,
+              boundCleanUpNotificationClickHandler,
             )
           } else {
             browser.notifications.onClicked.removeListener(
-              this.boundHandleNotificationClicks,
+              boundHandleNotificationClicks,
             )
             browser.notifications.onClosed.removeListener(
-              this.boundCleanUpNotificationClickHandler,
+              boundCleanUpNotificationClickHandler,
             )
           }
         }
@@ -90,11 +90,9 @@ export default class NotificationsService extends BaseService<Events> {
     )
 
     if (this.isPermissionGranted) {
-      browser.notifications.onClicked.addListener(
-        this.boundHandleNotificationClicks,
-      )
+      browser.notifications.onClicked.addListener(boundHandleNotificationClicks)
       browser.notifications.onClosed.addListener(
-        this.boundCleanUpNotificationClickHandler,
+        boundCleanUpNotificationClickHandler,
       )
     }
 

--- a/background/services/notifications/index.ts
+++ b/background/services/notifications/index.ts
@@ -1,0 +1,154 @@
+import { uniqueId } from "lodash"
+import BaseService from "../base"
+import IslandService from "../island"
+import PreferenceService from "../preferences"
+import { ServiceCreatorFunction, ServiceLifecycleEvents } from "../types"
+
+type Events = ServiceLifecycleEvents & {
+  notificationDisplayed: string
+  notificationSuppressed: string
+}
+
+type NotificationClickHandler = (() => Promise<void>) | (() => void)
+
+/**
+ * The NotificationService manages all notifications for the extension. It is
+ * charged both with managing the actual notification lifecycle (notification
+ * delivery, dismissal, and reaction to clicks) and delivery (i.e., responding
+ * to user preferences to deliver vs not deliver notifications), but also is
+ * charged with actually creating the notifications themselves.
+ *
+ * Adding a new notification should involve connecting the appropriate event in
+ * another service to a method in NotificationService that will generate the
+ * corresponding notification. In that way, the NotificationService is more part
+ * of the UI aspect of the extension than the background aspect, as it decides
+ * on and creates user-visible content directly.
+ */
+export default class NotificationsService extends BaseService<Events> {
+  private deliverNotifications = false
+
+  private clickHandlers: {
+    [notificationId: string]: NotificationClickHandler
+  } = {}
+
+  /*
+   * Create a new NotificationsService. The service isn't initialized until
+   * startService() is called and resolved.
+   */
+  static create: ServiceCreatorFunction<
+    Events,
+    NotificationsService,
+    [Promise<PreferenceService>, Promise<IslandService>]
+  > = async (preferenceService, islandService) =>
+    new this(await preferenceService, await islandService)
+
+  private constructor(
+    private preferenceService: PreferenceService,
+    private islandService: IslandService,
+  ) {
+    super()
+  }
+
+  protected override async internalStartService(): Promise<void> {
+    await super.internalStartService()
+
+    // Preference and listener setup.
+    // NOTE: Below, we assume if we got `shouldShowNotifications` as true, the
+    // browser notifications permission has been granted. The preferences service
+    // does guard this, but if that ends up not being true, browser.notifications
+    // will be undefined and all of this will explode.
+    this.deliverNotifications =
+      await this.preferenceService.getShouldShowNotifications()
+    this.preferenceService.emitter.on(
+      "updateShouldShowNotifications",
+      ({ shouldShowNotifications }) => {
+        this.deliverNotifications = shouldShowNotifications
+
+        if (shouldShowNotifications) {
+          browser.notifications.onClicked.addListener(
+            this.handleNotificationClicks.bind(this),
+          )
+          browser.notifications.onClosed.addListener(
+            this.cleanUpNotificationClickHandler.bind(this),
+          )
+        } else {
+          browser.notifications.onClicked.removeListener(
+            this.handleNotificationClicks.bind(this),
+          )
+          browser.notifications.onClosed.removeListener(
+            this.cleanUpNotificationClickHandler.bind(this),
+          )
+        }
+      },
+    )
+
+    if (this.deliverNotifications) {
+      browser.notifications.onClicked.addListener(
+        this.handleNotificationClicks.bind(this),
+      )
+      browser.notifications.onClosed.addListener(
+        this.cleanUpNotificationClickHandler.bind(this),
+      )
+    }
+
+    /*
+     * FIXME add below
+    this.islandService.emitter.on("xpDropped", this.notifyXpDrop.bind(this))
+    */
+  }
+
+  protected async notifyDrop(/* xpInfos: XpInfo[] */): Promise<void> {
+    this.notify("", "", "", () => {
+      browser.tabs.create({
+        url: "dapp url for realm claim, XpInfo must include realm id, ideally some way to communicate if the address is right as well",
+      })
+    })
+  }
+
+  // Fires the click handler for the given notification id.
+  protected handleNotificationClicks(notificationId: string): void {
+    this.clickHandlers?.[notificationId]()
+  }
+
+  // Clears the click handler for the given notification id.
+  protected cleanUpNotificationClickHandler(notificationId: string): void {
+    delete this.clickHandlers?.[notificationId]
+  }
+
+  /**
+   * Issues a notification with the given title, message, and context message.
+   * The click action, if specified, will be fired when the user clicks on the
+   * notification.
+   */
+  protected async notify(
+    title: string,
+    message: string,
+    contextMessage: string,
+    clickAction?: () => void,
+  ) {
+    if (!this.deliverNotifications) {
+      return
+    }
+
+    const notificationId = uniqueId("notification-")
+
+    if (typeof clickAction === "function") {
+      this.clickHandlers[notificationId] = clickAction
+
+      await browser.notifications.create(notificationId, {
+        type: "basic",
+        title: "",
+        message: "",
+        contextMessage: "",
+        isClickable: true,
+      })
+    } else {
+      await browser.notifications.create({
+        type: "basic",
+        title: "",
+        message: "",
+        contextMessage: "",
+      })
+    }
+  }
+}

--- a/background/services/notifications/index.ts
+++ b/background/services/notifications/index.ts
@@ -69,20 +69,22 @@ export default class NotificationsService extends BaseService<Events> {
     this.preferenceService.emitter.on(
       "setNotificationsPermission",
       (isPermissionGranted) => {
-        if (isPermissionGranted) {
-          browser.notifications.onClicked.addListener(
-            this.boundHandleNotificationClicks,
-          )
-          browser.notifications.onClosed.addListener(
-            this.boundCleanUpNotificationClickHandler,
-          )
-        } else {
-          browser.notifications.onClicked.removeListener(
-            this.boundHandleNotificationClicks,
-          )
-          browser.notifications.onClosed.removeListener(
-            this.boundCleanUpNotificationClickHandler,
-          )
+        if (typeof browser !== "undefined") {
+          if (isPermissionGranted) {
+            browser.notifications.onClicked.addListener(
+              this.boundHandleNotificationClicks,
+            )
+            browser.notifications.onClosed.addListener(
+              this.boundCleanUpNotificationClickHandler,
+            )
+          } else {
+            browser.notifications.onClicked.removeListener(
+              this.boundHandleNotificationClicks,
+            )
+            browser.notifications.onClosed.removeListener(
+              this.boundCleanUpNotificationClickHandler,
+            )
+          }
         }
       },
     )

--- a/background/services/notifications/index.ts
+++ b/background/services/notifications/index.ts
@@ -31,6 +31,12 @@ export default class NotificationsService extends BaseService<Events> {
     [notificationId: string]: NotificationClickHandler
   } = {}
 
+  protected boundHandleNotificationClicks =
+    this.handleNotificationClicks.bind(this)
+
+  protected boundCleanUpNotificationClickHandler =
+    this.cleanUpNotificationClickHandler.bind(this)
+
   /*
    * Create a new NotificationsService. The service isn't initialized until
    * startService() is called and resolved.
@@ -65,17 +71,17 @@ export default class NotificationsService extends BaseService<Events> {
       (isPermissionGranted) => {
         if (isPermissionGranted) {
           browser.notifications.onClicked.addListener(
-            this.handleNotificationClicks.bind(this),
+            this.boundHandleNotificationClicks,
           )
           browser.notifications.onClosed.addListener(
-            this.cleanUpNotificationClickHandler.bind(this),
+            this.boundCleanUpNotificationClickHandler,
           )
         } else {
           browser.notifications.onClicked.removeListener(
-            this.handleNotificationClicks.bind(this),
+            this.boundHandleNotificationClicks,
           )
           browser.notifications.onClosed.removeListener(
-            this.cleanUpNotificationClickHandler.bind(this),
+            this.boundCleanUpNotificationClickHandler,
           )
         }
       },
@@ -83,10 +89,10 @@ export default class NotificationsService extends BaseService<Events> {
 
     if (this.isPermissionGranted) {
       browser.notifications.onClicked.addListener(
-        this.handleNotificationClicks.bind(this),
+        this.boundHandleNotificationClicks,
       )
       browser.notifications.onClosed.addListener(
-        this.cleanUpNotificationClickHandler.bind(this),
+        this.boundCleanUpNotificationClickHandler,
       )
     }
 
@@ -96,14 +102,15 @@ export default class NotificationsService extends BaseService<Events> {
     */
   }
 
-  protected async notifyDrop(/* xpInfos: XpInfo[] */): Promise<void> {
-    const callback = () => {
-      browser.tabs.create({
-        url: "dapp url for realm claim, XpInfo must include realm id, ideally some way to communicate if the address is right as well",
-      })
-    }
-    this.pushNotification({ callback })
-  }
+  // TODO: uncomment when the XP drop is ready
+  // protected async notifyDrop(/* xpInfos: XpInfo[] */): Promise<void> {
+  //   const callback = () => {
+  //     browser.tabs.create({
+  //       url: "dapp url for realm claim, XpInfo must include realm id, ideally some way to communicate if the address is right as well",
+  //     })
+  //   }
+  //   this.notify({ callback })
+  // }
 
   // Fires the click handler for the given notification id.
   protected handleNotificationClicks(notificationId: string): void {
@@ -120,7 +127,7 @@ export default class NotificationsService extends BaseService<Events> {
    * The click action, if specified, will be fired when the user clicks on the
    * notification.
    */
-  protected async pushNotification({
+  protected async notify({
     title = "",
     message = "",
     contextMessage = "",

--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -64,6 +64,7 @@ export type Preferences = {
   accountSignersSettings: AccountSignerSettings[]
   analytics: AnalyticsPreferences
   autoLockInterval: UNIXTime
+  shouldShowNotifications: boolean
 }
 
 /**
@@ -423,6 +424,16 @@ export class PreferenceDatabase extends Dexie {
         }),
     )
 
+    // Add default notifications and set as default off.
+    this.version(21).upgrade((tx) =>
+      tx
+        .table("preferences")
+        .toCollection()
+        .modify((storedPreferences: Omit<Preferences, "showNotifications">) => {
+          Object.assign(storedPreferences, { showNotifications: false })
+        }),
+    )
+
     // This is the old version for populate
     // https://dexie.org/docs/Dexie/Dexie.on.populate-(old-version)
     // The this does not behave according the new docs, but works
@@ -447,6 +458,18 @@ export class PreferenceDatabase extends Dexie {
       .toCollection()
       .modify((storedPreferences: Preferences) => {
         const update: Partial<Preferences> = { autoLockInterval: newValue }
+
+        Object.assign(storedPreferences, update)
+      })
+  }
+
+  async setShouldShowNotifications(newValue: boolean): Promise<void> {
+    await this.preferences
+      .toCollection()
+      .modify((storedPreferences: Preferences) => {
+        const update: Partial<Preferences> = {
+          shouldShowNotifications: newValue,
+        }
 
         Object.assign(storedPreferences, update)
       })

--- a/background/services/preferences/defaults.ts
+++ b/background/services/preferences/defaults.ts
@@ -34,6 +34,7 @@ const defaultPreferences = {
     hasDefaultOnBeenTurnedOn: false,
   },
   autoLockInterval: DEFAULT_AUTOLOCK_INTERVAL,
+  shouldShowNotifications: false,
 }
 
 export default defaultPreferences

--- a/background/services/preferences/index.ts
+++ b/background/services/preferences/index.ts
@@ -17,7 +17,6 @@ import { EVMNetwork, sameNetwork } from "../../networks"
 import { HexString, UNIXTime } from "../../types"
 import { AccountSignerSettings } from "../../ui"
 import { AccountSignerWithId } from "../../signing"
-import logger from "../../lib/logger"
 
 export {
   AnalyticsPreferences,
@@ -277,17 +276,12 @@ export default class PreferenceService extends BaseService<Events> {
           {
             permissions: ["notifications"],
           },
-          async (granted) => {
+          (granted) => {
             resolve(granted)
           },
         )
       } else {
-        chrome.permissions.remove(
-          { permissions: ["notifications"] },
-          async (removed) => {
-            resolve(!removed)
-          },
-        )
+        resolve(false)
       }
     })
 

--- a/background/services/preferences/index.ts
+++ b/background/services/preferences/index.ts
@@ -17,6 +17,7 @@ import { EVMNetwork, sameNetwork } from "../../networks"
 import { HexString, UNIXTime } from "../../types"
 import { AccountSignerSettings } from "../../ui"
 import { AccountSignerWithId } from "../../signing"
+import logger from "../../lib/logger"
 
 export {
   AnalyticsPreferences,

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -33,6 +33,7 @@
     "default_popup": "popup.html"
   },
   "permissions": ["alarms", "storage", "unlimitedStorage", "activeTab"],
+  "optional_permissions": ["notifications"],
   "background": {
     "persistent": true,
     "scripts": ["background.js", "background-ui.js"]

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -559,7 +559,7 @@
     },
     "mainMenu": "Settings",
     "signing": "Signing",
-    "showPushNotifications": "Show notifications",
+    "showNotifications": "Show Subscape notifications",
     "hideSmallAssetBalance": "Hide asset balances under {{sign}}{{amount}}",
     "setAsDefault": "Use Taho as default wallet",
     "enableTestNetworks": "Show testnet networks",

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -559,6 +559,7 @@
     },
     "mainMenu": "Settings",
     "signing": "Signing",
+    "showPushNotifications": "Show notifications",
     "hideSmallAssetBalance": "Hide asset balances under {{sign}}{{amount}}",
     "setAsDefault": "Use Taho as default wallet",
     "enableTestNetworks": "Show testnet networks",

--- a/ui/components/Wallet/Banner/PortalBanner.tsx
+++ b/ui/components/Wallet/Banner/PortalBanner.tsx
@@ -13,7 +13,6 @@ export default function PortalBanner(): ReactElement | null {
   const hasIslandAssets = useBackgroundSelector(selectHasIslandAssets)
 
   const showIslandAndDismissBanner = () => {
-    browser.permissions.request({ permissions: ["notifications"] })
     browser.tabs.create({ url: "https://app.taho.xyz" })
   }
 

--- a/ui/components/Wallet/Banner/PortalBanner.tsx
+++ b/ui/components/Wallet/Banner/PortalBanner.tsx
@@ -13,6 +13,7 @@ export default function PortalBanner(): ReactElement | null {
   const hasIslandAssets = useBackgroundSelector(selectHasIslandAssets)
 
   const showIslandAndDismissBanner = () => {
+    browser.permissions.request({ permissions: ["notifications"] })
     browser.tabs.create({ url: "https://app.taho.xyz" })
   }
 

--- a/ui/components/Wallet/WalletSubscapeLink.tsx
+++ b/ui/components/Wallet/WalletSubscapeLink.tsx
@@ -3,7 +3,7 @@ import classNames from "classnames"
 import { useDispatch, useSelector } from "react-redux"
 import {
   selectShowNotifications,
-  showNotifications,
+  setShouldShowNotifications,
 } from "@tallyho/tally-background/redux-slices/ui"
 import SharedIcon from "../Shared/SharedIcon"
 
@@ -14,7 +14,7 @@ export default function WalletSubspaceLink(): ReactElement {
 
   const onClick = () => {
     if (!shouldShowNotifications) {
-      dispatch(showNotifications(true))
+      dispatch(setShouldShowNotifications(true))
     }
 
     window.open("https://app.taho.xyz/", "_blank")?.focus()

--- a/ui/components/Wallet/WalletSubscapeLink.tsx
+++ b/ui/components/Wallet/WalletSubscapeLink.tsx
@@ -2,14 +2,14 @@ import React, { ReactElement, useState } from "react"
 import classNames from "classnames"
 import { useDispatch, useSelector } from "react-redux"
 import {
-  selectNotifications,
+  selectShowNotifications,
   showNotifications,
 } from "@tallyho/tally-background/redux-slices/ui"
 import SharedIcon from "../Shared/SharedIcon"
 
 export default function WalletSubspaceLink(): ReactElement {
   const dispatch = useDispatch()
-  const shouldShowNotifications = useSelector(selectNotifications)
+  const shouldShowNotifications = useSelector(selectShowNotifications)
   const [isIconOnly, setIsIconOnly] = useState(true)
 
   const onClick = () => {

--- a/ui/components/Wallet/WalletSubscapeLink.tsx
+++ b/ui/components/Wallet/WalletSubscapeLink.tsx
@@ -1,17 +1,30 @@
 import React, { ReactElement, useState } from "react"
 import classNames from "classnames"
+import { useDispatch, useSelector } from "react-redux"
+import {
+  selectNotifications,
+  showNotifications,
+} from "@tallyho/tally-background/redux-slices/ui"
 import SharedIcon from "../Shared/SharedIcon"
 
 export default function WalletSubspaceLink(): ReactElement {
+  const dispatch = useDispatch()
+  const shouldShowNotifications = useSelector(selectNotifications)
   const [isIconOnly, setIsIconOnly] = useState(true)
+
+  const onClick = () => {
+    if (!shouldShowNotifications) {
+      dispatch(showNotifications(true))
+    }
+
+    window.open("https://app.taho.xyz/", "_blank")?.focus()
+  }
 
   return (
     <button
       type="button"
       className={classNames("subscape_link", { icon_only: isIconOnly })}
-      onClick={() => {
-        window.open("https://app.taho.xyz/", "_blank")?.focus()
-      }}
+      onClick={onClick}
       onMouseEnter={() => setIsIconOnly(false)}
       onMouseLeave={() => setIsIconOnly(true)}
     >

--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -4,6 +4,8 @@ import { Trans, useTranslation } from "react-i18next"
 import {
   selectHideDust,
   toggleHideDust,
+  selectPushNotifications,
+  togglePushNotifications,
   selectShowTestNetworks,
   toggleTestNetworks,
   toggleHideBanners,
@@ -165,11 +167,16 @@ export default function Settings(): ReactElement {
   const hideBanners = useSelector(selectHideBanners)
   const showTestNetworks = useSelector(selectShowTestNetworks)
   const showUnverifiedAssets = useSelector(selectShowUnverifiedAssets)
+  const showPushNotifications = useSelector(selectPushNotifications)
   const useFlashbots = useSelector(selectUseFlashbots)
   const mainCurrencySign = useBackgroundSelector(selectMainCurrencySign)
 
   const toggleHideDustAssets = (toggleValue: boolean) => {
     dispatch(toggleHideDust(toggleValue))
+  }
+
+  const toggleShowPushNotifications = (toggleValue: boolean) => {
+    dispatch(togglePushNotifications(toggleValue))
   }
 
   const toggleShowTestNetworks = (defaultWalletValue: boolean) => {
@@ -211,6 +218,16 @@ export default function Settings(): ReactElement {
       <SharedToggleButton
         onChange={(toggleValue) => toggleShowUnverified(toggleValue)}
         value={showUnverifiedAssets}
+      />
+    ),
+  }
+
+  const pushNotifications = {
+    title: t("settings.showPushNotifications"),
+    component: () => (
+      <SharedToggleButton
+        onChange={(toggleValue) => toggleShowPushNotifications(toggleValue)}
+        value={showPushNotifications}
       />
     ),
   }
@@ -400,6 +417,7 @@ export default function Settings(): ReactElement {
     walletOptions: {
       title: t("settings.group.walletOptions"),
       items: [
+        pushNotifications,
         hideSmallAssetBalance,
         unverifiedAssets,
         customNetworks,

--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -5,7 +5,7 @@ import {
   selectHideDust,
   toggleHideDust,
   selectPushNotifications,
-  toggleShowPushNotifications,
+  showPushNotifications,
   selectShowTestNetworks,
   toggleTestNetworks,
   toggleHideBanners,
@@ -167,7 +167,7 @@ export default function Settings(): ReactElement {
   const hideBanners = useSelector(selectHideBanners)
   const showTestNetworks = useSelector(selectShowTestNetworks)
   const showUnverifiedAssets = useSelector(selectShowUnverifiedAssets)
-  const showPushNotifications = useSelector(selectPushNotifications)
+  const shouldShowPushNotifications = useSelector(selectPushNotifications)
   const useFlashbots = useSelector(selectUseFlashbots)
   const mainCurrencySign = useBackgroundSelector(selectMainCurrencySign)
 
@@ -176,7 +176,7 @@ export default function Settings(): ReactElement {
   }
 
   const togglePushNotifications = (toggleValue: boolean) => {
-    dispatch(toggleShowPushNotifications(toggleValue))
+    dispatch(showPushNotifications(toggleValue))
   }
 
   const toggleShowTestNetworks = (defaultWalletValue: boolean) => {
@@ -227,7 +227,7 @@ export default function Settings(): ReactElement {
     component: () => (
       <SharedToggleButton
         onChange={(toggleValue) => togglePushNotifications(toggleValue)}
-        value={showPushNotifications}
+        value={shouldShowPushNotifications}
       />
     ),
   }

--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -4,8 +4,8 @@ import { Trans, useTranslation } from "react-i18next"
 import {
   selectHideDust,
   toggleHideDust,
-  selectPushNotifications,
-  showPushNotifications,
+  selectNotifications,
+  showNotifications,
   selectShowTestNetworks,
   toggleTestNetworks,
   toggleHideBanners,
@@ -167,7 +167,7 @@ export default function Settings(): ReactElement {
   const hideBanners = useSelector(selectHideBanners)
   const showTestNetworks = useSelector(selectShowTestNetworks)
   const showUnverifiedAssets = useSelector(selectShowUnverifiedAssets)
-  const shouldShowPushNotifications = useSelector(selectPushNotifications)
+  const shouldShowNotifications = useSelector(selectNotifications)
   const useFlashbots = useSelector(selectUseFlashbots)
   const mainCurrencySign = useBackgroundSelector(selectMainCurrencySign)
 
@@ -175,8 +175,8 @@ export default function Settings(): ReactElement {
     dispatch(toggleHideDust(toggleValue))
   }
 
-  const togglePushNotifications = (toggleValue: boolean) => {
-    dispatch(showPushNotifications(toggleValue))
+  const toggleNotifications = (toggleValue: boolean) => {
+    dispatch(showNotifications(toggleValue))
   }
 
   const toggleShowTestNetworks = (defaultWalletValue: boolean) => {
@@ -222,12 +222,12 @@ export default function Settings(): ReactElement {
     ),
   }
 
-  const pushNotifications = {
-    title: t("settings.showPushNotifications"),
+  const toggleShowNotifications = {
+    title: t("settings.showNotifications"),
     component: () => (
       <SharedToggleButton
-        onChange={(toggleValue) => togglePushNotifications(toggleValue)}
-        value={shouldShowPushNotifications}
+        onChange={(toggleValue) => toggleNotifications(toggleValue)}
+        value={shouldShowNotifications}
       />
     ),
   }
@@ -417,7 +417,7 @@ export default function Settings(): ReactElement {
     walletOptions: {
       title: t("settings.group.walletOptions"),
       items: [
-        pushNotifications,
+        toggleShowNotifications,
         hideSmallAssetBalance,
         unverifiedAssets,
         customNetworks,

--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -4,7 +4,7 @@ import { Trans, useTranslation } from "react-i18next"
 import {
   selectHideDust,
   toggleHideDust,
-  selectNotifications,
+  selectShowNotifications,
   showNotifications,
   selectShowTestNetworks,
   toggleTestNetworks,
@@ -167,7 +167,7 @@ export default function Settings(): ReactElement {
   const hideBanners = useSelector(selectHideBanners)
   const showTestNetworks = useSelector(selectShowTestNetworks)
   const showUnverifiedAssets = useSelector(selectShowUnverifiedAssets)
-  const shouldShowNotifications = useSelector(selectNotifications)
+  const shouldShowNotifications = useSelector(selectShowNotifications)
   const useFlashbots = useSelector(selectUseFlashbots)
   const mainCurrencySign = useBackgroundSelector(selectMainCurrencySign)
 

--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -5,7 +5,7 @@ import {
   selectHideDust,
   toggleHideDust,
   selectPushNotifications,
-  togglePushNotifications,
+  toggleShowPushNotifications,
   selectShowTestNetworks,
   toggleTestNetworks,
   toggleHideBanners,
@@ -175,8 +175,8 @@ export default function Settings(): ReactElement {
     dispatch(toggleHideDust(toggleValue))
   }
 
-  const toggleShowPushNotifications = (toggleValue: boolean) => {
-    dispatch(togglePushNotifications(toggleValue))
+  const togglePushNotifications = (toggleValue: boolean) => {
+    dispatch(toggleShowPushNotifications(toggleValue))
   }
 
   const toggleShowTestNetworks = (defaultWalletValue: boolean) => {
@@ -226,7 +226,7 @@ export default function Settings(): ReactElement {
     title: t("settings.showPushNotifications"),
     component: () => (
       <SharedToggleButton
-        onChange={(toggleValue) => toggleShowPushNotifications(toggleValue)}
+        onChange={(toggleValue) => togglePushNotifications(toggleValue)}
         value={showPushNotifications}
       />
     ),

--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -5,7 +5,7 @@ import {
   selectHideDust,
   toggleHideDust,
   selectShowNotifications,
-  showNotifications,
+  setShouldShowNotifications,
   selectShowTestNetworks,
   toggleTestNetworks,
   toggleHideBanners,
@@ -176,7 +176,7 @@ export default function Settings(): ReactElement {
   }
 
   const toggleNotifications = (toggleValue: boolean) => {
-    dispatch(showNotifications(toggleValue))
+    dispatch(setShouldShowNotifications(toggleValue))
   }
 
   const toggleShowTestNetworks = (defaultWalletValue: boolean) => {


### PR DESCRIPTION
This PR adds notification-related preference, service, optional manifest permission,
and code to request the permission on Subscape banner click.

More to come!


-------------
UPDATE: 11/20/23
PR is rebased with the main branch. Force push was required because of unverified commits.
To open a dialog window with a request notification you need to click the link hidden in the Subscape bubble.

The first push notification will be added in #3667

Latest build: [extension-builds-3666](https://github.com/tahowallet/extension/suites/18412947056/artifacts/1067032376) (as of Wed, 22 Nov 2023 13:41:33 GMT).