### PR TITLE
Add Subscape realms by adddress not name

### DIFF
--- a/background/services/island/contracts.ts
+++ b/background/services/island/contracts.ts
@@ -1930,12 +1930,14 @@ export const CLAIM_WITH_FRIENDS_ABI = [
   },
 ] as const
 
-export const STARTING_REALM_NAMES = [
-  "Creators",
-  "Defi",
-  "Educate",
-  "Social",
-  "Vampire",
+export const STARTING_REALM_ADDRESSES = [
+  "0xa5853ca1eac56bf78213b8300b695e7cfa563b4a",
+  "0x06894597d381542a55d2946e20117c29dbae2351",
+  "0xc92AF0c1f3111254b73eea97D803155b1E542Ee3",
+  "0x42a0b5cab976d7a2a0038138dd1279b96b73f029",
+  "0x26770639eB1262cfA47A4C3Aa27902fa8FCA3465",
+  "0x6a3d1d9a7eb615be82b5c50bba8c6ecc7606afe6",
+  "0xdc053c0beed726ee6316d4d04135d755466522c8",
 ]
 
 export function buildRealmContract(

--- a/background/services/island/index.ts
+++ b/background/services/island/index.ts
@@ -9,9 +9,8 @@ import { sameNetwork } from "../../networks"
 import {
   ClaimWithFriends,
   ISLAND_NETWORK,
-  STARTING_REALM_NAMES,
+  STARTING_REALM_ADDRESSES,
   TESTNET_TAHO,
-  TestnetTahoDeployer,
   buildRealmContract,
 } from "./contracts"
 import IndexingService from "../indexing"
@@ -108,16 +107,11 @@ export default class IslandService extends BaseService<Events> {
         this.emitter.emit("monitoringTestnetAsset", TESTNET_TAHO)
       }
 
-      const connectedDeployer = TestnetTahoDeployer.connect(islandProvider)
       await Promise.all(
-        STARTING_REALM_NAMES.map(async (realmName) => {
-          const realmAddress =
-            await connectedDeployer.functions[
-              `${realmName.toUpperCase()}_REALM`
-            ]()
-          const realmContract = buildRealmContract(realmAddress[0]).connect(
-            islandProvider,
-          )
+        STARTING_REALM_ADDRESSES.map(async (realmAddress) => {
+          const realmContract = buildRealmContract(
+            normalizeEVMAddress(realmAddress),
+          ).connect(islandProvider)
 
           const realmVeTahoAddress = (await realmContract.functions.veTaho())[0]
           const realmVeAsset =
@@ -134,7 +128,7 @@ export default class IslandService extends BaseService<Events> {
 
           if (realmXpAddress === ethers.constants.AddressZero) {
             logger.debug(
-              `XP token for realm ${realmName} at ${realmAddress} is not yet set, throwing an error to retry tracking later.`,
+              `XP token for realm at ${realmAddress} is not yet set, throwing an error to retry tracking later.`,
             )
 
             throw new Error(`XP token does not exist for realm ${realmAddress}`)


### PR DESCRIPTION
Resolves https://github.com/tahowallet/extension/issues/3693

### What

As we have new realms not pre-named in the protocol let's add them by addresses

### Testing

- [x] Make sure you can see XP and veTAHO of Base and zkSync realms as verified tokens

Latest build: [extension-builds-3695](https://github.com/tahowallet/extension/suites/18973789557/artifacts/1109219752) (as of Tue, 12 Dec 2023 13:43:30 GMT).