### PR TITLE
Fix removing custom networks

### DIFF
--- a/background/services/chain/db.ts
+++ b/background/services/chain/db.ts
@@ -292,6 +292,7 @@ export class ChainDatabase extends Dexie {
       this.baseAssets,
       this.rpcConfig,
       this.accountsToTrack,
+      this.customRpcConfig,
       async () => {
         await Promise.all([
           this.networks.where({ chainID }).delete(),


### PR DESCRIPTION
Resolves https://github.com/tahowallet/extension/issues/3685

### What

Add database transaction dependency to fix removing items from `customRpcConfig` table.

### Testing

- [x] add custom network
- [x] succesfully remove it

Latest build: [extension-builds-3699](https://github.com/tahowallet/extension/suites/19016838762/artifacts/1114194310) (as of Thu, 14 Dec 2023 09:34:36 GMT).