### PR TITLE
Disable listeners on realm contract

### DIFF
--- a/background/services/island/index.ts
+++ b/background/services/island/index.ts
@@ -142,9 +142,10 @@ export default class IslandService extends BaseService<Events> {
             )
           if (realmXpAsset !== undefined) {
             this.emitter.emit("monitoringTestnetAsset", realmXpAsset)
-            realmContract.on(realmContract.filters.XpDistributed(), () => {
-              this.checkXPDrop()
-            })
+            // TODO: disabled because it causes `eth_getLogs` to spam the RPC node
+            // realmContract.on(realmContract.filters.XpDistributed(), () => {
+            //   this.checkXPDrop()
+            // })
           }
         }),
       )


### PR DESCRIPTION
Listening on realm contracts causes `eth_getLogs` to spam RPC node. Let's disable for now to stop spamming Alchemy.

### Testing

- take a look at the prod extension - it is spamming `eth_getLogs` constantly
- check here - there is no more spam 
![image](https://github.com/tahowallet/extension/assets/20949277/2da229d6-ac54-4102-917d-2b33ba1d2c17)
