### PR TITLE
Check DevTools when executing tests on release testlist

### DIFF
--- a/.github/workflows/test-list/release-test-list.md
+++ b/.github/workflows/test-list/release-test-list.md
@@ -23,6 +23,13 @@ This release checklist should be performed before release is published.
 🤖 Items marked with this emoji are good candidates for automation (although
 it does not mean that they all would be obsolete once automated).
 
+### 📝 Background processes
+
+1. During execution of other tests on the list monitor extension's DevTools
+   - [ ] check that there are no problematic errors in the Console tab
+   - [ ] check the number of requests on the Network tab (the number shouldn't
+         increase significantly in periods of user inactivity)
+
 ### 📨 Add account
 
 1. Add read-only account with ENS


### PR DESCRIPTION
We want to make sure that during the release testing the tests are executed with an open DevTools window and that the logs and network traffic are monitored.

Latest build: [extension-builds-3704](https://github.com/tahowallet/extension/suites/19073390611/artifacts/1116830471) (as of Fri, 15 Dec 2023 09:04:07 GMT).