### PR TITLE
Prevent read-only address submission when validating input

### DIFF
--- a/ui/components/Shared/SharedAddressInput.tsx
+++ b/ui/components/Shared/SharedAddressInput.tsx
@@ -1,5 +1,11 @@
 import { HexString } from "@tallyho/tally-background/types"
-import React, { ReactElement, useEffect, useState } from "react"
+import React, {
+  Dispatch,
+  ReactElement,
+  SetStateAction,
+  useEffect,
+  useState,
+} from "react"
 import { useDelayContentChange } from "../../hooks"
 import { useAddressOrNameValidation } from "../../hooks/validation-hooks"
 
@@ -16,6 +22,7 @@ type Props = {
   id?: string
   placeholder?: string
   isEmpty?: boolean
+  setIsValidating?: Dispatch<SetStateAction<boolean>>
 }
 
 export default function SharedAddressInput({
@@ -26,6 +33,7 @@ export default function SharedAddressInput({
   id,
   placeholder,
   isEmpty,
+  setIsValidating,
 }: Props): ReactElement {
   const [inputValue, setInputValue] = useState(value ?? "")
   const debouncedValue = useDelayContentChange(
@@ -40,6 +48,12 @@ export default function SharedAddressInput({
   useEffect(() => {
     handleInputChange(debouncedValue)
   }, [debouncedValue, handleInputChange])
+
+  useEffect(() => {
+    if (setIsValidating !== undefined) {
+      setIsValidating(isValidating)
+    }
+  }, [setIsValidating, isValidating])
 
   return (
     <>

--- a/ui/components/Shared/SharedAddressInput.tsx
+++ b/ui/components/Shared/SharedAddressInput.tsx
@@ -1,11 +1,5 @@
 import { HexString } from "@tallyho/tally-background/types"
-import React, {
-  Dispatch,
-  ReactElement,
-  SetStateAction,
-  useEffect,
-  useState,
-} from "react"
+import React, { ReactElement, useEffect, useState } from "react"
 import { useDelayContentChange } from "../../hooks"
 import { useAddressOrNameValidation } from "../../hooks/validation-hooks"
 
@@ -19,10 +13,10 @@ type Props = {
     value: { address: HexString; name?: string } | undefined,
   ) => void
   onFocus?: () => void
+  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>
   id?: string
   placeholder?: string
   isEmpty?: boolean
-  setIsValidating?: Dispatch<SetStateAction<boolean>>
 }
 
 export default function SharedAddressInput({
@@ -30,10 +24,10 @@ export default function SharedAddressInput({
   label,
   onAddressChange,
   onFocus,
+  onKeyDown,
   id,
   placeholder,
   isEmpty,
-  setIsValidating,
 }: Props): ReactElement {
   const [inputValue, setInputValue] = useState(value ?? "")
   const debouncedValue = useDelayContentChange(
@@ -49,12 +43,6 @@ export default function SharedAddressInput({
     handleInputChange(debouncedValue)
   }, [debouncedValue, handleInputChange])
 
-  useEffect(() => {
-    if (setIsValidating !== undefined) {
-      setIsValidating(isValidating)
-    }
-  }, [setIsValidating, isValidating])
-
   return (
     <>
       <SharedInput
@@ -62,6 +50,7 @@ export default function SharedAddressInput({
         label={label}
         onChange={setInputValue}
         onFocus={onFocus}
+        onKeyDown={onKeyDown}
         errorMessage={errorMessage}
         id={id}
         placeholder={placeholder}

--- a/ui/components/Shared/SharedInput.tsx
+++ b/ui/components/Shared/SharedInput.tsx
@@ -14,6 +14,7 @@ interface Props<T> {
   value?: string | undefined
   onChange?: (value: T | undefined) => void
   onFocus?: () => void
+  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>
   errorMessage?: string
   warningMessage?: string
   autoFocus?: boolean
@@ -37,6 +38,7 @@ export function SharedTypedInput<T = string>(props: Props<T>): ReactElement {
     name,
     onChange,
     onFocus,
+    onKeyDown,
     value: currentValue,
     errorMessage,
     warningMessage,
@@ -92,6 +94,7 @@ export function SharedTypedInput<T = string>(props: Props<T>): ReactElement {
           handleInputChange(event.target.value)
         }
         onFocus={onFocus}
+        onKeyDown={onKeyDown}
         data-empty={inputValue.trim().length < 1}
         className={classNames({
           error: !isEmpty && (errorMessage ?? parserError !== undefined),

--- a/ui/pages/Onboarding/Tabbed/ViewOnlyWallet.tsx
+++ b/ui/pages/Onboarding/Tabbed/ViewOnlyWallet.tsx
@@ -21,8 +21,6 @@ export default function ViewOnlyWallet(): ReactElement {
     AddressOnNetwork | undefined
   >(undefined)
 
-  const [isValidating, setIsValidating] = useState(false)
-
   const { t } = useTranslation("translation", {
     keyPrefix: "onboarding.tabbed.addWallet.viewOnly",
   })
@@ -44,9 +42,7 @@ export default function ViewOnlyWallet(): ReactElement {
   )
 
   const handleSubmitViewOnlyAddress = useCallback(async () => {
-    if (addressOnNetwork === undefined || isValidating) {
-      return
-    }
+    if (addressOnNetwork === undefined) return
 
     await dispatch(addAddressNetwork(addressOnNetwork))
 
@@ -63,7 +59,23 @@ export default function ViewOnlyWallet(): ReactElement {
 
     dispatch(setNewSelectedAccount(addressOnNetwork))
     setRedirect(true)
-  }, [dispatch, addressOnNetwork, isValidating])
+  }, [dispatch, addressOnNetwork])
+
+  const handleFormSubmitOnEnter = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (event.key === "Enter") {
+      event.preventDefault()
+      handleSubmitViewOnlyAddress()
+    }
+  }
+
+  const handleFormSubmitOnClick = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => {
+    event.preventDefault()
+    handleSubmitViewOnlyAddress()
+  }
 
   // Redirect to the final onboarding tab once an account is set
   if (redirect) {
@@ -86,26 +98,20 @@ export default function ViewOnlyWallet(): ReactElement {
         </div>
       </header>
       <div className="content">
-        <form
-          onSubmit={(event) => {
-            event.preventDefault()
-            handleSubmitViewOnlyAddress()
-          }}
-        >
+        <form>
           <div className="input_wrap">
             <SharedAddressInput
               onAddressChange={handleNewAddress}
-              setIsValidating={setIsValidating}
+              onKeyDown={handleFormSubmitOnEnter}
             />
           </div>
           <SharedButton
             type="primary"
             size="large"
-            onClick={handleSubmitViewOnlyAddress}
+            onClick={handleFormSubmitOnClick}
             isDisabled={addressOnNetwork === undefined}
             showLoadingOnClick
             center
-            isFormSubmit
           >
             {t("submit")}
           </SharedButton>

--- a/ui/pages/Onboarding/Tabbed/ViewOnlyWallet.tsx
+++ b/ui/pages/Onboarding/Tabbed/ViewOnlyWallet.tsx
@@ -21,6 +21,8 @@ export default function ViewOnlyWallet(): ReactElement {
     AddressOnNetwork | undefined
   >(undefined)
 
+  const [isValidating, setIsValidating] = useState(false)
+
   const { t } = useTranslation("translation", {
     keyPrefix: "onboarding.tabbed.addWallet.viewOnly",
   })
@@ -42,7 +44,7 @@ export default function ViewOnlyWallet(): ReactElement {
   )
 
   const handleSubmitViewOnlyAddress = useCallback(async () => {
-    if (addressOnNetwork === undefined) {
+    if (addressOnNetwork === undefined || isValidating) {
       return
     }
 
@@ -61,7 +63,7 @@ export default function ViewOnlyWallet(): ReactElement {
 
     dispatch(setNewSelectedAccount(addressOnNetwork))
     setRedirect(true)
-  }, [dispatch, addressOnNetwork])
+  }, [dispatch, addressOnNetwork, isValidating])
 
   // Redirect to the final onboarding tab once an account is set
   if (redirect) {
@@ -91,7 +93,10 @@ export default function ViewOnlyWallet(): ReactElement {
           }}
         >
           <div className="input_wrap">
-            <SharedAddressInput onAddressChange={handleNewAddress} />
+            <SharedAddressInput
+              onAddressChange={handleNewAddress}
+              setIsValidating={setIsValidating}
+            />
           </div>
           <SharedButton
             type="primary"


### PR DESCRIPTION
Resolves #3686

## What has been done:
Refactored read-only wallet form, not to submit the form automatically - preventing the infinite loading spinner

## Testing
- [x] Enter invalid data and click on button - nothing happens
- [x] Enter invalid data and click Enter - nothing happens
- [x] Enter valid data and click on button - form submits
- [x] Enter invalid data and click Enter - form submits

Latest build: [extension-builds-3705](https://github.com/tahowallet/extension/suites/19134208688/artifacts/1121095791) (as of Mon, 18 Dec 2023 10:49:33 GMT).