### PR TITLE
Enable swaps on Sepolia testnet

### DIFF
--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -186,7 +186,7 @@ export const CHAIN_ID_TO_0X_API_BASE: {
   [POLYGON.chainID]: "polygon.api.0x.org",
   [OPTIMISM.chainID]: "optimism.api.0x.org",
   [GOERLI.chainID]: "goerli.api.0x.org",
-  // TODO: Add Swap API for Sepolia once 0x supports it.
+  [SEPOLIA.chainID]: "sepolia.api.0x.org",
   [ARBITRUM_ONE.chainID]: "arbitrum.api.0x.org",
   [AVALANCHE.chainID]: "avalanche.api.0x.org",
   [BINANCE_SMART_CHAIN.chainID]: "bsc.api.0x.org",


### PR DESCRIPTION
As Goerli testnets becomes deprecated with end of 2023, we've been migrating to another testnet - Sepolia. Up to this point we were not able to support swaps there, as 0x did not support Sepolia. But recently 0x created theAPI endpoint for Sepolia, so we're now able to use their services.
Read more: https://0x.org/docs/0x-swap-api/api-references/overview.

Tests:
- [x] Execute swap of a base asset on Ethereum Sepolia
- [x] Execute swap of an ERC-20 asset on Ethereum Sepolia
- [x] Make sure swaps are not available for Arbitrum Sepolia

Latest build: [extension-builds-3710](https://github.com/tahowallet/extension/suites/19134730944/artifacts/1121134638) (as of Mon, 18 Dec 2023 11:08:22 GMT).