### PR TITLE
Show wallet address after hovering on wallet name

### DIFF
--- a/ui/components/NFTs/Filters/FilterList.tsx
+++ b/ui/components/NFTs/Filters/FilterList.tsx
@@ -1,5 +1,7 @@
 import { Filter } from "@tallyho/tally-background/redux-slices/nfts"
-import React from "react"
+import React, { useCallback } from "react"
+import { setSnackbarMessage } from "@tallyho/tally-background/redux-slices/ui"
+import { useDispatch } from "react-redux"
 import SharedSkeletonLoader from "../../Shared/SharedSkeletonLoader"
 import SharedToggleItem from "../../Shared/SharedToggleItem"
 
@@ -7,6 +9,7 @@ const HEIGHT = 40
 
 type FilterListProps = {
   filters: Filter[]
+  isAccountFilter?: boolean
   onChange: (filter: Filter) => void
   isLoaded?: boolean
   emptyMessage?: string
@@ -17,11 +20,22 @@ const FilterList = React.forwardRef<HTMLDivElement, FilterListProps>(
   (props: FilterListProps, ref) => {
     const {
       filters,
+      isAccountFilter = false,
       isLoaded = true,
       onChange,
       emptyMessage,
       testid = "nft_filters_list",
     } = props
+
+    const dispatch = useDispatch()
+
+    const copyAddress = useCallback(
+      (address: string) => {
+        navigator.clipboard.writeText(address)
+        dispatch(setSnackbarMessage("Address copied to clipboard"))
+      },
+      [dispatch],
+    )
 
     return (
       <div ref={ref} className="filter_list" data-testid={testid}>
@@ -33,14 +47,31 @@ const FilterList = React.forwardRef<HTMLDivElement, FilterListProps>(
                 isLoaded={isLoaded}
                 height={HEIGHT}
               >
-                <SharedToggleItem
-                  label={item.name}
-                  thumbnailURL={item?.thumbnailURL}
-                  checked={item.isEnabled}
-                  onChange={(toggleValue) =>
-                    onChange({ ...item, isEnabled: toggleValue })
-                  }
-                />
+                {isAccountFilter ? (
+                  <button
+                    type="button"
+                    onClick={() => copyAddress(item.id)}
+                    title={`Copy to clipboard:\n${item.id}`}
+                  >
+                    <SharedToggleItem
+                      label={item.name}
+                      thumbnailURL={item?.thumbnailURL}
+                      checked={item.isEnabled}
+                      onChange={(toggleValue) =>
+                        onChange({ ...item, isEnabled: toggleValue })
+                      }
+                    />
+                  </button>
+                ) : (
+                  <SharedToggleItem
+                    label={item.name}
+                    thumbnailURL={item?.thumbnailURL}
+                    checked={item.isEnabled}
+                    onChange={(toggleValue) =>
+                      onChange({ ...item, isEnabled: toggleValue })
+                    }
+                  />
+                )}
               </SharedSkeletonLoader>
             ))}
           </>

--- a/ui/components/NFTs/Filters/NFTsFilters.tsx
+++ b/ui/components/NFTs/Filters/NFTsFilters.tsx
@@ -128,6 +128,7 @@ export default function NFTsFilters(): ReactElement {
           <span className="filter_title">{t("accountsTitle")}</span>
           <FilterList
             filters={filters.accounts}
+            isAccountFilter
             onChange={handleUpdateAccountFilter}
             testid="nft_account_filters"
           />


### PR DESCRIPTION
Resolves #3171 

## What has been done

- Show address to be copies in "Copy address" tooltip
- In filters on account list hover, show the truncated address (instead of ens/uns name)

## Testing
- [ ] Hover over item on accounts list in filters - address shows

![Zrzut ekranu 2023-12-19 o 11 29 19](https://github.com/tahowallet/extension/assets/73061939/6d74c95c-d4aa-4df9-9d68-09bc4f6f1efc)

Latest build: [extension-builds-3713](https://github.com/tahowallet/extension/suites/19199860149/artifacts/1128487044) (as of Thu, 21 Dec 2023 09:31:19 GMT).