### PR TITLE
Move action using node12 to a newer version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           POAP_API_KEY: ${{ secrets.POAP_API_KEY }}
           DAYLIGHT_API_KEY: ${{ secrets.DAYLIGHT_API_KEY }}
       - name: Create Release and Upload Artifacts
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: dist/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           POAP_API_KEY: ${{ secrets.POAP_API_KEY }}
           DAYLIGHT_API_KEY: ${{ secrets.DAYLIGHT_API_KEY }}
       - name: Create Release and Upload Artifacts
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564 # v2.0.4
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: dist/*.zip


### PR DESCRIPTION
Node12 has been out of support since April 2022. As a result GH has started the deprecation process of Node12 for GitHub Actions by migrating all actions to run on Node16 ([read
more](https://github.blog/changelog/2023-07-17-github-actions-removal-of-node12-from-the-actions-runner/)). The `softprops/action-gh-release` action's version which we used in the `build.yml` workflow was running on Node12. But a newer version (`v0.1.15`) of the action is run on Node16. We're swithing to using that newer version. This should make `The following actions uses node12 which is deprecated and will be forced to run on node16: softprops/action-gh-release@1e07f4...` annotation disappear from the details of the workflow runs.

The upgrade may also remove the `The "set-output" command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/` annotation.

Latest build: [extension-builds-3722](https://github.com/tahowallet/extension/suites/22731384889/artifacts/1411333659) (as of Sat, 13 Apr 2024 18:02:51 GMT).