### PR TITLE
Drop Arbirum Sepolia Alchemy support

### DIFF
--- a/background/services/chain/taho-provider.ts
+++ b/background/services/chain/taho-provider.ts
@@ -24,9 +24,6 @@ export default class TahoAlchemyProvider extends AlchemyProvider {
       case 11155111: // Ethereum Sepolia
         host = "eth-sepolia.g.alchemy.com/v2/"
         break
-      case 421614: // Arbitrum Sepolia
-        host = "arb-sepolia.g.alchemy.com/v2/"
-        break
       default:
         return AlchemyProvider.getUrl(network, apiKey)
     }


### PR DESCRIPTION
Due to eth_getLogs usage from Subscape XP drop monitoring, the Alchemy endpoint for Taho had to be blocked completely. After a release that removed the log monitoring, we were still seeing very high usage of eth_getLogs, indicating small numbers of older installs were still causing issues.

Here, we drop built-in Alchemy support for Taho. Instead, we use existing public RPCs to handle all requests. Because Alchemy was blanket blocking all RPC requests from Taho (due to the aforementioned eth_getLogs issue), transaction submission was completely blocked (because the serial fallback provider prefers Alchemy providers to all others when available). This new setup should allow for public RPCs to handle transaction submission (since there will no longer be an Alchemy provider) and thus unblock any trailing XP claims.

Latest build: [extension-builds-3726](https://github.com/tahowallet/extension/suites/19848797684/artifacts/1173937441) (as of Wed, 17 Jan 2024 01:24:05 GMT).