### PR TITLE
v0.56.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -51,6 +51,7 @@ body:
       label: Version
       description: What version of the extension are you running?
       options:
+        - v0.56.0
         - v0.55.0
         - v0.54.0
         - v0.53.1

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Taho",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "description": "The community owned and operated Web3 wallet.",
   "homepage_url": "https://taho.xyz",
   "author": "https://taho.xyz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tallyho/tally-extension",
   "private": true,
-  "version": "0.55.0",
+  "version": "0.56.0",
   "description": "Taho, the community owned and operated Web3 wallet.",
   "main": "index.js",
   "repository": "git@github.com:thesis/tally-extension.git",


### PR DESCRIPTION
## What's Changed
* v0.55.0 by @xpaczka in https://github.com/tahowallet/extension/pull/3720
* Drop Arbirum Sepolia Alchemy support by @Shadowfiend in https://github.com/tahowallet/extension/pull/3726
* Alchemy API key has changed to phase out the older API key that was having Arbitrum Sepolia load issues.


**Full Changelog**: https://github.com/tahowallet/extension/compare/v0.55.0...v0.56.0

Latest build: [extension-builds-3729](https://github.com/tahowallet/extension/suites/19956250425/artifacts/1182217763) (as of Fri, 19 Jan 2024 22:10:22 GMT).