### PR TITLE
v0.56.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -51,6 +51,7 @@ body:
       label: Version
       description: What version of the extension are you running?
       options:
+        - v0.56.1
         - v0.56.0
         - v0.55.0
         - v0.54.0

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Taho",
-  "version": "0.56.0",
+  "version": "0.56.1",
   "description": "The community owned and operated Web3 wallet.",
   "homepage_url": "https://taho.xyz",
   "author": "https://taho.xyz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tallyho/tally-extension",
   "private": true,
-  "version": "0.56.0",
+  "version": "0.56.1",
   "description": "Taho, the community owned and operated Web3 wallet.",
   "main": "index.js",
   "repository": "git@github.com:thesis/tally-extension.git",


### PR DESCRIPTION
## What's Changed
* v0.56.0 by @Shadowfiend in https://github.com/tahowallet/extension/pull/3729
* Drop Arbitrum Sepolia from Alchemy supported network ids by @Shadowfiend in https://github.com/tahowallet/extension/pull/3730


**Full Changelog**: https://github.com/tahowallet/extension/compare/v0.56.0...v0.56.1

Latest build: [extension-builds-3731](https://github.com/tahowallet/extension/suites/20022293818/artifacts/1187100269) (as of Mon, 22 Jan 2024 22:31:05 GMT).