### PR TITLE
Disable abilities extension-wide

### DIFF
--- a/background/services/abilities/index.ts
+++ b/background/services/abilities/index.ts
@@ -5,7 +5,7 @@ import {
   createSpamReport,
   DaylightAbility,
   DaylightAbilityRequirement,
-  getDaylightAbilities,
+  // getDaylightAbilities,
 } from "../../lib/daylight"
 import { AbilitiesDatabase, getOrCreateDB } from "./db"
 import ChainService from "../chain"
@@ -149,7 +149,15 @@ export default class AbilitiesService extends BaseService<Events> {
     return this.db.getSortedAbilities()
   }
 
+  // Re-enable once polling is re-enabled.
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
   async pollForAbilities(address: NormalizedEVMAddress): Promise<void> {
+    // FIXME Disabled due to high usage on the Daylight side. UI should also be
+    // FIXME disconnected. Re-enabling should involve reconsidering our
+    // FIXME fetch/sync strategy to be based on user access/usage or other
+    // FIXME triggers, or be aggressively throttled when there is no direct
+    // FIXME user interaction.
+    /*
     const latestDaylightAbilities = await getDaylightAbilities(address)
     const latestAbilities = normalizeDaylightAbilities(
       latestDaylightAbilities,
@@ -162,6 +170,7 @@ export default class AbilitiesService extends BaseService<Events> {
       address,
       abilities: updatedAbilities,
     })
+    */
   }
 
   async markAbilityAsCompleted(

--- a/background/services/abilities/tests/index.integration.test.ts
+++ b/background/services/abilities/tests/index.integration.test.ts
@@ -77,7 +77,8 @@ describe("AbilitiesService", () => {
     })
   })
 
-  describe("pollForAbilities", () => {
+  // FIXME Restore once abilities polling is restored.
+  describe.skip("pollForAbilities", () => {
     let daylightAbilities: DaylightAbility[]
 
     beforeEach(async () => {

--- a/ui/components/Overview/AbilitiesHeader.tsx
+++ b/ui/components/Overview/AbilitiesHeader.tsx
@@ -1,18 +1,18 @@
-import { toggleHideDescription } from "@tallyho/tally-background/redux-slices/abilities"
+/* import { toggleHideDescription } from "@tallyho/tally-background/redux-slices/abilities"
 import {
   selectDescriptionHidden,
   selectOpenAbilityCount,
 } from "@tallyho/tally-background/redux-slices/selectors"
 import classNames from "classnames"
-import React, { ReactElement } from "react"
+import React  , { ReactElement } from "react"
 import { useTranslation } from "react-i18next"
 import { useSelector } from "react-redux"
 import { useHistory } from "react-router-dom"
 import { useBackgroundDispatch } from "../../hooks"
-import SharedButton from "../Shared/SharedButton"
+import SharedButton from "../Shared/SharedButton" */
 
-export default function AbilitiesHeader(): ReactElement {
-  const { t } = useTranslation("translation", {
+export default function AbilitiesHeader(): null /* ReactElement */ {
+  /* const { t } = useTranslation("translation", {
     keyPrefix: "abilities",
   })
   const openAbilities = useSelector(selectOpenAbilityCount)
@@ -36,9 +36,10 @@ export default function AbilitiesHeader(): ReactElement {
     if (e.key === "Enter") {
       handleClick()
     }
-  }
+    } */
 
-  return (
+  return null
+  /* return (
     <div
       className={classNames("abilities_header", {
         small_banner: hideDescription,
@@ -198,5 +199,5 @@ export default function AbilitiesHeader(): ReactElement {
         }
       `}</style>
     </div>
-  )
+    ) */
 }

--- a/ui/components/TabBar/TabBar.tsx
+++ b/ui/components/TabBar/TabBar.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, useCallback } from "react"
 import { matchPath, useHistory, useLocation } from "react-router-dom"
 import {
   selectCurrentNetwork,
-  selectOpenAbilityCount,
+  // selectOpenAbilityCount,
 } from "@tallyho/tally-background/redux-slices/selectors"
 import { NETWORKS_SUPPORTING_SWAPS } from "@tallyho/tally-background/constants/networks"
 import { EVMNetwork } from "@tallyho/tally-background/networks"
@@ -24,7 +24,7 @@ const isTabSupportedByNetwork = (tab: TabInfo, network: EVMNetwork) => {
 export default function TabBar(): ReactElement {
   const location = useLocation()
   const selectedNetwork = useBackgroundSelector(selectCurrentNetwork)
-  const abilityCount = useBackgroundSelector(selectOpenAbilityCount)
+  // const abilityCount = useBackgroundSelector(selectOpenAbilityCount)
 
   const history = useHistory()
   const { t } = useTranslation()
@@ -42,12 +42,14 @@ export default function TabBar(): ReactElement {
     (path: string): boolean => {
       switch (path) {
         case "/portfolio":
-          return abilityCount > 0
+          return false // abilityCount > 0
         default:
           return false
       }
     },
-    [abilityCount],
+    [
+      /* abilityCount */
+    ],
   )
 
   return (


### PR DESCRIPTION
Due to the way that abilities are currently implemented, load on the Daylight API side is very high. We don't have the cycles right now to implement the underlying changes that would improve API load, so for now we disable abilities fetching, as well as access to abilities in the UI.

The code that is commented out is targeted to only remove the parts that link to the abilities UI and the parts that call out to the Daylight API; the rest remains in place so that turning things back on once the fetching strategy can be improved is straightforward.

Latest build: [extension-builds-3734](https://github.com/tahowallet/extension/suites/20839694050/artifacts/1252426921) (as of Fri, 16 Feb 2024 21:10:27 GMT).