### PR TITLE
v0.57.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -51,6 +51,7 @@ body:
       label: Version
       description: What version of the extension are you running?
       options:
+        - v0.57.0
         - v0.56.0
         - v0.55.0
         - v0.54.0

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Taho",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "The community owned and operated Web3 wallet.",
   "homepage_url": "https://taho.xyz",
   "author": "https://taho.xyz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tallyho/tally-extension",
   "private": true,
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "Taho, the community owned and operated Web3 wallet.",
   "main": "index.js",
   "repository": "git@github.com:thesis/tally-extension.git",


### PR DESCRIPTION
## What's Changed
* v0.56.0 by @Shadowfiend in https://github.com/tahowallet/extension/pull/3729
* Drop Arbitrum Sepolia from Alchemy supported network ids by @Shadowfiend in https://github.com/tahowallet/extension/pull/3730
* Disable abilities extension-wide by @Shadowfiend in https://github.com/tahowallet/extension/pull/3734


**Full Changelog**: https://github.com/tahowallet/extension/compare/v0.56.0...v0.57.0

Latest build: [extension-builds-3735](https://github.com/tahowallet/extension/suites/20840877238/artifacts/1252537126) (as of Fri, 16 Feb 2024 22:05:55 GMT).