### PR TITLE
Include the latest Ledger Nano X product ID

### DIFF
--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -32,6 +32,7 @@ enum LedgerType {
   UNKNOWN,
   LEDGER_NANO_S,
   LEDGER_NANO_X,
+  LEDGER_NANO_X_1,
   LEDGER_NANO_S_PLUS,
 }
 
@@ -46,6 +47,7 @@ export type LedgerAccountSigner = {
 export const LedgerProductDatabase = {
   LEDGER_NANO_S: { productId: 0x1015 },
   LEDGER_NANO_X: { productId: 0x4015 },
+  LEDGER_NANO_X_1: { productId: 0x4000 },
   LEDGER_NANO_S_PLUS: { productId: 0x5015 },
 }
 
@@ -71,6 +73,7 @@ const DisplayDetailsByLedgerType: {
   [LedgerType.UNKNOWN]: { messageSigningDisplayLength: 0 },
   [LedgerType.LEDGER_NANO_S]: { messageSigningDisplayLength: 99 },
   [LedgerType.LEDGER_NANO_X]: { messageSigningDisplayLength: 255 },
+  [LedgerType.LEDGER_NANO_X_1]: { messageSigningDisplayLength: 255 },
   [LedgerType.LEDGER_NANO_S_PLUS]: { messageSigningDisplayLength: 255 },
 }
 


### PR DESCRIPTION
The latest version of Ledger Nano X firmware changes the product ID to `0x4000`, breaking connections with newer devices.

I tested this patch locally with a newly updated Ledger Nano X, though I haven't been able to test it with an older (pre-upgrade) Nano X.

The Ledger team suggests we move to the [Device Management Kit](https://developers.ledger.com/docs/device-interaction/beginner/discover_and_connect). I haven't had time to dig in further on whether the DMK connection flow would work with WebUSB, and [opened an issue](https://github.com/tahowallet/extension/issues/3754) for later.

Latest build: [extension-builds-3755](https://github.com/tahowallet/extension/suites/32049732661/artifacts/2319383990) (as of Fri, 13 Dec 2024 20:47:52 GMT).