### PR TITLE
Bump playwright to 1.48.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     tags:
       - v*
 
+env:
+  NODE_OPTIONS: --openssl-legacy-provider
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pledge-signer-sync/package.json
+++ b/.github/workflows/pledge-signer-sync/package.json
@@ -3,9 +3,6 @@
   "type": "module",
   "version": "1.0.0",
   "private": true,
-  "engines": {
-    "node": ">=16.0.0 <17.0.0"
-  },
   "dependencies": {
     "firebase": "^9.9.0",
     "node-fetch": "3.3.1"

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-v16.20.0
+lts/hydrogen

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@babel/preset-react": "^7.22.5",
     "@babel/preset-typescript": "^7.22.11",
     "@babel/register": "^7.22.5",
-    "@playwright/test": "^1.39",
+    "@playwright/test": "^1.48.0",
     "@redux-devtools/cli": "^2.0.0",
     "@thesis-co/eslint-config": "^0.6.1",
     "@types/archiver": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3425,12 +3425,12 @@
     picocolors "^1.0.0"
     tslib "^2.6.0"
 
-"@playwright/test@^1.39":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.39.0.tgz#d10ba8e38e44104499e25001945f07faa9fa91cd"
-  integrity sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==
+"@playwright/test@^1.48.0":
+  version "1.49.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.49.1.tgz#55fa360658b3187bfb6371e2f8a64f50ef80c827"
+  integrity sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==
   dependencies:
-    playwright "1.39.0"
+    playwright "1.49.1"
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -13015,17 +13015,17 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.39.0:
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.39.0.tgz#efeaea754af4fb170d11845b8da30b2323287c63"
-  integrity sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==
+playwright-core@1.49.1:
+  version "1.49.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.49.1.tgz#32c62f046e950f586ff9e35ed490a424f2248015"
+  integrity sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==
 
-playwright@1.39.0:
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.39.0.tgz#184c81cd6478f8da28bcd9e60e94fcebf566e077"
-  integrity sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==
+playwright@1.49.1:
+  version "1.49.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.49.1.tgz#830266dbca3008022afa7b4783565db9944ded7c"
+  integrity sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==
   dependencies:
-    playwright-core "1.39.0"
+    playwright-core "1.49.1"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
The new version should support Ubuntu 24.04 in Github Actions

https://github.com/microsoft/playwright/issues/30368

Latest build: [extension-builds-3756](https://github.com/tahowallet/extension/suites/32386348469/artifacts/2356688184) (as of Mon, 23 Dec 2024 17:03:36 GMT).