### PR TITLE
v0.63.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -51,6 +51,7 @@ body:
       label: Version
       description: What version of the extension are you running?
       options:
+        - v0.63.0
         - v0.62.0
         - v0.58.0
         - v0.57.0

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Taho",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "description": "The community owned and operated Web3 wallet.",
   "homepage_url": "https://taho.xyz",
   "author": "https://taho.xyz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tallyho/tally-extension",
   "private": true,
-  "version": "0.62.1",
+  "version": "0.63.0",
   "description": "Taho, the community owned and operated Web3 wallet.",
   "main": "index.js",
   "repository": "git@github.com:thesis/tally-extension.git",


### PR DESCRIPTION
## What's Changed
* v0.62.0: Manifest v3 support plus a few other QOL changes by @Shadowfiend in https://github.com/tahowallet/extension/pull/3759
* Merging Pains: Fix token list duplication for good by @Shadowfiend in https://github.com/tahowallet/extension/pull/3760


**Full Changelog**: https://github.com/tahowallet/extension/compare/v0.62.0...v0.63.0

Latest build: [extension-builds-3761](https://github.com/tahowallet/extension/suites/32966492861/artifacts/2419470374) (as of Sun, 12 Jan 2025 22:26:22 GMT).