### PR TITLE
Fixes empty screen when opening the account switching panel.

### DIFF
--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -471,6 +471,10 @@ export default function AccountsNotificationPanelAccounts({
             return acc
           }, {})
 
+          if (accountTypeTotals.length < 1) {
+            return null
+          }
+
           return (
             <section key={category} className="account-category">
               <div className="category_wrap simple_text">


### PR DESCRIPTION
Checks there are accounts to render before attempting to render the account's category ('Imported', 'Hardware...', etc)

Closes #3762 