### PR TITLE
Correct dApp info passed on eth_requestAccounts

### DIFF
--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -234,7 +234,6 @@ export default class ProviderBridgeService extends BaseService<Events> {
       // methods).
       const [title, faviconUrl] = (event.request.params as unknown[]).slice(
         -2,
-        0,
       ) as string[]
 
       const existingPermission = await this.checkPermission(origin, dAppChainID)


### PR DESCRIPTION
This was making one of the e2e test fail as an empty array was passed as dApp connection info.

<img src="https://github.com/user-attachments/assets/4b7c977a-bd2f-4f54-b988-e044f6862aaf" width="400"/>


## To test
- [ ] Head to https://swap.cow.fi, connect and check title and logo displayed under connection info

Latest build: [extension-builds-3768](https://github.com/tahowallet/extension/suites/33209975358/artifacts/2449542737) (as of Fri, 17 Jan 2025 22:18:50 GMT).