### PR TITLE
Improve RPC provider request handling

### DIFF
--- a/background/services/chain/serial-fallback-provider.ts
+++ b/background/services/chain/serial-fallback-provider.ts
@@ -1,6 +1,5 @@
 import {
   EventType,
-  JsonRpcBatchProvider,
   JsonRpcProvider,
   Listener,
   WebSocketProvider,
@@ -27,14 +26,23 @@ import {
 import { FeatureFlags, isEnabled } from "../../features"
 import { RpcConfig } from "./db"
 import TahoAlchemyProvider from "./taho-provider"
+import TahoRPCProvider from "./taho-rpc-provider"
 
-type RPCProvider = WebSocketProvider | JsonRpcProvider | JsonRpcBatchProvider
+type RPCProvider = WebSocketProvider | JsonRpcProvider | TahoRPCProvider
 
 export type ProviderCreator = {
   type: "alchemy" | "custom" | "generic"
   supportedMethods?: string[]
   creator: () => RPCProvider
 }
+
+const isWebSocketProvider = (
+  provider: RPCProvider,
+): provider is WebSocketProvider => provider instanceof WebSocketProvider
+
+const isJsonRpcProvider = (
+  provider: RPCProvider,
+): provider is TahoRPCProvider => provider instanceof TahoRPCProvider
 
 /**
  * Method list, to describe which rpc method calls on which networks should
@@ -110,11 +118,8 @@ function backedOffMs(): number {
  * this information, nor does it attempt to reconnect in these cases.
  */
 function isClosedOrClosingWebSocketProvider(provider: RPCProvider): boolean {
-  if (provider instanceof WebSocketProvider) {
-    // Digging into the innards of Ethers here because there's no
-    // other way to get access to the WebSocket connection situation.
-    // eslint-disable-next-line no-underscore-dangle
-    const webSocket = provider._websocket as WebSocket
+  if (isWebSocketProvider(provider)) {
+    const webSocket = provider.websocket
 
     return (
       webSocket.readyState === WebSocket.CLOSING ||
@@ -130,11 +135,8 @@ function isClosedOrClosingWebSocketProvider(provider: RPCProvider): boolean {
  * connecting. Ethers does not provide direct access to this information.
  */
 function isConnectingWebSocketProvider(provider: RPCProvider): boolean {
-  if (provider instanceof WebSocketProvider) {
-    // Digging into the innards of Ethers here because there's no
-    // other way to get access to the WebSocket connection situation.
-    // eslint-disable-next-line no-underscore-dangle
-    const webSocket = provider._websocket as WebSocket
+  if (isWebSocketProvider(provider)) {
+    const webSocket = provider.websocket
     return webSocket.readyState === WebSocket.CONNECTING
   }
 
@@ -239,21 +241,6 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
   // The index of the provider creator that created the current provider. Used
   // for reconnects when relevant.
   private currentProviderIndex = 0
-
-  // If nonzero and the underlying provider is a batch provider, forces the
-  // batch size to be no more than this number, holding other requests until
-  // the existing batch has cleared.
-  private forcedBatchMaxSize: number = 0
-
-  // If this promise is set, new RPC calls will await on it before being
-  // processed. When forcedBatchMaxSize is nonzero and that number of RPC calls
-  // are pending, this promise will be set so subsequent requests will wait
-  // until the batch flushes.
-  private forcedBatchMaxPromise: Promise<void> | undefined = undefined
-
-  // During max size update, this value is set so that the value is not
-  // decreased by multiple failed requests.
-  private forcedBatchMaxPreviousSize: number = 0
 
   // TEMPORARY cache for latest account balances to reduce number of rpc calls
   // This is intended as a temporary fix to the burst of account enrichment that
@@ -365,46 +352,7 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
       delete this.messagesToSend[messageId]
       return cachedResult
     }
-
-    if (this.forcedBatchMaxPromise) {
-      await this.forcedBatchMaxPromise
-    }
-
-    const pendingBatch =
-      "_pendingBatch" in this.currentProvider
-        ? // Accessing ethers internals for forced max batch sizing.
-          // eslint-disable-next-line no-underscore-dangle
-          (this.currentProvider._pendingBatch as { length: number } | undefined)
-        : undefined
-    const pendingBatchSize = pendingBatch?.length
     const existingProviderIndex = this.currentProviderIndex
-
-    if (
-      pendingBatch &&
-      this.forcedBatchMaxSize &&
-      // Accessing ethers internals for forced max batch sizing.
-      // eslint-disable-next-line no-underscore-dangle
-      pendingBatch.length >= this.forcedBatchMaxSize
-    ) {
-      this.forcedBatchMaxPromise = new Promise((resolve) => {
-        const checkInterval = setInterval(() => {
-          const latestPendingBatch =
-            "_pendingBatch" in this.currentProvider
-              ? // Accessing ethers internals for forced max batch sizing.
-                // eslint-disable-next-line no-underscore-dangle
-                (this.currentProvider._pendingBatch as
-                  | { length: number }
-                  | undefined)
-              : undefined
-
-          if ((latestPendingBatch?.length ?? 0) < this.forcedBatchMaxSize) {
-            resolve()
-            clearInterval(checkInterval)
-          }
-        }, 5)
-      })
-    }
-
     try {
       if (isClosedOrClosingWebSocketProvider(this.currentProvider)) {
         // Detect disconnected WebSocket and immediately throw.
@@ -444,42 +392,35 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
       return result
     } catch (error) {
       // Awful, but what can ya do.
+
       const stringifiedError = String(error)
 
       if (
-        stringifiedError.match(/Batch size too large/) &&
-        (pendingBatchSize === undefined || pendingBatchSize === 0)
+        stringifiedError.match(/Batch size too large/i) &&
+        isJsonRpcProvider(this.currentProvider)
       ) {
-        this.forcedBatchMaxPreviousSize =
-          pendingBatch?.length ?? pendingBatchSize ?? 1
-        this.forcedBatchMaxSize =
-          (pendingBatch?.length ?? pendingBatchSize ?? 2) / 2
+        const requestBatch = this.currentProvider.getBatchFromError(error)
 
-        logger.debug(
-          "Setting a max batch size of",
-          this.forcedBatchMaxSize,
-          "on chain",
-          this.chainID,
-          "and retrying: ",
-          method,
-          params,
-        )
+        const batchLen = requestBatch.length
 
-        return this.routeRpcCall(messageId)
-      }
+        // Note that every other request in the batch will set the length to
+        // the same value
+        if (batchLen <= this.currentProvider.getOptions().maxBatchLength) {
+          const newMaxBatchLen = Math.max(Math.floor(batchLen / 2), 1)
 
-      if (stringifiedError.match(/Batch size too large/)) {
-        logger.debug(
-          "Using max batch size of",
-          this.forcedBatchMaxSize,
-          "on chain",
-          this.chainID,
-          "and retrying: ",
-          method,
-          params,
-        )
+          this.currentProvider.setOptions({
+            maxBatchLength: newMaxBatchLen,
+          })
 
-        return this.routeRpcCall(messageId)
+          logger.debug(
+            "Setting a max batch size of",
+            newMaxBatchLen,
+            "for rpc",
+            this.currentProvider.connection.url,
+          )
+        }
+        // Retry with a new limit on batch length
+        return waitAnd(500, () => this.routeRpcCall(messageId))
       }
 
       if (
@@ -758,7 +699,7 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
   ): Promise<void> {
     const subscription = { tag, param, processFunc }
 
-    if (this.currentProvider instanceof WebSocketProvider) {
+    if (isWebSocketProvider(this.currentProvider)) {
       // eslint-disable-next-line no-underscore-dangle
       await this.currentProvider._subscribe(tag, param, processFunc)
       this.subscriptions.push(subscription)
@@ -913,12 +854,12 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
   private disconnectCurrentProvider() {
     logger.debug(
       "Disconnecting current provider; websocket: ",
-      this.currentProvider instanceof WebSocketProvider,
+      isWebSocketProvider(this.currentProvider),
       "on chain",
       this.chainID,
       ".",
     )
-    if (this.currentProvider instanceof WebSocketProvider) {
+    if (isWebSocketProvider(this.currentProvider)) {
       this.currentProvider.destroy()
     } else {
       // For non-WebSocket providers, kill all subscriptions so the listeners
@@ -1011,9 +952,7 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
       return false
     }
 
-    if (provider instanceof WebSocketProvider) {
-      const websocketProvider = provider as WebSocketProvider
-
+    if (isWebSocketProvider(provider)) {
       // Chain promises to serially resubscribe.
       //
       // TODO If anything fails along the way, it should yield the same kind of
@@ -1025,7 +964,7 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
               // Direct subscriptions are internal, but we want to be able to
               // restore them.
               // eslint-disable-next-line no-underscore-dangle
-              websocketProvider._subscribe(tag, param, processFunc),
+              provider._subscribe(tag, param, processFunc),
             ),
           ),
         Promise.resolve(),
@@ -1170,15 +1109,7 @@ function getProviderCreator(rpcUrl: string): RPCProvider {
     return new WebSocketProvider(rpcUrl)
   }
 
-  if (/rpc\.ankr\.com|1rpc\.io|polygon-rpc\.com/.test(url.href)) {
-    return new JsonRpcBatchProvider({
-      url: rpcUrl,
-      throttleLimit: 1,
-      timeout: PROVIDER_REQUEST_TIMEOUT,
-    })
-  }
-
-  return new JsonRpcProvider({
+  return new TahoRPCProvider({
     url: rpcUrl,
     throttleLimit: 1,
     timeout: PROVIDER_REQUEST_TIMEOUT,
@@ -1189,7 +1120,8 @@ export function makeFlashbotsProviderCreator(): ProviderCreator {
   return {
     type: "custom",
     supportedMethods: ["eth_sendRawTransaction"],
-    creator: () => getProviderCreator(FLASHBOTS_RPC_URL),
+    creator: () =>
+      new TahoRPCProvider(FLASHBOTS_RPC_URL, undefined, { maxBatchSize: 1 }),
   }
 }
 
@@ -1202,7 +1134,7 @@ export function makeSerialFallbackProvider(
     return new SerialFallbackProvider(FORK.chainID, [
       {
         type: "generic" as const,
-        creator: () => new JsonRpcProvider(process.env.MAINNET_FORK_URL),
+        creator: () => new TahoRPCProvider(process.env.MAINNET_FORK_URL),
       },
     ])
   }
@@ -1221,7 +1153,7 @@ export function makeSerialFallbackProvider(
     return new SerialFallbackProvider(ARBITRUM_SEPOLIA.chainID, [
       {
         type: "generic" as const,
-        creator: () => new JsonRpcBatchProvider(process.env.ARBITRUM_FORK_RPC),
+        creator: () => new TahoRPCProvider(process.env.ARBITRUM_FORK_RPC),
       },
     ])
   }

--- a/background/services/chain/serial-fallback-provider.ts
+++ b/background/services/chain/serial-fallback-provider.ts
@@ -28,10 +28,12 @@ import { FeatureFlags, isEnabled } from "../../features"
 import { RpcConfig } from "./db"
 import TahoAlchemyProvider from "./taho-provider"
 
+type RPCProvider = WebSocketProvider | JsonRpcProvider | JsonRpcBatchProvider
+
 export type ProviderCreator = {
   type: "alchemy" | "custom" | "generic"
   supportedMethods?: string[]
-  creator: () => WebSocketProvider | JsonRpcProvider
+  creator: () => RPCProvider
 }
 
 /**
@@ -107,9 +109,7 @@ function backedOffMs(): number {
  * either closing or already closed. Ethers does not provide direct access to
  * this information, nor does it attempt to reconnect in these cases.
  */
-function isClosedOrClosingWebSocketProvider(
-  provider: JsonRpcProvider,
-): boolean {
+function isClosedOrClosingWebSocketProvider(provider: RPCProvider): boolean {
   if (provider instanceof WebSocketProvider) {
     // Digging into the innards of Ethers here because there's no
     // other way to get access to the WebSocket connection situation.
@@ -129,7 +129,7 @@ function isClosedOrClosingWebSocketProvider(
  * Returns true if the given provider is using a WebSocket AND the WebSocket is
  * connecting. Ethers does not provide direct access to this information.
  */
-function isConnectingWebSocketProvider(provider: JsonRpcProvider): boolean {
+function isConnectingWebSocketProvider(provider: RPCProvider): boolean {
   if (provider instanceof WebSocketProvider) {
     // Digging into the innards of Ethers here because there's no
     // other way to get access to the WebSocket connection situation.
@@ -194,23 +194,19 @@ function customOrDefaultProvider(
 export default class SerialFallbackProvider extends JsonRpcProvider {
   // Functions that will create and initialize a new provider, in priority
   // order.
-  private providerCreators: [
-    () => WebSocketProvider | JsonRpcProvider,
-    ...(() => JsonRpcProvider)[],
-  ]
+  private providerCreators: (() => RPCProvider)[]
 
   // The currently-used provider, produced by the provider-creator at
   // currentProviderIndex.
-  private currentProvider: JsonRpcProvider
+  private currentProvider: RPCProvider
 
-  private alchemyProvider: JsonRpcProvider | undefined
+  private alchemyProvider: RPCProvider | undefined
 
-  private customProvider: JsonRpcProvider | undefined
+  private customProvider: RPCProvider | undefined
 
   private customProviderSupportedMethods: string[] = []
 
-  private cachedProvidersByIndex: Record<string, JsonRpcProvider | undefined> =
-    {}
+  private cachedProvidersByIndex: Record<string, RPCProvider | undefined> = {}
 
   /**
    * This object holds all messages that are either being sent to a provider
@@ -226,13 +222,11 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
     }
   } = {}
 
-  private alchemyProviderCreator:
-    | (() => WebSocketProvider | JsonRpcProvider)
-    | undefined
+  private alchemyProviderCreator: (() => RPCProvider) | undefined
 
   supportsAlchemy = false
 
-  private customProviderCreator: (() => JsonRpcProvider) | undefined
+  private customProviderCreator: (() => RPCProvider) | undefined
 
   /**
    * Since our architecture follows a pattern of using distinct provider instances
@@ -280,7 +274,7 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
   // reloaded and the property of having code updates quite rarely.
   private latestHasCodeCache: {
     [address: string]: {
-      hasCode: boolean
+      hasCode: string
     }
   } = {}
 
@@ -625,7 +619,7 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
     if (method === "eth_getCode" && (params as string[])[1] === "latest") {
       const address = (params as string[])[0]
       this.latestHasCodeCache[address] = {
-        hasCode: result as boolean,
+        hasCode: result as string,
       }
     }
   }
@@ -835,7 +829,7 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
   }
 
   /**
-   * Behaves the same as the `JsonRpcProvider` `on` method, but also trakcs the
+   * Behaves the same as the `JsonRpcProvider` `on` method, but also tracks the
    * event subscription so that an underlying provider failure will not prevent
    * it from firing.
    */
@@ -852,7 +846,7 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
   }
 
   /**
-   * Behaves the same as the `JsonRpcProvider` `once` method, but also trakcs
+   * Behaves the same as the `JsonRpcProvider` `once` method, but also tracks
    * the event subscription so that an underlying provider failure will not
    * prevent it from firing.
    */
@@ -1003,7 +997,7 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
    * @param provider The provider to use to resubscribe
    * @returns A boolean indicating if websocket subscription was successful or not
    */
-  private async resubscribe(provider: JsonRpcProvider): Promise<boolean> {
+  private async resubscribe(provider: RPCProvider): Promise<boolean> {
     logger.debug("Resubscribing subscriptions", "on chain", this.chainID, "...")
 
     if (
@@ -1170,9 +1164,7 @@ export default class SerialFallbackProvider extends JsonRpcProvider {
   }
 }
 
-function getProviderCreator(
-  rpcUrl: string,
-): JsonRpcProvider | WebSocketProvider {
+function getProviderCreator(rpcUrl: string): RPCProvider {
   const url = new URL(rpcUrl)
   if (/^wss?/.test(url.protocol)) {
     return new WebSocketProvider(rpcUrl)

--- a/background/services/chain/taho-rpc-provider.ts
+++ b/background/services/chain/taho-rpc-provider.ts
@@ -1,0 +1,282 @@
+import { JsonRpcProvider, Networkish } from "@ethersproject/providers"
+import { deepCopy } from "@ethersproject/properties"
+import { ConnectionInfo, fetchJson } from "@ethersproject/web"
+import logger from "../../lib/logger"
+
+type RPCPayload = {
+  method: string
+  params: unknown[]
+  id: number
+  jsonrpc: "2.0"
+}
+
+type RPCResponse = RPCResponseResult | RPCResponseError
+
+type RPCResponseError = {
+  id: number
+  error: {
+    code: number
+    message: string
+    data?: unknown
+  }
+  jsonrpc: "2.0"
+}
+
+type RPCResponseResult = {
+  id: number
+  result: unknown
+  jsonrpc: "2.0"
+}
+
+type RPCPendingRequest = {
+  resolve: (value: unknown) => void
+  reject: (reason: unknown) => void
+  payload: RPCPayload
+}
+
+type RPCOptions = {
+  /**
+   * Maximum number of requests to be batched
+   * @default 20 requests
+   */
+  maxBatchLength?: number
+  /**
+   * Maximum length in bytes of the batch
+   * @default 1Mb
+   */
+  maxBatchSize?: number
+  /**
+   * How long to wait to aggregate requests
+   * @default 100ms
+   */
+  batchStallTime?: number
+}
+
+const defaultOptions = {
+  maxBatchLength: 20,
+  // eslint-disable-next-line no-bitwise
+  maxBatchSize: 1 << 20, // 1Mb
+  batchStallTime: 100,
+}
+
+const makeSerializableError = (
+  message: string,
+  code?: number,
+  data?: unknown,
+) => {
+  const error = new Error()
+  Object.assign(error, { message, code, data })
+  return error
+}
+
+/**
+ * TODO: This should be able to fallback into a standard rpc provider
+ * if batches are unsupported
+ */
+export default class TahoRPCProvider extends JsonRpcProvider {
+  // Requests queued in this provider
+  private pending: RPCPendingRequest[] = []
+
+  #options: Required<RPCOptions>
+
+  // Tracks whether this provider is currently accepting requests
+  #destroyed = false
+
+  #sendTimer: NodeJS.Timer | null = null
+
+  #errorToBatch = new WeakMap<WeakKey, RPCPendingRequest[]>()
+
+  constructor(
+    url?: ConnectionInfo | string,
+    network?: Networkish,
+    options?: RPCOptions,
+  ) {
+    super(url, network)
+
+    this.#options = { ...defaultOptions, ...options }
+  }
+
+  private async sendNextBatch() {
+    // This prevents queueing multiple batches simultaneously
+    if (this.#sendTimer) {
+      return
+    }
+
+    this.#sendTimer = setTimeout(() => {
+      this.#sendTimer = null
+
+      const batch: RPCPendingRequest[] = []
+
+      const trackBatchError = (err: Error) => {
+        this.#errorToBatch.set(err, batch)
+        return err
+      }
+
+      while (this.pending.length > 0) {
+        batch.push(this.pending.shift() as RPCPendingRequest)
+
+        if (batch.length === this.#options.maxBatchLength) {
+          break
+        }
+      }
+
+      // Enforce max batch size
+      while (
+        JSON.stringify(batch.map(({ payload }) => payload)).length >
+        this.#options.maxBatchSize
+      ) {
+        this.pending.unshift(batch.pop() as RPCPendingRequest)
+
+        if (batch.length === 0) {
+          throw new Error("INVALID_MAX_BATCH_SIZE")
+        }
+      }
+
+      if (this.pending.length) {
+        // if there are still pending requests, schedule another batch for sending
+        this.sendNextBatch()
+      }
+
+      const request = batch.map(({ payload }) => payload)
+
+      this.emit("debug", {
+        action: "requestBatch",
+        request: deepCopy(request),
+        provider: this,
+      })
+
+      fetchJson(
+        this.connection,
+        // Some RPCs will reject batch payloads even if they send a single
+        // request (e.g. flashbots)
+        JSON.stringify(request.length === 1 ? request[0] : request),
+      )
+        .then((response) => {
+          const wrappedResponse: RPCResponse[] = Array.isArray(response)
+            ? response
+            : [response]
+
+          this.emit("debug", {
+            action: "response",
+            request,
+            response,
+            provider: this,
+          })
+
+          if (batch.length > 1 && !Array.isArray(response)) {
+            batch.forEach(({ reject }) => {
+              reject(
+                trackBatchError(
+                  makeSerializableError(
+                    response?.error?.message ?? "INVALID_RESPONSE",
+                    response?.error?.code,
+                    response,
+                  ),
+                ),
+              )
+            })
+          }
+
+          batch.forEach(({ payload: { id }, reject, resolve }) => {
+            const match = wrappedResponse.find((resp) => id === resp.id)
+
+            if (!match) {
+              reject(
+                trackBatchError(makeSerializableError("bad response", -32000)),
+              )
+              return
+            }
+
+            if ("error" in match) {
+              reject(
+                trackBatchError(
+                  makeSerializableError(
+                    match.error.message,
+                    match.error.code,
+                    match.error.data,
+                  ),
+                ),
+              )
+            } else {
+              resolve(match.result)
+            }
+          })
+        })
+        .catch((error) => {
+          this.emit("debug", {
+            action: "response",
+            error,
+            request,
+            provider: this,
+          })
+
+          // Any other error during fetch should propagate
+          batch.forEach(({ reject }) => reject(trackBatchError(error)))
+        })
+    }, this.#options.batchStallTime)
+  }
+
+  override send(method: string, params: unknown[]): Promise<unknown> {
+    if (this.#destroyed) {
+      return Promise.reject(new Error("PROVIDER_DESTROYED"))
+    }
+
+    const promise = new Promise((resolve, reject) => {
+      this.pending.push({
+        resolve,
+        reject,
+        // eslint-disable-next-line no-plusplus, no-underscore-dangle
+        payload: { method, params, id: this._nextId++, jsonrpc: "2.0" },
+      })
+    })
+
+    this.sendNextBatch()
+    return promise
+  }
+
+  /**
+   * Drops any pending requests
+   */
+  async destroy() {
+    this.#destroyed = true
+
+    if (this.#sendTimer) clearTimeout(this.#sendTimer)
+
+    this.pending.forEach((request) =>
+      request.reject(new Error("PROVIDER_DESTROYED")),
+    )
+
+    this.pending = []
+  }
+
+  async reconnect() {
+    this.#destroyed = false
+  }
+
+  setOptions(settings: RPCOptions): void {
+    Object.assign(this.#options, settings)
+  }
+
+  getOptions(): Readonly<Required<RPCOptions>> {
+    return { ...this.#options }
+  }
+
+  /**
+   * Useful for adjusting batch limits
+   * @param err The error returned as the response
+   * @returns The associated batch sent
+   */
+  getBatchFromError(err: unknown): RPCPendingRequest[] {
+    if (
+      typeof err !== "object" ||
+      err === null ||
+      !this.#errorToBatch.has(err)
+    ) {
+      throw logger.buildError(
+        `Could not retrieve batch using error: ${err} as reference`,
+      )
+    }
+
+    return this.#errorToBatch.get(err)!
+  }
+}


### PR DESCRIPTION
This adds `TahoRPCProvider` to optimize RPC batching and request handling and sets it as default provider used since most
public RPCs support batching. This provider is configurable and sets sane defaults that seem to work fine with most of the public RPCs we use within the wallet. 

Furthermore since options can be changed at runtime, the serial fallback provider should be able use error data to adjust the provider options if the already strict limits change in the future.