### PR TITLE
Reuse existing activity state data

### DIFF
--- a/background/services/redux/index.ts
+++ b/background/services/redux/index.ts
@@ -589,6 +589,7 @@ export default class ReduxService extends BaseService<never> {
 
   async enrichActivities(addressNetwork: AddressOnNetwork): Promise<void> {
     const accountsToTrack = await this.chainService.getAccountsToTrack()
+
     const activitiesToEnrich = selectActivitesHashesForEnrichment(
       this.store.getState(),
     )


### PR DESCRIPTION
This adds a check into the account activity initialization process so we re-use already-enriched activity data if it corresponds to a finalized transaction.

Improves worker startup and prevents requests bursts by optimizing activity initialization for tracked accounts.

## To Test
- [ ] Load an account e.g. `testertesting.eth`
- [ ] On initial extension load, check that there are some RPC requests made for transaction enrichment
- [ ] Reload extension, check that there aren't as many requests as before

Latest build: [extension-builds-3783](https://github.com/tahowallet/extension/suites/34503181381/artifacts/2605178562) (as of Mon, 17 Feb 2025 19:35:53 GMT).