### PR TITLE
Prevented unnecessary analytics events on initialization

### DIFF
--- a/background/services/redux/index.ts
+++ b/background/services/redux/index.ts
@@ -1631,20 +1631,28 @@ export default class ReduxService extends BaseService<never> {
 
     this.preferenceService.emitter.on(
       "updateAnalyticsPreferences",
-      async (analyticsPreferences: AnalyticsPreferences) => {
+      async ({ isEnabled }: AnalyticsPreferences) => {
+        const currentValue = this.store.getState().ui.settings.collectAnalytics
+
+        // Check if this value has been updated so we prevent dispatching unnecessary
+        // analytics events during initialization
+        if (currentValue === isEnabled) {
+          return
+        }
+
         // This event is used on initialization and data change
         this.store.dispatch(
           toggleCollectAnalytics(
             // we are using only this field on the UI atm
             // it's expected that more detailed analytics settings will come
-            analyticsPreferences.isEnabled,
+            isEnabled,
           ),
         )
 
         this.analyticsService.sendAnalyticsEvent(
           AnalyticsEvent.ANALYTICS_TOGGLED,
           {
-            analyticsEnabled: analyticsPreferences.isEnabled,
+            analyticsEnabled: isEnabled,
           },
         )
       },


### PR DESCRIPTION
This prevents dispatching a "Analytics Toggled" event during initialization of analytics preferences by checking if the setting has been changed before dispatching updates/events.

## To Test
- [ ] Open up service worker inspector and check posthog requests
- [ ] Reload the extension, there should not be another posthog request unless analytics settings are updated

Latest build: [extension-builds-3784](https://github.com/tahowallet/extension/suites/34817574924/artifacts/2643584644) (as of Mon, 24 Feb 2025 19:20:05 GMT).