### PR TITLE
Lower batch size for price discovery calls

### DIFF
--- a/background/lib/priceOracle.ts
+++ b/background/lib/priceOracle.ts
@@ -36,7 +36,10 @@ import logger, { logRejectedAndReturnFulfilledResults } from "./logger"
 // The size of a batch of on-chain price lookups. Too high and the request will
 // fail due to running out of gas, as eth_call is still subject to gas limits.
 // Too low and we will make additional unnecessary RPC requests.
-const BATCH_SIZE = 20
+//
+// Some public RPCS (such as ankr) have stricter limits on gas for eth_calls
+// for now, this size appears to work fine
+const BATCH_SIZE = 5
 
 // Oracle Documentation and Address references can be found
 // at https://docs.1inch.io/docs/spot-price-aggregator/introduction/


### PR DESCRIPTION
Helps reduce occurrences of `out of gas` errors when calling public RPCs. Won't help with calls made through multicall when they receive a valid RPC response with empty results. But, will reduce frequency of these scenarios.

Latest build: [extension-builds-3786](https://github.com/tahowallet/extension/suites/34820924724/artifacts/2644023557) (as of Mon, 24 Feb 2025 20:33:38 GMT).