### PR TITLE
Increase frequency of price fetching

### DIFF
--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -124,7 +124,7 @@ export default class IndexingService extends BaseService<Events> {
    */
   private scheduledTokenRefresh = false
 
-  private lastPriceAlarmTime = 0
+  #pricesUpdateTimer: NodeJS.Timer | null = null
 
   private cachedAssets: Record<EVMNetwork["chainID"], AnyAsset[]> =
     Object.fromEntries(
@@ -180,7 +180,7 @@ export default class IndexingService extends BaseService<Events> {
           delayInMinutes: 1,
           periodInMinutes: 10,
         },
-        handler: () => this.handlePriceAlarm(),
+        handler: () => this.scheduleUpdateAssetsPrices(),
       },
     })
   }
@@ -194,7 +194,7 @@ export default class IndexingService extends BaseService<Events> {
     const tokenListLoad = this.fetchAndCacheTokenLists()
 
     this.chainService.emitter.once("serviceStarted").then(async () => {
-      this.handlePriceAlarm()
+      this.scheduleUpdateAssetsPrices()
 
       const trackedNetworks = await this.chainService.getTrackedNetworks()
 
@@ -476,7 +476,7 @@ export default class IndexingService extends BaseService<Events> {
         await this.loadAccountBalancesFor(addressOnNetwork)
 
         // FIXME Refactor this to only update prices for tokens with balances.
-        this.handlePriceAlarm()
+        this.scheduleUpdateAssetsPrices()
       },
     )
 
@@ -939,21 +939,20 @@ export default class IndexingService extends BaseService<Events> {
     }
   }
 
-  private async handlePriceAlarm(): Promise<void> {
-    if (Date.now() < this.lastPriceAlarmTime + 5 * SECOND) {
-      // If this is quickly called multiple times (for example when
-      // using a network for the first time with a wallet loaded
-      // with many accounts) only fetch prices once.
+  private async scheduleUpdateAssetsPrices(): Promise<void> {
+    // If there's a pending update do nothing
+    if (this.#pricesUpdateTimer) {
       return
     }
 
-    this.lastPriceAlarmTime = Date.now()
-
-    // Avoid awaiting here so price fetching can happen in the background
-    // and the extension can go on doing whatever it needs to do while waiting
-    // for prices to come back.
-    this.getBaseAssetsPrices()
-    this.getTrackedAssetsPrices()
+    this.#pricesUpdateTimer = setTimeout(() => {
+      this.#pricesUpdateTimer = null
+      // Avoid awaiting here so price fetching can happen in the background
+      // and the extension can go on doing whatever it needs to do while waiting
+      // for prices to come back.
+      this.getBaseAssetsPrices()
+      this.getTrackedAssetsPrices()
+    }, 5 * SECOND)
   }
 
   private async fetchAndCacheTokenLists(): Promise<void> {

--- a/background/services/indexing/tests/index.integration.test.ts
+++ b/background/services/indexing/tests/index.integration.test.ts
@@ -266,10 +266,9 @@ describe("IndexingService", () => {
 
       await indexingDb.addAssetToTrack(smartContractAsset)
 
-      const spy = getPrivateMethodSpy<IndexingService["handlePriceAlarm"]>(
-        indexingService,
-        "handlePriceAlarm",
-      )
+      const spy = getPrivateMethodSpy<
+        IndexingService["scheduleUpdateAssetsPrices"]
+      >(indexingService, "scheduleUpdateAssetsPrices")
 
       await Promise.all([
         chainService.startService(),
@@ -306,9 +305,9 @@ describe("IndexingService", () => {
       await indexingDb.addAssetToTrack(smartContractAsset)
 
       // Skip loading prices at service init
-      getPrivateMethodSpy<IndexingService["handlePriceAlarm"]>(
+      getPrivateMethodSpy<IndexingService["scheduleUpdateAssetsPrices"]>(
         indexingService,
-        "handlePriceAlarm",
+        "scheduleUpdateAssetsPrices",
       ).mockResolvedValue(Promise.resolve())
 
       await Promise.all([
@@ -359,9 +358,9 @@ describe("IndexingService", () => {
       await indexingDb.addAssetToTrack(smartContractAsset)
 
       // Skip loading prices at service init
-      getPrivateMethodSpy<IndexingService["handlePriceAlarm"]>(
+      getPrivateMethodSpy<IndexingService["scheduleUpdateAssetsPrices"]>(
         indexingService,
-        "handlePriceAlarm",
+        "scheduleUpdateAssetsPrices",
       ).mockResolvedValue(Promise.resolve())
 
       await Promise.all([

--- a/background/services/indexing/tests/index.integration.test.ts
+++ b/background/services/indexing/tests/index.integration.test.ts
@@ -255,6 +255,8 @@ describe("IndexingService", () => {
     // Check that we're using proper token ids for built in network assets
     // TODO: Remove once we add an e2e test for balances
     it("should query builtin network asset prices", async () => {
+      jest.useFakeTimers()
+
       const indexingDb = await getIndexingDB()
 
       const smartContractAsset = createSmartContractAsset()
@@ -279,7 +281,9 @@ describe("IndexingService", () => {
 
       expect(spy).toHaveBeenCalled()
 
-      await spy.mock.results[0].value
+      jest.advanceTimersByTime(6000)
+      await jest.advanceTimersToNextTimerAsync()
+      jest.useRealTimers()
 
       expect(
         fetchJsonStub


### PR DESCRIPTION
Prevents missed updates if a price fetch is requested shortly after after detecting a new token balance.

Latest build: [extension-builds-3787](https://github.com/tahowallet/extension/suites/34970189586/artifacts/2662917777) (as of Thu, 27 Feb 2025 12:20:43 GMT).