### PR TITLE
Fix excessive loading time on new accounts

### DIFF
--- a/background/redux-slices/selectors/accountsSelectors.ts
+++ b/background/redux-slices/selectors/accountsSelectors.ts
@@ -44,7 +44,7 @@ import { DOGGO } from "../../constants/assets"
 import { FeatureFlags, isEnabled } from "../../features"
 import { AccountSigner, SignerType } from "../../services/signing"
 import { SignerImportSource } from "../../services/internal-signer"
-import { assertUnreachable } from "../../lib/utils/type-guards"
+import { assertUnreachable, isDefined } from "../../lib/utils/type-guards"
 import { PricesState, selectAssetPricePoint } from "../prices"
 import { TESTNET_TAHO } from "../../services/island"
 
@@ -264,7 +264,7 @@ export const selectAccountAndTimestampedActivities = createSelector(
     return {
       combinedData: {
         assets: combinedAssetAmounts,
-        totalMainCurrencyValue: totalMainCurrencyAmount
+        totalMainCurrencyValue: isDefined(totalMainCurrencyAmount)
           ? formatCurrencyAmount(
               mainCurrencySymbol,
               totalMainCurrencyAmount,
@@ -317,7 +317,7 @@ export const selectCurrentAccountBalances = createSelector(
       allAssetAmounts,
       assetAmounts: combinedAssetAmounts,
       unverifiedAssetAmounts,
-      totalMainCurrencyValue: totalMainCurrencyAmount
+      totalMainCurrencyValue: isDefined(totalMainCurrencyAmount)
         ? formatCurrencyAmount(
             mainCurrencySymbol,
             totalMainCurrencyAmount,

--- a/background/services/redux/index.ts
+++ b/background/services/redux/index.ts
@@ -376,7 +376,7 @@ export default class ReduxService extends BaseService<never> {
   ) {
     super({
       initialLoadWaitExpired: {
-        schedule: { delayInMinutes: 2.5 },
+        schedule: { delayInMinutes: 1.5 },
         handler: () => this.store.dispatch(initializationLoadingTimeHitLimit()),
       },
     })


### PR DESCRIPTION
Fixes a case where a balance of zero would prevent loading from finishing early and reduces the `initialLoad` timer to 90 seconds.

## To Test
- [ ] Do a fresh install and import or make a new account, popup shouldn't remain stuck loading for 2 minutes

Latest build: [extension-builds-3788](https://github.com/tahowallet/extension/suites/34873113422/artifacts/2650541060) (as of Tue, 25 Feb 2025 18:02:31 GMT).