### PR TITLE
Force-toggle testnets visibility in network switcher

### DIFF
--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -15,7 +15,7 @@ import { DEFAULT_AUTOLOCK_INTERVAL } from "../services/preferences/defaults"
 export const defaultSettings = {
   hideDust: false,
   defaultWallet: false,
-  showTestNetworks: false,
+  showTestNetworks: true,
   showNotifications: undefined,
   collectAnalytics: false,
   showAnalyticsNotification: false,
@@ -77,6 +77,7 @@ export type Events = {
   updateAnalyticsPreferences: Partial<AnalyticsPreferences>
   addCustomNetworkResponse: [string, boolean]
   updateAutoLockInterval: number
+  toggleShowTestNetworks: boolean
 }
 
 export const emitter = new Emittery<Events>()
@@ -362,6 +363,13 @@ export const updateAutoLockInterval = createBackgroundAsyncThunk(
     }
 
     emitter.emit("updateAutoLockInterval", parsedValue)
+  },
+)
+
+export const toggleShowTestNetworks = createBackgroundAsyncThunk(
+  "ui/toggleShowTestNetworks",
+  async (value: boolean) => {
+    await emitter.emit("toggleShowTestNetworks", value)
   },
 )
 

--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -65,6 +65,7 @@ export type Preferences = {
   analytics: AnalyticsPreferences
   autoLockInterval: UNIXTime
   shouldShowNotifications: boolean
+  showTestNetworks: boolean
 }
 
 /**
@@ -439,6 +440,19 @@ export class PreferenceDatabase extends Dexie {
         }),
     )
 
+    this.version(22).upgrade((tx) =>
+      tx
+        .table("preferences")
+        .toCollection()
+        .modify((storedPreferences: Omit<Preferences, "showTestNetworks">) => {
+          const update: Partial<Preferences> = {
+            showTestNetworks: true,
+          }
+
+          Object.assign(storedPreferences, update)
+        }),
+    )
+
     // This is the old version for populate
     // https://dexie.org/docs/Dexie/Dexie.on.populate-(old-version)
     // The this does not behave according the new docs, but works
@@ -463,6 +477,16 @@ export class PreferenceDatabase extends Dexie {
       .toCollection()
       .modify((storedPreferences: Preferences) => {
         const update: Partial<Preferences> = { autoLockInterval: newValue }
+
+        Object.assign(storedPreferences, update)
+      })
+  }
+
+  async setShowTestNetworks(newValue: boolean): Promise<void> {
+    await this.preferences
+      .toCollection()
+      .modify((storedPreferences: Preferences) => {
+        const update: Partial<Preferences> = { showTestNetworks: newValue }
 
         Object.assign(storedPreferences, update)
       })

--- a/background/services/preferences/defaults.ts
+++ b/background/services/preferences/defaults.ts
@@ -35,6 +35,7 @@ const defaultPreferences = {
   },
   autoLockInterval: DEFAULT_AUTOLOCK_INTERVAL,
   shouldShowNotifications: false,
+  showTestNetworks: true,
 }
 
 export default defaultPreferences

--- a/background/services/preferences/index.ts
+++ b/background/services/preferences/index.ts
@@ -109,6 +109,7 @@ interface Events extends ServiceLifecycleEvents {
   initializeSelectedAccount: AddressOnNetwork
   initializeShownDismissableItems: DismissableItem[]
   initializeNotificationsPreferences: boolean
+  initializeShowTestNetworks: boolean
   updateAnalyticsPreferences: AnalyticsPreferences
   addressBookEntryModified: AddressBookEntry
   updatedSignerSettings: AccountSignerSettings[]
@@ -161,6 +162,11 @@ export default class PreferenceService extends BaseService<Events> {
     this.emitter.emit(
       "initializeNotificationsPreferences",
       await this.getShouldShowNotificationsPreferences(),
+    )
+
+    this.emitter.emit(
+      "initializeShowTestNetworks",
+      await this.getShowTestNetworks(),
     )
   }
 
@@ -288,6 +294,14 @@ export default class PreferenceService extends BaseService<Events> {
 
   async getCurrency(): Promise<FiatCurrency> {
     return (await this.db.getPreferences())?.currency
+  }
+
+  async setShowTestNetworks(value: boolean): Promise<void> {
+    await this.db.setShowTestNetworks(value)
+  }
+
+  async getShowTestNetworks(): Promise<boolean> {
+    return (await this.db.getPreferences()).showTestNetworks
   }
 
   async getTokenListPreferences(): Promise<TokenListPreferences> {

--- a/background/services/redux/index.ts
+++ b/background/services/redux/index.ts
@@ -82,6 +82,7 @@ import {
   dismissableItemMarkedAsShown,
   MezoClaimStatus,
   updateCampaignState,
+  toggleTestNetworks,
 } from "../../redux-slices/ui"
 import {
   estimatedFeesPerGas,
@@ -1353,6 +1354,18 @@ export default class ReduxService extends BaseService<never> {
         await this.store.dispatch(setDefaultWallet(isDefaultWallet))
       },
     )
+
+    this.preferenceService.emitter.on(
+      "initializeShowTestNetworks",
+      async (showTestNetworks: boolean) => {
+        await this.store.dispatch(toggleTestNetworks(showTestNetworks))
+      },
+    )
+
+    uiSliceEmitter.on("toggleShowTestNetworks", async (value) => {
+      await this.preferenceService.setShowTestNetworks(value)
+      await this.store.dispatch(toggleTestNetworks(value))
+    })
 
     this.preferenceService.emitter.on(
       "initializeSelectedAccount",

--- a/background/services/redux/index.ts
+++ b/background/services/redux/index.ts
@@ -1360,10 +1360,7 @@ export default class ReduxService extends BaseService<never> {
         if (dbAddressNetwork) {
           // Wait until chain service starts and populates supported networks
           await this.chainService.started()
-          // TBD: naming the normal reducer and async thunks
-          // Initialize redux from the db
-          // !!! Important: this action belongs to a regular reducer.
-          // NOT to be confused with the setNewCurrentAddress asyncThunk
+
           const { address, network } = dbAddressNetwork
           let supportedNetwork = this.chainService.supportedNetworks.find(
             (net) => sameNetwork(network, net),

--- a/ui/pages/Settings.tsx
+++ b/ui/pages/Settings.tsx
@@ -8,8 +8,8 @@ import {
   selectShowNotifications,
   setShouldShowNotifications,
   selectShowTestNetworks,
-  toggleTestNetworks,
   toggleHideBanners,
+  toggleShowTestNetworks,
   selectHideBanners,
   selectShowUnverifiedAssets,
   toggleShowUnverifiedAssets,
@@ -186,8 +186,8 @@ export default function Settings(): ReactElement {
       )
   }
 
-  const toggleShowTestNetworks = (defaultWalletValue: boolean) => {
-    dispatch(toggleTestNetworks(defaultWalletValue))
+  const toggleShowTestnets = (defaultWalletValue: boolean) => {
+    dispatch(toggleShowTestNetworks(defaultWalletValue))
   }
 
   const toggleShowUnverified = (toggleValue: boolean) => {
@@ -243,7 +243,7 @@ export default function Settings(): ReactElement {
     title: t("settings.enableTestNetworks"),
     component: () => (
       <SharedToggleButton
-        onChange={(toggleValue) => toggleShowTestNetworks(toggleValue)}
+        onChange={(toggleValue) => toggleShowTestnets(toggleValue)}
         value={showTestNetworks}
       />
     ),


### PR DESCRIPTION
This PR moves the testnet visibility setting to the preference service, and sets a migration to enable it on all existing and new installs.

## Testing
- [ ] On a new install, check testnets shows up by default on network switcher
- [ ] On existing install, after update testnets should show up