### PR TITLE
Move active campaign concerns to campaign service

### DIFF
--- a/background/networks.ts
+++ b/background/networks.ts
@@ -422,3 +422,7 @@ export const isEnrichedEVMTransactionRequest = (
   transactionRequest: TransactionRequest,
 ): transactionRequest is EnrichedEVMTransactionRequest =>
   "annotation" in transactionRequest
+
+export const isTransactionWithReceipt = (
+  transaction: AnyEVMTransaction,
+): transaction is ConfirmedEVMTransaction => "status" in transaction

--- a/background/redux-slices/selectors/uiSelectors.ts
+++ b/background/redux-slices/selectors/uiSelectors.ts
@@ -37,7 +37,7 @@ export const selectShowingActivityDetail = createSelector(
 )
 
 export const selectActiveCampaigns = createSelector(
-  (state: RootState) => state.ui.activeCampaigns,
+  (state: RootState) => state.ui.campaigns,
   (campaigns) => campaigns,
 )
 

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -12,6 +12,11 @@ import { createBackgroundAsyncThunk } from "./utils"
 import { UNIXTime } from "../types"
 import { DEFAULT_AUTOLOCK_INTERVAL } from "../services/preferences/defaults"
 import type { RootState } from "."
+import {
+  CampaignIds,
+  Campaigns,
+  FilterCampaignsById,
+} from "../services/campaign/types"
 
 export const defaultSettings = {
   hideDust: false,
@@ -24,14 +29,8 @@ export const defaultSettings = {
   hideBanners: false,
   useFlashbots: false,
   autoLockInterval: DEFAULT_AUTOLOCK_INTERVAL,
+  campaigns: {},
 }
-
-export type MezoClaimStatus =
-  | "not-eligible"
-  | "eligible"
-  | "claimed-sats"
-  | "borrowed"
-  | "campaign-complete"
 
 export type UIState = {
   selectedAccount: AddressOnNetwork
@@ -55,12 +54,15 @@ export type UIState = {
   routeHistoryEntries?: Partial<Location>[]
   slippageTolerance: number
   accountSignerSettings: AccountSignerSettings[]
-  activeCampaigns: {
-    "mezo-claim"?: {
-      dateFrom: string
-      dateTo: string
-      state: MezoClaimStatus
-    }
+  // Active user campaigns
+  campaigns: {
+    /**
+     * Some hash used to invalidate cached data and update UI
+     */
+    [campaignId in CampaignIds]?: FilterCampaignsById<
+      Campaigns,
+      campaignId
+    >["data"]
   }
 }
 
@@ -94,7 +96,7 @@ export const initialState: UIState = {
   snackbarMessage: "",
   slippageTolerance: 0.01,
   accountSignerSettings: [],
-  activeCampaigns: {},
+  campaigns: {},
 }
 
 const uiSlice = createSlice({
@@ -239,21 +241,15 @@ const uiSlice = createSlice({
       ...state,
       settings: { ...state.settings, autoLockInterval: payload },
     }),
-    updateCampaignState: <T extends keyof UIState["activeCampaigns"]>(
+    updateCampaignsState: (
       immerState: UIState,
       {
         payload,
       }: {
-        payload: [T, Partial<UIState["activeCampaigns"][T]>]
+        payload: UIState["campaigns"]
       },
     ) => {
-      const [campaignId, update] = payload
-
-      immerState.activeCampaigns ??= {}
-      immerState.activeCampaigns[campaignId] = {
-        ...immerState.activeCampaigns[campaignId],
-        ...update,
-      }
+      immerState.campaigns = payload
     },
   },
 })
@@ -279,7 +275,7 @@ export const {
   setSlippageTolerance,
   setAccountsSignerSettings,
   setAutoLockInterval,
-  updateCampaignState,
+  updateCampaignsState,
 } = uiSlice.actions
 
 export default uiSlice.reducer

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -81,6 +81,7 @@ export type Events = {
   addCustomNetworkResponse: [string, boolean]
   updateAutoLockInterval: number
   toggleShowTestNetworks: boolean
+  clearNotification: string
 }
 
 export const emitter = new Emittery<Events>()
@@ -300,6 +301,13 @@ export const deleteAnalyticsData = createBackgroundAsyncThunk(
   "ui/deleteAnalyticsData",
   async () => {
     await emitter.emit("deleteAnalyticsData")
+  },
+)
+
+export const clearNotification = createBackgroundAsyncThunk(
+  "ui/clearNotification",
+  async (id: string) => {
+    await emitter.emit("clearNotification", id)
   },
 )
 

--- a/background/services/campaign/db.ts
+++ b/background/services/campaign/db.ts
@@ -1,0 +1,48 @@
+import Dexie from "dexie"
+import { CampaignIds, Campaigns, FilterCampaignsById } from "./types"
+
+export class CampaignDatabase extends Dexie {
+  private campaigns!: Dexie.Table<Campaigns, CampaignIds>
+
+  constructor() {
+    super("taho/campaigns")
+
+    this.version(1).stores({
+      campaigns: "&id",
+    })
+  }
+
+  async getActiveCampaigns() {
+    return this.campaigns
+      .toCollection()
+      .filter((campaign) => campaign.enabled)
+      .toArray()
+  }
+
+  async getCampaignData<K extends CampaignIds>(
+    id: K,
+  ): Promise<FilterCampaignsById<Campaigns, K> | undefined> {
+    return this.campaigns.get(id) as Promise<
+      FilterCampaignsById<Campaigns, K> | undefined
+    >
+  }
+
+  async upsertCampaign(campaign: Campaigns): Promise<void> {
+    await this.campaigns.put(campaign)
+  }
+
+  async updateCampaignData<K extends CampaignIds>(
+    id: K,
+    data: Partial<FilterCampaignsById<Campaigns, K>["data"]>,
+  ): Promise<void> {
+    await this.campaigns.toCollection().modify((campaign) => {
+      if (campaign.id === id) {
+        Object.assign(campaign, { data })
+      }
+    })
+  }
+}
+
+export async function getOrCreateDB(): Promise<CampaignDatabase> {
+  return new CampaignDatabase()
+}

--- a/background/services/campaign/index.ts
+++ b/background/services/campaign/index.ts
@@ -1,0 +1,254 @@
+import dayjs from "dayjs"
+import isBetween from "dayjs/plugin/isBetween"
+import browser from "webextension-polyfill"
+import { isDisabled } from "../../features"
+import { checkIsBorrowingTx } from "../../lib/mezo"
+import AnalyticsService from "../analytics"
+import BaseService from "../base"
+import ChainService from "../chain"
+import EnrichmentService from "../enrichment"
+import NotificationsService from "../notifications"
+import PreferenceService from "../preferences"
+import { ServiceCreatorFunction, ServiceLifecycleEvents } from "../types"
+import { CampaignDatabase, getOrCreateDB } from "./db"
+import MEZO_CAMPAIGN, { MezoClaimStatus } from "./matsnet-nft"
+import { isTransactionWithReceipt } from "../../networks"
+import { Campaigns } from "./types"
+
+dayjs.extend(isBetween)
+
+interface Events extends ServiceLifecycleEvents {
+  /**
+   * Replaces UI state with active campaigns data
+   */
+  campaignStatusUpdate: Campaigns[]
+}
+
+export default class CampaignService extends BaseService<Events> {
+  static create: ServiceCreatorFunction<
+    Events,
+    CampaignService,
+    [
+      Promise<ChainService>,
+      Promise<AnalyticsService>,
+      Promise<PreferenceService>,
+      Promise<EnrichmentService>,
+      Promise<NotificationsService>,
+    ]
+  > = async (
+    chainService,
+    analyticsService,
+    preferenceService,
+    enrichmentService,
+    notificationsService,
+  ) =>
+    new this(
+      await getOrCreateDB(),
+      await chainService,
+      await analyticsService,
+      await preferenceService,
+      await enrichmentService,
+      await notificationsService,
+    )
+
+  private constructor(
+    private db: CampaignDatabase,
+    private chainService: ChainService,
+    private analyticsService: AnalyticsService,
+    private preferenceService: PreferenceService,
+    private enrichmentService: EnrichmentService,
+    private notificationsService: NotificationsService,
+  ) {
+    super({
+      checkMezoEligibility: {
+        schedule: { delayInMinutes: 1, periodInMinutes: 60 },
+        handler: () => this.checkMezoCampaignState(),
+      },
+    })
+  }
+
+  protected override async internalStartService(): Promise<void> {
+    // Not correct but it's what spawned its existence
+    if (isDisabled("SUPPORT_MEZO_NETWORK")) {
+      return
+    }
+
+    this.enrichmentService.emitter.on(
+      "enrichedEVMTransaction",
+      async ({ transaction }) => {
+        const campaignData = await this.db.getCampaignData(MEZO_CAMPAIGN.id)
+        // Before snooping, check if we're at the right campaign state
+        if (!campaignData || campaignData?.data?.state !== "can-borrow") {
+          return
+        }
+
+        if (
+          isTransactionWithReceipt(transaction) &&
+          checkIsBorrowingTx(transaction)
+        ) {
+          await this.db.updateCampaignData(MEZO_CAMPAIGN.id, {
+            state: "can-claim-nft",
+          })
+
+          this.emitter.emit(
+            "campaignStatusUpdate",
+            await this.db.getActiveCampaigns(),
+          )
+        }
+      },
+    )
+
+    const campaigns = await this.db.getActiveCampaigns()
+    this.emitter.emit("campaignStatusUpdate", campaigns)
+  }
+
+  async checkMezoCampaignState() {
+    if (isDisabled("SUPPORT_MEZO_NETWORK")) {
+      return
+    }
+
+    await this.started()
+    const accounts = await this.chainService.getAccountsToTrack()
+    // TODO: needs to be sent to API
+    // const installId = await this.analyticsService.analyticsUUID
+
+    const campaign = await this.db.getCampaignData(MEZO_CAMPAIGN.id)
+    const lastKnownState = campaign?.data?.state
+
+    if (
+      !accounts.length ||
+      (campaign && !campaign.enabled) ||
+      lastKnownState === "campaign-complete" ||
+      lastKnownState === "not-eligible"
+    ) {
+      return
+    }
+
+    const shownItems = new Set(
+      await this.preferenceService.getShownDismissableItems(),
+    )
+
+    const hasSeenEligibilityPush = shownItems.has(
+      MEZO_CAMPAIGN.notificationIds.eligible,
+    )
+
+    const hasSeenBorrowPush = shownItems.has(
+      MEZO_CAMPAIGN.notificationIds.canBorrow,
+    )
+
+    const hasSeenNFTNotification = shownItems.has(
+      MEZO_CAMPAIGN.notificationIds.canClaimNFT,
+    )
+
+    // fetch with uuid
+    const campaignData = {
+      dateFrom: "2025-02-21",
+      dateTo: "2025-03-28",
+      state: "eligible" as MezoClaimStatus,
+    }
+
+    if (campaignData.state === "not-eligible") {
+      await this.db.upsertCampaign({
+        id: MEZO_CAMPAIGN.id,
+        data: undefined,
+        enabled: false,
+      })
+
+      return
+    }
+
+    const isOngoing = dayjs().isBetween(
+      campaignData.dateFrom,
+      campaignData.dateTo,
+      "day",
+      "[]",
+    )
+
+    if (
+      isOngoing &&
+      campaignData.state === "eligible" &&
+      !hasSeenEligibilityPush
+    ) {
+      this.notificationsService.notify({
+        options: {
+          title:
+            "Enjoy 20,000 sats on Mezo testnet. Try borrow for an exclusive Mezo NFT!",
+          message: "Login to Mezo to claim",
+          onDismiss: () =>
+            this.preferenceService.markDismissableItemAsShown(
+              MEZO_CAMPAIGN.notificationIds.eligible,
+            ),
+        },
+        callback: () => {
+          browser.tabs.create({ url: "https://mezo.org/matsnet" })
+          this.preferenceService.markDismissableItemAsShown(
+            MEZO_CAMPAIGN.notificationIds.eligible,
+          )
+        },
+      })
+    }
+
+    if (
+      isOngoing &&
+      campaignData.state === "can-borrow" &&
+      !hasSeenBorrowPush
+    ) {
+      this.notificationsService.notify({
+        options: {
+          title: "Borrow mUSD with testnet sats for an exclusive Mezo NFT!",
+          message: "Click to borrow mUSD ",
+          onDismiss: () =>
+            this.preferenceService.markDismissableItemAsShown(
+              MEZO_CAMPAIGN.notificationIds.canBorrow,
+            ),
+        },
+        callback: () => {
+          browser.tabs.create({ url: "https://mezo.org/matsnet/borrow" })
+          this.preferenceService.markDismissableItemAsShown(
+            MEZO_CAMPAIGN.notificationIds.canBorrow,
+          )
+        },
+      })
+    }
+
+    if (
+      isOngoing &&
+      campaignData.state === "can-claim-nft" &&
+      !hasSeenNFTNotification
+    ) {
+      this.notificationsService.notify({
+        options: {
+          title:
+            "Spend testnet mUSD in the Mezo store for an exclusive Mezo NFT!",
+          message: "Click to visit the Mezo Store",
+          onDismiss: () =>
+            this.preferenceService.markDismissableItemAsShown(
+              MEZO_CAMPAIGN.notificationIds.canClaimNFT,
+            ),
+        },
+        callback: () => {
+          browser.tabs.create({ url: "https://mezo.org/matsnet/borrow" })
+          this.preferenceService.markDismissableItemAsShown(
+            MEZO_CAMPAIGN.notificationIds.canClaimNFT,
+          )
+        },
+      })
+    }
+
+    if (campaignData.state !== lastKnownState) {
+      // If there was no campaign data create it
+      if (!campaign) {
+        await this.db.upsertCampaign({
+          id: MEZO_CAMPAIGN.id,
+          data: campaignData,
+          enabled: true,
+        })
+      } else {
+        await this.db.updateCampaignData(MEZO_CAMPAIGN.id, campaignData)
+      }
+
+      const campaigns = await this.db.getActiveCampaigns()
+      this.emitter.emit("campaignStatusUpdate", campaigns)
+    }
+  }
+}

--- a/background/services/campaign/matsnet-nft.ts
+++ b/background/services/campaign/matsnet-nft.ts
@@ -1,0 +1,60 @@
+export type MezoClaimStatus =
+  | "not-eligible"
+  | "eligible"
+  | "can-borrow"
+  | "can-claim-nft"
+  | "campaign-complete"
+
+export type MezoCampaignState = {
+  dateFrom: string
+  dateTo: string
+  state: MezoClaimStatus
+}
+
+export const CAMPAIGN_ID = "mezo-nft-claim"
+
+export type MezoCampaign = {
+  id: typeof CAMPAIGN_ID
+  data: MezoCampaignState | undefined
+  enabled: boolean
+}
+
+const prefixWithCampaignId = (str: string): `campaign::${string}` =>
+  `campaign::${CAMPAIGN_ID}-${str}`
+
+export const IS_ELIGIBLE_NOTIFICATION_ID = prefixWithCampaignId(
+  "eligible-notification",
+)
+export const BORROW_AD_NOTIFICATION_ID = prefixWithCampaignId(
+  "borrow-notification",
+)
+export const CLAIM_NFT_NOTIFICATION_ID = prefixWithCampaignId(
+  "claim-nft-notification",
+)
+
+export const isActiveCampaign = (state: MezoClaimStatus) => {
+  const activeStates: MezoClaimStatus[] = [
+    "eligible",
+    "can-borrow",
+    "can-claim-nft",
+  ]
+
+  return activeStates.some((value) => value === state)
+}
+
+const MATSNET_NFT_CAMPAIGN = {
+  id: CAMPAIGN_ID,
+  notificationIds: {
+    eligible: IS_ELIGIBLE_NOTIFICATION_ID,
+    canBorrow: BORROW_AD_NOTIFICATION_ID,
+    canClaimNFT: CLAIM_NFT_NOTIFICATION_ID,
+  },
+  bannerIds: {
+    eligible: prefixWithCampaignId("eligible-banner"),
+    canBorrow: prefixWithCampaignId("borrow-banner"),
+    canClaimNFT: prefixWithCampaignId("claim-nft-banner"),
+  },
+  isActive: isActiveCampaign,
+} as const
+
+export default MATSNET_NFT_CAMPAIGN

--- a/background/services/campaign/types.ts
+++ b/background/services/campaign/types.ts
@@ -1,0 +1,28 @@
+import { MezoCampaign } from "./matsnet-nft"
+
+type FilterValidCampaigns<T> = T extends {
+  id: string
+  data: unknown
+  /**
+   * The campaign is disabled if the user is e.g. not eligible
+   */
+  enabled: boolean
+}
+  ? T
+  : never
+
+/**
+ * Campaigns must use the following format
+ * ```ts
+ *  {
+ *    id: "some-campaign-id"
+ *    data: {...}
+ *    disabled: boolean
+ *  }
+ * ```
+ */
+export type Campaigns = FilterValidCampaigns<MezoCampaign>
+
+export type CampaignIds = Campaigns["id"]
+
+export type FilterCampaignsById<T, K> = T extends { id: K } ? T : never

--- a/background/services/preferences/db.ts
+++ b/background/services/preferences/db.ts
@@ -83,17 +83,22 @@ export type ManuallyDismissableItem =
  * be used for tours, or for popups that can be retriggered but will not
  * auto-display more than once.
  */
-export type SingleShotItem =
-  | "default-connection-popover"
-  | "mezo-eligible-notification"
-  | "mezo-borrow-notification"
-  | "mezo-nft-notification"
+export type SingleShotItem = "default-connection-popover"
 
+/**
+ * Items that the user might see only during campaigns.
+ * These are prefixed to distinguish them from common UI
+ * dismissable items
+ */
+export type CampaignDismissableItem = `campaign::${string}`
 /**
  * Items that the user will view one time and either manually dismiss or that
  * will remain auto-collapsed after first view.
  */
-export type DismissableItem = ManuallyDismissableItem | SingleShotItem
+export type DismissableItem =
+  | ManuallyDismissableItem
+  | SingleShotItem
+  | CampaignDismissableItem
 
 type DismissableItemEntry = {
   id: DismissableItem

--- a/background/services/redux/index.ts
+++ b/background/services/redux/index.ts
@@ -1596,6 +1596,10 @@ export default class ReduxService extends BaseService<never> {
     this.islandService.emitter.on("newXpDrop", () => {
       this.notificationsService.notifyXPDrop()
     })
+
+    uiSliceEmitter.on("clearNotification", (id: string) =>
+      this.notificationsService.clearNotification(id),
+    )
   }
 
   async unlockInternalSigners(password: string): Promise<boolean> {

--- a/background/services/redux/index.ts
+++ b/background/services/redux/index.ts
@@ -1709,10 +1709,12 @@ export default class ReduxService extends BaseService<never> {
     uiSliceEmitter.on(
       "shouldShowNotifications",
       async (shouldShowNotifications: boolean) => {
-        await this.preferenceService.setShouldShowNotifications(
-          shouldShowNotifications,
-        )
-        this.store.dispatch(toggleNotifications(shouldShowNotifications))
+        const notificationsEnabled =
+          await this.preferenceService.setShouldShowNotifications(
+            shouldShowNotifications,
+          )
+
+        this.store.dispatch(toggleNotifications(notificationsEnabled))
       },
     )
 

--- a/background/services/redux/index.ts
+++ b/background/services/redux/index.ts
@@ -1,9 +1,6 @@
-import browser, { Runtime } from "webextension-polyfill"
+import { Runtime } from "webextension-polyfill"
 import { PermissionRequest } from "@tallyho/provider-bridge-shared"
 import { utils } from "ethers"
-
-import isBetween from "dayjs/plugin/isBetween"
-import dayjs from "dayjs"
 
 import {
   isProbablyEVMAddress,
@@ -80,9 +77,8 @@ import {
   toggleNotifications,
   setShownDismissableItems,
   dismissableItemMarkedAsShown,
-  MezoClaimStatus,
-  updateCampaignState,
   toggleTestNetworks,
+  updateCampaignsState,
 } from "../../redux-slices/ui"
 import {
   estimatedFeesPerGas,
@@ -203,10 +199,7 @@ import {
 } from "../../redux-slices/prices"
 import NotificationsService from "../notifications"
 import { ReduxStoreType, initializeStore, readAndMigrateState } from "./store"
-import { checkIsBorrowingTx } from "../../lib/mezo"
-import { isDisabled } from "../../features"
-
-dayjs.extend(isBetween)
+import CampaignService from "../campaign"
 
 export default class ReduxService extends BaseService<never> {
   /**
@@ -271,6 +264,14 @@ export default class ReduxService extends BaseService<never> {
       ledgerService,
     )
 
+    const campaignService = CampaignService.create(
+      chainService,
+      analyticsService,
+      preferenceService,
+      enrichmentService,
+      notificationsService,
+    )
+
     const savedReduxState = readAndMigrateState()
 
     return new this(
@@ -291,6 +292,7 @@ export default class ReduxService extends BaseService<never> {
       await nftsService,
       await abilitiesService,
       await notificationsService,
+      await campaignService,
     )
   }
 
@@ -383,15 +385,16 @@ export default class ReduxService extends BaseService<never> {
      * A promise to the Notifications service which takes care of observing and delivering notifications
      */
     private notificationsService: NotificationsService,
+
+    /**
+     * A promise to the Campaign service which takes care of managing current and upcoming campaigns
+     */
+    private campaignService: CampaignService,
   ) {
     super({
       initialLoadWaitExpired: {
         schedule: { delayInMinutes: 1.5 },
         handler: () => this.store.dispatch(initializationLoadingTimeHitLimit()),
-      },
-      checkMezoEligibility: {
-        schedule: { delayInMinutes: 1, periodInMinutes: 60 },
-        handler: () => this.checkMezoCampaignState(),
       },
     })
 
@@ -420,6 +423,7 @@ export default class ReduxService extends BaseService<never> {
       this.nftsService.startService(),
       this.abilitiesService.startService(),
       this.notificationsService.startService(),
+      this.campaignService.startService(),
     ]
 
     await Promise.all(servicesToBeStarted)
@@ -443,6 +447,7 @@ export default class ReduxService extends BaseService<never> {
       this.nftsService.stopService(),
       this.abilitiesService.stopService(),
       this.notificationsService.stopService(),
+      this.campaignService.stopService(),
     ]
 
     await Promise.all(servicesToBeStopped)
@@ -465,7 +470,7 @@ export default class ReduxService extends BaseService<never> {
     this.connectAbilitiesService()
     this.connectNFTsService()
     this.connectNotificationsService()
-    this.connectMezoCampaignListeners()
+    this.connectCampaignService()
 
     await this.connectChainService()
 
@@ -1733,136 +1738,16 @@ export default class ReduxService extends BaseService<never> {
     })
   }
 
-  async connectMezoCampaignListeners() {
-    if (isDisabled("SUPPORT_MEZO_NETWORK")) {
-      return
-    }
-
-    this.enrichmentService.emitter.on(
-      "enrichedEVMTransaction",
-      ({ transaction }) => {
-        if (checkIsBorrowingTx(transaction)) {
-          this.store.dispatch(
-            updateCampaignState(["mezo-claim", { state: "campaign-complete" }]),
-          )
-        }
-      },
-    )
-  }
-
-  async checkMezoCampaignState() {
-    if (isDisabled("SUPPORT_MEZO_NETWORK")) {
-      return
-    }
-
-    await this.started()
-    const accounts = await this.chainService.getAccountsToTrack()
-    const lastKnownState =
-      this.store.getState().ui.activeCampaigns?.["mezo-claim"]?.state
-
-    if (
-      !accounts.length ||
-      lastKnownState === "campaign-complete" ||
-      lastKnownState === "not-eligible"
-    ) {
-      return
-    }
-
-    const shownItems = new Set(
-      await this.preferenceService.getShownDismissableItems(),
-    )
-
-    // const uuid = this.analyticsService.analyticsUUID
-    const hasSeenEligibilityPush = shownItems.has("mezo-eligible-notification")
-    const hasSeenBorrowPush = shownItems.has("mezo-borrow-notification")
-    const hasSeenNFTNotification = shownItems.has("mezo-nft-notification")
-
-    // fetch with uuid
-    const campaignData = {
-      dateFrom: "2025-02-21",
-      dateTo: "2025-03-28",
-      state: "eligible" as MezoClaimStatus,
-    }
-
-    const isActiveCampaign = dayjs().isBetween(
-      campaignData.dateFrom,
-      campaignData.dateTo,
-      "day",
-      "[]",
-    )
-
-    if (
-      isActiveCampaign &&
-      campaignData.state === "eligible" &&
-      !hasSeenEligibilityPush
-    ) {
-      this.notificationsService.notify({
-        options: {
-          title:
-            "Enjoy 20,000 sats on Mezo testnet. Try borrow for an exclusive Mezo NFT!",
-          message: "Login to Mezo to claim",
-          onDismiss: () =>
-            this.preferenceService.markDismissableItemAsShown(
-              "mezo-eligible-notification",
-            ),
-        },
-        callback: () => {
-          browser.tabs.create({ url: "https://mezo.org/matsnet" })
-          this.preferenceService.markDismissableItemAsShown(
-            "mezo-eligible-notification",
-          )
-        },
-      })
-    }
-
-    if (
-      isActiveCampaign &&
-      campaignData.state === "claimed-sats" &&
-      !hasSeenBorrowPush
-    ) {
-      this.notificationsService.notify({
-        options: {
-          title: "Borrow mUSD with testnet sats for an exclusive Mezo NFT!",
-          message: "Click to borrow mUSD ",
-          onDismiss: () =>
-            this.preferenceService.markDismissableItemAsShown(
-              "mezo-borrow-notification",
-            ),
-        },
-        callback: () => {
-          browser.tabs.create({ url: "https://mezo.org/matsnet/borrow" })
-          this.preferenceService.markDismissableItemAsShown(
-            "mezo-borrow-notification",
-          )
-        },
-      })
-    }
-
-    if (
-      isActiveCampaign &&
-      campaignData.state === "borrowed" &&
-      !hasSeenNFTNotification
-    ) {
-      this.notificationsService.notify({
-        options: {
-          title:
-            "Spend testnet mUSD in the Mezo store for an exclusive Mezo NFT!",
-          message: "Click to visit the Mezo Store",
-          onDismiss: () =>
-            this.preferenceService.markDismissableItemAsShown(
-              "mezo-borrow-notification",
-            ),
-        },
-        callback: () => {
-          browser.tabs.create({ url: "https://mezo.org/matsnet/borrow" })
-          this.preferenceService.markDismissableItemAsShown(
-            "mezo-borrow-notification",
-          )
-        },
-      })
-    }
-
-    this.store.dispatch(updateCampaignState(["mezo-claim", campaignData]))
+  async connectCampaignService() {
+    this.campaignService.emitter.on("campaignStatusUpdate", (campaigns) => {
+      this.store.dispatch(
+        updateCampaignsState(
+          Object.fromEntries(
+            campaigns.map((campaign) => [campaign.id, campaign.data]),
+          ),
+        ),
+      )
+    })
   }
 
   async updateAssetMetadata(

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -563,7 +563,7 @@
     },
     "mainMenu": "Settings",
     "signing": "Signing",
-    "showNotifications": "Show Subscape notifications",
+    "showNotifications": "Show Mezo notifications",
     "hideSmallAssetBalance": "Hide asset balances under {{sign}}{{amount}}",
     "setAsDefault": "Use Taho as default wallet",
     "enableTestNetworks": "Show testnet networks",

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -551,7 +551,7 @@
     "compatibleChain": "EVM-compatible blockchain",
     "avalanche": "Mainnet C-Chain",
     "connected": "Connected",
-    "featuredNetwork": "new"
+    "newNetwork": "new"
   },
   "readOnly": "Read-only",
   "readOnlyNotice": "Read-only mode",

--- a/ui/components/Shared/SharedBanner.tsx
+++ b/ui/components/Shared/SharedBanner.tsx
@@ -13,7 +13,7 @@ type BannerProps = {
 }
 
 export type CanBeClosedProps =
-  | { canBeClosed: true; id: string }
+  | { canBeClosed: true; id: string; onDismiss?: (id: string) => void }
   | { canBeClosed?: false; id?: never }
 
 function Banner(props: BannerProps): ReactElement {
@@ -72,10 +72,18 @@ function Banner(props: BannerProps): ReactElement {
 }
 
 function BannerWithClose(
-  props: BannerProps & { id: string },
+  props: BannerProps & { id: string; onDismiss?: (id: string) => void },
 ): ReactElement | null {
-  const { id, children, icon, iconColor, style, iconAriaLabel, hasShadow } =
-    props
+  const {
+    id,
+    children,
+    icon,
+    iconColor,
+    style,
+    iconAriaLabel,
+    hasShadow,
+    onDismiss,
+  } = props
   const [isVisible, setIsVisible] = useLocalStorage(`banner_${id}`, "true")
 
   if (isVisible === "false") return null
@@ -89,7 +97,10 @@ function BannerWithClose(
       hasShadow={hasShadow}
     >
       <SharedIcon
-        onClick={() => setIsVisible("false")}
+        onClick={() => {
+          setIsVisible("false")
+          onDismiss?.(id)
+        }}
         icon="icons/s/close.svg"
         ariaLabel="close"
         width={16}

--- a/ui/components/TopMenu/TopMenuProtocolListItem.tsx
+++ b/ui/components/TopMenu/TopMenuProtocolListItem.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 const isFeaturedNetwork = (network: EVMNetwork) => {
   if (sameNetwork(network, MEZO_TESTNET)) {
-    return Date.now() < new Date("2025-04-10").getTime()
+    return Date.now() < new Date("2025-04-17").getTime()
   }
   return false
 }
@@ -50,7 +50,7 @@ export default function TopMenuProtocolListItem(props: Props): ReactElement {
         <div className="title">
           {network.name}
           {isFeaturedNetwork(network) && (
-            <span className="featured">{t("protocol.featuredNetwork")}</span>
+            <span className="featured">{t("protocol.newNetwork")}</span>
           )}
         </div>
         <div className="sub_title">

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -17,6 +17,8 @@ import { NETWORKS_SUPPORTING_NFTS } from "@tallyho/tally-background/nfts"
 import { selectShowUnverifiedAssets } from "@tallyho/tally-background/redux-slices/ui"
 import { CompleteAssetAmount } from "@tallyho/tally-background/redux-slices/accounts"
 import { SwappableAsset } from "@tallyho/tally-background/assets"
+import MATSNET_NFT_CAMPAIGN from "@tallyho/tally-background/services/campaign/matsnet-nft"
+
 import { useHistory } from "react-router-dom"
 import { useBackgroundDispatch, useBackgroundSelector } from "../hooks"
 import SharedPanelSwitcher from "../components/Shared/SharedPanelSwitcher"
@@ -108,7 +110,7 @@ export default function Wallet(): ReactElement {
   panelNames.push(t("wallet.pages.activity"))
 
   const renderMezoCampaignBanner = () => {
-    const campaign = activeCampaigns?.["mezo-claim"]
+    const campaign = activeCampaigns?.[MATSNET_NFT_CAMPAIGN.id]
     if (
       !campaign ||
       campaign.state === "not-eligible" ||


### PR DESCRIPTION
This moves campaign related logic out of the main service into a dedicated service. It also causes dismissing campaign banners to clear and stop triggering notifications about the same topic. 

Campaign state is kept within the service db and updates are pushed to state in redux.


Latest build: [extension-builds-3794](https://github.com/tahowallet/extension/suites/35331061341/artifacts/2708368343) (as of Fri, 07 Mar 2025 03:08:56 GMT).