### PR TITLE
Set analytics data on mezo campaign items

### DIFF
--- a/background/lib/posthog.ts
+++ b/background/lib/posthog.ts
@@ -16,6 +16,10 @@ export enum AnalyticsEvent {
   DAPP_CONNECTED = "Dapp Connected",
   VAULT_MIGRATION = "Migrate to newer vault version",
   VAULT_MIGRATION_FAILED = "Vault version migration failed",
+  // Campaign events
+  CAMPAIGN_MEZO_NFT_ELIGIBLE_BANNER = "clicked-banner-mezo-sats",
+  CAMPAIGN_MEZO_NFT_BORROW_BANNER = "clicked-banner-mezo_borrow",
+  CAMPAIGN_MEZO_NFT_CLAIM_NFT_BANNER = "clicked-banner-mezo-nft",
 }
 
 export enum OneTimeAnalyticsEvent {

--- a/background/lib/posthog.ts
+++ b/background/lib/posthog.ts
@@ -17,9 +17,9 @@ export enum AnalyticsEvent {
   VAULT_MIGRATION = "Migrate to newer vault version",
   VAULT_MIGRATION_FAILED = "Vault version migration failed",
   // Campaign events
-  CAMPAIGN_MEZO_NFT_ELIGIBLE_BANNER = "clicked-banner-mezo-sats",
-  CAMPAIGN_MEZO_NFT_BORROW_BANNER = "clicked-banner-mezo_borrow",
-  CAMPAIGN_MEZO_NFT_CLAIM_NFT_BANNER = "clicked-banner-mezo-nft",
+  CAMPAIGN_MEZO_NFT_ELIGIBLE_BANNER = "in_wallet-claim_sats",
+  CAMPAIGN_MEZO_NFT_BORROW_BANNER = "in_wallet-borrow_musd",
+  CAMPAIGN_MEZO_NFT_CLAIM_NFT_BANNER = "in_wallet-visit_store",
 }
 
 export enum OneTimeAnalyticsEvent {

--- a/background/services/campaign/index.ts
+++ b/background/services/campaign/index.ts
@@ -180,7 +180,9 @@ export default class CampaignService extends BaseService<Events> {
             ),
         },
         callback: () => {
-          browser.tabs.create({ url: "https://mezo.org/matsnet" })
+          browser.tabs.create({
+            url: "https://mezo.org/matsnet/borrow?src=taho-claim-sats-banner",
+          })
           this.preferenceService.markDismissableItemAsShown(
             MEZO_CAMPAIGN.notificationIds.eligible,
           )
@@ -203,7 +205,9 @@ export default class CampaignService extends BaseService<Events> {
             ),
         },
         callback: () => {
-          browser.tabs.create({ url: "https://mezo.org/matsnet/borrow" })
+          browser.tabs.create({
+            url: "https://mezo.org/matsnet/borrow?src=taho-borrow-banner",
+          })
           this.preferenceService.markDismissableItemAsShown(
             MEZO_CAMPAIGN.notificationIds.canBorrow,
           )
@@ -227,7 +231,9 @@ export default class CampaignService extends BaseService<Events> {
             ),
         },
         callback: () => {
-          browser.tabs.create({ url: "https://mezo.org/matsnet/borrow" })
+          browser.tabs.create({
+            url: "https://mezo.org/matsnet/store?src=taho-claim-nft-banner",
+          })
           this.preferenceService.markDismissableItemAsShown(
             MEZO_CAMPAIGN.notificationIds.canClaimNFT,
           )

--- a/background/services/campaign/index.ts
+++ b/background/services/campaign/index.ts
@@ -14,6 +14,7 @@ import { CampaignDatabase, getOrCreateDB } from "./db"
 import MEZO_CAMPAIGN, { MezoClaimStatus } from "./matsnet-nft"
 import { isConfirmedEVMTransaction } from "../../networks"
 import { Campaigns } from "./types"
+import { AnalyticsEvent } from "../../lib/posthog"
 
 dayjs.extend(isBetween)
 
@@ -180,6 +181,9 @@ export default class CampaignService extends BaseService<Events> {
             ),
         },
         callback: () => {
+          this.analyticsService.sendAnalyticsEvent(
+            AnalyticsEvent.CAMPAIGN_MEZO_NFT_ELIGIBLE_BANNER,
+          )
           browser.tabs.create({
             url: "https://mezo.org/matsnet/borrow?src=taho-claim-sats-banner",
           })
@@ -205,6 +209,9 @@ export default class CampaignService extends BaseService<Events> {
             ),
         },
         callback: () => {
+          this.analyticsService.sendAnalyticsEvent(
+            AnalyticsEvent.CAMPAIGN_MEZO_NFT_BORROW_BANNER,
+          )
           browser.tabs.create({
             url: "https://mezo.org/matsnet/borrow?src=taho-borrow-banner",
           })
@@ -231,6 +238,9 @@ export default class CampaignService extends BaseService<Events> {
             ),
         },
         callback: () => {
+          this.analyticsService.sendAnalyticsEvent(
+            AnalyticsEvent.CAMPAIGN_MEZO_NFT_CLAIM_NFT_BANNER,
+          )
           browser.tabs.create({
             url: "https://mezo.org/matsnet/store?src=taho-claim-nft-banner",
           })

--- a/ui/components/Wallet/Banner/WalletCampaignBanner.tsx
+++ b/ui/components/Wallet/Banner/WalletCampaignBanner.tsx
@@ -6,7 +6,11 @@ import MEZO_CAMPAIGN, {
   MezoClaimStatus,
 } from "@tallyho/tally-background/services/campaign/matsnet-nft"
 import { assertUnreachable } from "@tallyho/tally-background/lib/utils/type-guards"
-import { markDismissableItemAsShown } from "@tallyho/tally-background/redux-slices/ui"
+import { AnalyticsEvent } from "@tallyho/tally-background/lib/posthog"
+import {
+  markDismissableItemAsShown,
+  sendEvent,
+} from "@tallyho/tally-background/redux-slices/ui"
 
 import SharedButton from "../../Shared/SharedButton"
 import SharedIcon from "../../Shared/SharedIcon"
@@ -45,13 +49,22 @@ export default function MezoWalletCampaignBanner({
     browser.permissions.request({ permissions: ["notifications"] })
     switch (state) {
       case "eligible":
-        browser.tabs.create({ url: "https://mezo.org/matsnet/borrow" })
+        dispatch(sendEvent(AnalyticsEvent.CAMPAIGN_MEZO_NFT_ELIGIBLE_BANNER))
+        browser.tabs.create({
+          url: "https://mezo.org/matsnet/borrow?src=taho-claim-sats-banner",
+        })
         break
       case "can-borrow":
-        browser.tabs.create({ url: "https://mezo.org/matsnet/borrow" })
+        dispatch(sendEvent(AnalyticsEvent.CAMPAIGN_MEZO_NFT_BORROW_BANNER))
+        browser.tabs.create({
+          url: "https://mezo.org/matsnet/borrow?src=taho-borrow-banner",
+        })
         break
       case "can-claim-nft":
-        browser.tabs.create({ url: "https://mezo.org/matsnet/store" })
+        dispatch(sendEvent(AnalyticsEvent.CAMPAIGN_MEZO_NFT_CLAIM_NFT_BANNER))
+        browser.tabs.create({
+          url: "https://mezo.org/matsnet/store?src=taho-claim-nft-banner",
+        })
         break
       default:
         assertUnreachable(state)


### PR DESCRIPTION
Adds `src` query strings to identify banners clicked from Mezo, and sets analytics events to dispatch on banner click

## Testing
- [ ] Check posthog events are being sent on banner/notification click

Latest build: [extension-builds-3801](https://github.com/tahowallet/extension/suites/35630590546/artifacts/2745445456) (as of Thu, 13 Mar 2025 13:21:56 GMT).