### PR TITLE
Add missing endpoint for reverse `.mezo` resolution

### DIFF
--- a/background/services/name/resolvers/mezo.ts
+++ b/background/services/name/resolvers/mezo.ts
@@ -47,11 +47,26 @@ export default function mezoResolver(): NameResolver<"MEZO"> {
     async lookUpAvatar() {
       return undefined
     },
-    async lookUpNameForAddress(
-      _: AddressOnNetwork,
-    ): Promise<NameOnNetwork | undefined> {
-      // FIXME: Missing endpoint
-      return undefined
+    async lookUpNameForAddress({
+      address,
+      network,
+    }: AddressOnNetwork): Promise<NameOnNetwork | undefined> {
+      type ReverseLookupData = {
+        mezoId: string
+        linkedAccounts: {
+          type: string
+          evmAddress: string
+        }[]
+      }
+
+      const data: ReverseLookupData = await fetchJson(
+        `https://portal.api.mezo.org/accounts/${address}`,
+      )
+
+      return {
+        name: data.mezoId,
+        network,
+      }
     },
   }
 }

--- a/background/services/name/resolvers/mezo.ts
+++ b/background/services/name/resolvers/mezo.ts
@@ -36,7 +36,7 @@ export default function mezoResolver(): NameResolver<"MEZO"> {
       }
 
       const data: ResolveNameData = await fetchJson(
-        `https://portal.api.mezo.org/api/v2/external/accounts?mezoId=${name}`,
+        `https://api.mezo.org/accounts/${name}`,
       )
 
       return {
@@ -60,7 +60,7 @@ export default function mezoResolver(): NameResolver<"MEZO"> {
       }
 
       const data: ReverseLookupData = await fetchJson(
-        `https://portal.api.mezo.org/accounts/${address}`,
+        `https://api.mezo.org/accounts/${address}`,
       )
 
       return {


### PR DESCRIPTION
For resolving `0xd8da6bf26964af9d7eed9e03e53415d37aa96045` into `vitalik.mezo`

## Testing
:construction: Endpoint hasn't reached production yet

Latest build: [extension-builds-3806](https://github.com/tahowallet/extension/suites/35710604406/artifacts/2755893972) (as of Fri, 14 Mar 2025 22:02:54 GMT).