### PR TITLE
Update copy on campaign banner

### DIFF
--- a/background/services/redux/index.ts
+++ b/background/services/redux/index.ts
@@ -200,6 +200,7 @@ import {
 import NotificationsService from "../notifications"
 import { ReduxStoreType, initializeStore, readAndMigrateState } from "./store"
 import CampaignService from "../campaign"
+import { DAPP_BASE_URL } from "../campaign/matsnet-nft"
 
 export default class ReduxService extends BaseService<never> {
   /**
@@ -1323,7 +1324,7 @@ export default class ReduxService extends BaseService<never> {
     )
 
     providerBridgeSliceEmitter.on("grantPermission", async (permission) => {
-      if (permission.origin === "https://mezo.org") {
+      if (permission.origin === new URL(DAPP_BASE_URL).origin) {
         this.campaignService.checkMezoSatsDrop(permission.accountAddress)
       }
     })

--- a/ui/components/Wallet/Banner/WalletCampaignBanner.tsx
+++ b/ui/components/Wallet/Banner/WalletCampaignBanner.tsx
@@ -21,7 +21,7 @@ const claimStateBanners = {
   eligible: {
     bannerId: MEZO_CAMPAIGN.bannerIds.eligible,
     title: "Get the gift of sats",
-    body: "Enjoy 20,000 sats on the Mezo testnet. Try Mezo borrow and get an exclusive Taho x Mezo NFT.",
+    body: "Enjoy 20,000 testnet sats. Try Mezo Borrow and get an exclusive Taho x Mezo NFT (code\u00A0XTAHO).",
     action: "Login to claim",
   },
   "can-borrow": {
@@ -176,6 +176,7 @@ export default function MezoWalletCampaignBanner({
             max-width: 220px;
             font-weight: 500;
             font-size: 15px;
+            letter-spacing: -0.02em;
             line-height: 18px;
             color: #81aba8;
           }


### PR DESCRIPTION
Updates "Login to claim sats" banner text to include campaign referral code and removes a hardcoded origin.

Latest build: [extension-builds-3810](https://github.com/tahowallet/extension/suites/35950305371/artifacts/2785999191) (as of Thu, 20 Mar 2025 05:50:01 GMT).