### PR TITLE
Allow for replacing EIP6963 MetaMask as well

### DIFF
--- a/src/window-provider.ts
+++ b/src/window-provider.ts
@@ -514,7 +514,14 @@ function setupProviderWrapper() {
     "eip6963:announceProvider",
     (event) => {
       if (
-        "detail" in event &&
+        !("detail" in event) ||
+        typeof event.detail !== "object" ||
+        !event.detail
+      ) {
+        return
+      }
+
+      if (
         "provider" in event.detail &&
         (event.detail.provider === window.ethereum ||
           event.detail.provider === window.taho)
@@ -523,11 +530,19 @@ function setupProviderWrapper() {
       }
 
       if (
-        "detail" in event &&
         "info" in event.detail &&
+        typeof event.detail.info === "object" &&
+        event.detail.info &&
         "name" in event.detail.info &&
         event.detail.info.name === "MetaMask"
       ) {
+        const eip6963Info = event.detail.info as {
+          uuid?: string | null
+          name: string | null
+          icon?: string | null
+          rdns?: string | null
+        }
+
         event.preventDefault()
         event.stopImmediatePropagation()
 
@@ -535,10 +550,10 @@ function setupProviderWrapper() {
           new CustomEvent("eip6963:announceProvider", {
             detail: Object.freeze({
               info: {
-                uuid: event.detail.info.uuid,
-                name: event.detail.info.name,
-                icon: event.detail.info.icon,
-                rdns: event.detail.info.rdns,
+                uuid: eip6963Info.uuid,
+                name: eip6963Info.name,
+                icon: eip6963Info.icon,
+                rdns: eip6963Info.rdns,
               },
               provider: window.ethereum,
             }),


### PR DESCRIPTION
Note that EIP6963 should remove the need to do this, but instead sites like Etherscan still only present MetaMask as an option despite using a EIP6963-aware library under the covers. Malice, incompetence, or dirty dealings? That is left as an exercise for the reader.

## Testing
- [x] Go to https://etherscan.io/token/0xCdF7028ceAB81fA0C6971208e83fa7872994beE5 (or any contract).
- [x] Click contract & write contract
- [x] Click Connect to Web3 and then MetaMask
  - [x] With MetaMask enabled and Taho masquerading as MetaMask, Taho should come up.
  - [x] With MetaMask enabled and Taho NOT masquerading as MetaMask, MetaMask should come up.
  - [x] With MetaMask disabled and Taho masquerading as MetaMask, Taho should come up.
  - [x] With MetaMask disabled and Taho NOT masquerading as MetaMask, Taho should come up.

Latest build: [extension-builds-3811](https://github.com/tahowallet/extension/suites/36036334941/artifacts/2797168574) (as of Fri, 21 Mar 2025 16:15:20 GMT).